### PR TITLE
Delete unnecessary ignore key in config

### DIFF
--- a/config.json
+++ b/config.json
@@ -1157,10 +1157,6 @@
       ]
     }
   ],
-  "ignored": [
-    "docs",
-    "img"
-  ],
   "foregone": [
     "flatten-array",
     "nucleotide-codons",


### PR DESCRIPTION
I saw that we had some left-overs from before we moved exercises into the `exercises/` directory.