### PR TITLE
Improve build scripts

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,81 +1,149 @@
-$CakeVersion = "0.21.1"
-$DotNetVersion = "2.0.0";
-$DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1";
+<#
+.SYNOPSIS
+This is a Powershell script to bootstrap a Cake build.
+.DESCRIPTION
+This Powershell script will download NuGet if missing, restore NuGet tools (including Cake)
+and execute your Cake build script with the parameters you provide.
+.PARAMETER Target
+The build script target to run.
+.PARAMETER Configuration
+The build configuration to use.
+.PARAMETER Verbosity
+Specifies the amount of information to be displayed.
+.PARAMETER WhatIf
+Performs a dry run of the build script.
+No tasks will be executed.
+.PARAMETER Exercise
+The exercise to build and test. If not specified, all exercises will be built and tested.
+.PARAMETER ScriptArgs
+Remaining arguments are added here.
+.LINK
+http://cakebuild.net
+#>
+
+[CmdletBinding()]
+Param(
+    [string]$Target = "Default",
+    [ValidateSet("Release", "Debug")]
+    [string]$Configuration = "Release",
+    [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
+    [string]$Verbosity = "Normal",
+    [switch]$WhatIf,
+    [string]$Exercise,
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$ScriptArgs
+)
+
+function GetProxyEnabledWebClient
+{
+    $wc = New-Object System.Net.WebClient
+    $proxy = [System.Net.WebRequest]::GetSystemWebProxy()
+    $proxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials        
+    $wc.Proxy = $proxy
+    return $wc
+}
+
+Write-Host "Preparing to run build script..."
+
+if(!$PSScriptRoot){
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+
+$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+$NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
+$CAKE_VERSION = "0.21.1"
+$CAKE_DLL = Join-Path $TOOLS_DIR "Cake.CoreCLR.$CAKE_VERSION/Cake.dll"
+$DOTNET_DIR = Join-Path $PSScriptRoot ".dotnet"
+$DOTNET_CORE_2_VERSION = "2.0.0"
+$DOTNET_CORE_1_VERSION = "1.0.4"
+$DOTNET_INSTALLER_SCRIPT_URL = "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1"
+$DOTNET_INSTALLER_SCRIPT = Join-Path $DOTNET_DIR "dotnet-install.ps1"
+
+$env:PATH = "$TOOLS_DIR;$DOTNET_DIR;$env:PATH"
 
 # Make sure tools folder exists
-$PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
-$ToolPath = Join-Path $PSScriptRoot "tools"
-if (!(Test-Path $ToolPath)) {
-    Write-Verbose "Creating tools directory..."
-    New-Item -Path $ToolPath -Type directory | out-null
+if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
+    Write-Verbose -Message "Creating tools directory..."
+    New-Item -Path $TOOLS_DIR -Type directory | out-null
 }
 
-###########################################################################
-# INSTALL .NET CORE CLI
-###########################################################################
+# Make sure dotnet folder exists
+if ((Test-Path $PSScriptRoot) -and !(Test-Path $DOTNET_DIR)) {
+    Write-Verbose -Message "Creating .dotnet directory..."
+    New-Item -Path $DOTNET_DIR -Type directory | out-null
+}
 
-Function Remove-PathVariable([string]$VariableToRemove)
-{
-    $path = [Environment]::GetEnvironmentVariable("PATH", "User")
-    if ($path -ne $null)
-    {
-        $newItems = $path.Split(';', [StringSplitOptions]::RemoveEmptyEntries) | Where-Object { "$($_)" -inotlike $VariableToRemove }
-        [Environment]::SetEnvironmentVariable("PATH", [System.String]::Join(';', $newItems), "User")
-    }
-
-    $path = [Environment]::GetEnvironmentVariable("PATH", "Process")
-    if ($path -ne $null)
-    {
-        $newItems = $path.Split(';', [StringSplitOptions]::RemoveEmptyEntries) | Where-Object { "$($_)" -inotlike $VariableToRemove }
-        [Environment]::SetEnvironmentVariable("PATH", [System.String]::Join(';', $newItems), "Process")
+# Try download .NET installer script if not exists
+if (!(Test-Path $DOTNET_INSTALLER_SCRIPT)) {
+    Write-Verbose -Message "Downloading .NET installer script..."
+    try {
+        $wc = GetProxyEnabledWebClient
+        $wc.DownloadFile($DOTNET_INSTALLER_SCRIPT_URL, $DOTNET_INSTALLER_SCRIPT)
+    } catch {
+        Throw "Could not download .NET installer script."
     }
 }
 
-# Get .NET Core CLI path if installed.
-$FoundDotNetCliVersion = $null;
-if (Get-Command dotnet -ErrorAction SilentlyContinue) {
-    $FoundDotNetCliVersion = dotnet --version;
-}
+# Install .NET Core runtimes
+Invoke-Expression "&`"$DOTNET_INSTALLER_SCRIPT`" -Version $DOTNET_CORE_1_VERSION -InstallDir `"$DOTNET_DIR`""
+Invoke-Expression "&`"$DOTNET_INSTALLER_SCRIPT`" -Version $DOTNET_CORE_2_VERSION -InstallDir `"$DOTNET_DIR`""
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+$env:DOTNET_CLI_TELEMETRY_OPTOUT=1
 
-if($FoundDotNetCliVersion -ne $DotNetVersion) {
-    $InstallPath = Join-Path $PSScriptRoot ".dotnet"
-    if (!(Test-Path $InstallPath)) {
-        mkdir -Force $InstallPath | Out-Null;
+# Try find NuGet.exe in path if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Trying to find nuget.exe in PATH..."
+    $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_ -PathType Container) }
+    $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
+    if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
+        Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
+        $NUGET_EXE = $NUGET_EXE_IN_PATH.FullName
     }
-    (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, "$InstallPath\dotnet-install.ps1");
-    & $InstallPath\dotnet-install.ps1 -Version $DotNetVersion -InstallDir $InstallPath;
-
-    Remove-PathVariable "$InstallPath"
-    $env:PATH = "$InstallPath;$env:PATH"
-    $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-    $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
 }
 
-###########################################################################
-# INSTALL CAKE
-###########################################################################
-
-Add-Type -AssemblyName System.IO.Compression.FileSystem
-Function Unzip
-{
-    param([string]$zipfile, [string]$outpath)
-
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+# Try download NuGet.exe if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Downloading NuGet.exe..."
+    try {
+        $wc = GetProxyEnabledWebClient
+        $wc.DownloadFile($NUGET_URL, $NUGET_EXE)
+    } catch {
+        Throw "Could not download NuGet.exe."
+    }
 }
 
+# Save nuget.exe path to environment to be available to child processed
+$ENV:NUGET_EXE = $NUGET_EXE
 
-# Make sure Cake has been installed.
-$CakePath = Join-Path $ToolPath "Cake.CoreCLR.$CakeVersion/Cake.dll"
-if (!(Test-Path $CakePath)) {
-    Write-Host "Installing Cake..."
-     (New-Object System.Net.WebClient).DownloadFile("https://www.nuget.org/api/v2/package/Cake.CoreCLR/$CakeVersion", "$ToolPath\Cake.CoreCLR.zip")
-     Unzip "$ToolPath\Cake.CoreCLR.zip" "$ToolPath/Cake.CoreCLR.$CakeVersion"
-     Remove-Item "$ToolPath\Cake.CoreCLR.zip"
+# Try install Cake
+if (!(Test-Path $CAKE_DLL)) {
+    Write-Verbose -Message "Installing Cake..."
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install Cake.CoreCLR -Version $CAKE_VERSION -OutputDirectory `"$TOOLS_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "Could not install Cake."
+    }
+
+    Write-Verbose -Message ($NuGetOutput | out-string)
 }
 
-###########################################################################
-# RUN BUILD SCRIPT
-###########################################################################
+# Make sure that Cake has been installed
+if (!(Test-Path $CAKE_DLL)) {
+    Throw "Could not find Cake.dll at $CAKE_DLL"
+}
 
-& dotnet "$CakePath" $args
+# Build Cake arguments
+$cakeArguments = @("$Script");
+if ($Target) { $cakeArguments += "-target=$Target" }
+if ($Configuration) { $cakeArguments += "-configuration=$Configuration" }
+if ($Verbosity) { $cakeArguments += "-verbosity=$Verbosity" }
+if ($ShowDescription) { $cakeArguments += "-showdescription" }
+if ($DryRun) { $cakeArguments += "-dryrun" }
+if ($Exercise) { $cakeArguments += "-exercise=$Exercise" }
+$cakeArguments += $ScriptArgs
+
+# Start Cake
+Write-Host "Running build script..."
+Invoke-Expression "&dotnet `"$CAKE_DLL`" $cakeArguments"
 exit $LASTEXITCODE

--- a/build.sh
+++ b/build.sh
@@ -4,38 +4,68 @@
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 TOOLS_DIR=$SCRIPT_DIR/tools
 CAKE_VERSION=0.21.1
-CAKE_DLL=$TOOLS_DIR/Cake.CoreCLR.$CAKE_VERSION/Cake.dll
-DOTNET_VERSION=2.0.0
+CAKE_DIR=$TOOLS_DIR/Cake.CoreCLR.$CAKE_VERSION
+CAKE_DLL=$CAKE_DIR/Cake.dll
+CAKE_ZIP=$TOOLS_DIR/Cake.CoreCLR.$CAKE_VERSION.zip
+CAKE_URL=https://www.nuget.org/api/v2/package/Cake.CoreCLR/$CAKE_VERSION
+DOTNET_DIR=$SCRIPT_DIR/.dotnet
+DOTNET_CORE_2_VERSION=2.0.0
+DOTNET_CORE_1_VERSION=1.0.4
+DOTNET_INSTALLER_SCRIPT_URL=https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh
+DOTNET_INSTALLER_SCRIPT=$DOTNET_DIR/dotnet-install.sh
 
-# Make sure the tools folder exist. 
+# Define default arguments.
+TARGET="Default"
+CONFIGURATION="Release"
+VERBOSITY="Normal"
+DRYRUN=
+CAKE_ARGUMENTS=()
+
+# Parse arguments.
+for i in "$@"; do
+    case $1 in
+        -t|--target) TARGET="$2"; shift ;;
+        -c|--configuration) CONFIGURATION="$2"; shift ;;
+        -v|--verbosity) VERBOSITY="$2"; shift ;;
+        -d|--dryrun) DRYRUN="-dryrun" ;;
+        --) shift; CAKE_ARGUMENTS+=("$@"); break ;;
+        *) CAKE_ARGUMENTS+=("$1") ;;
+    esac
+    shift
+done
+
+# Make sure the tools folder exist.
 if [ ! -d "$TOOLS_DIR" ]; then
   mkdir "$TOOLS_DIR"
 fi
 
-###########################################################################
-# INSTALL .NET CORE CLI
-###########################################################################
-
-if [[ ! $(command -v dotnet) ]] || [ ! $(dotnet --version) == "$DOTNET_VERSION" ] ; then
-    echo "Installing .NET CLI..."
-    
-    if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
-        mkdir "$SCRIPT_DIR/.dotnet"
-    fi
-    curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh
-    sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version DOTNET_VERSION --install-dir .dotnet --no-path
-    export PATH="$SCRIPT_DIR/.dotnet":$PATH
-    export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-    export DOTNET_CLI_TELEMETRY_OPTOUT=1
-    "$SCRIPT_DIR/.dotnet/dotnet" --info
+# Make sure the dotnet folder exist.
+if [ ! -d "$DOTNET_DIR" ]; then
+  mkdir "$DOTNET_DIR"
 fi
 
-# ###########################################################################
-# # INSTALL CAKE
-# ###########################################################################
+# Download .NET installer script if it does not exist.
+if [ ! -f "$DOTNET_INSTALLER_SCRIPT" ]; then
+    echo "Downloading .NET installer script..."
+    curl -Lsfo "$DOTNET_INSTALLER_SCRIPT" $DOTNET_INSTALLER_SCRIPT_URL
+    if [ $? -ne 0 ]; then
+        echo "An error occured while downloading .NET installer script."
+        exit 1
+    fi
+fi
 
+# Install .NET Core runtimes
+$DOTNET_INSTALLER_SCRIPT --version $DOTNET_CORE_1_VERSION --install-dir "$DOTNET_DIR" --no-path
+$DOTNET_INSTALLER_SCRIPT --version $DOTNET_CORE_2_VERSION --install-dir "$DOTNET_DIR" --no-path
+export PATH="$DOTNET_DIR":$PATH
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+# Install Cake
 if [ ! -f "$CAKE_DLL" ]; then
-    curl -Lsfo Cake.CoreCLR.zip "https://www.nuget.org/api/v2/package/Cake.CoreCLR/$CAKE_VERSION" && unzip -q Cake.CoreCLR.zip -d "$TOOLS_DIR/Cake.CoreCLR.$CAKE_VERSION" && rm -f Cake.CoreCLR.zip
+    curl -Lsfo "$CAKE_ZIP" "$CAKE_URL"
+    unzip -q "$CAKE_ZIP" -d "$CAKE_DIR"
+    rm -f "$CAKE_ZIP"
     if [ $? -ne 0 ]; then
         echo "An error occured while installing Cake."
         exit 1
@@ -44,13 +74,9 @@ fi
 
 # Make sure that Cake has been installed.
 if [ ! -f "$CAKE_DLL" ]; then
-    echo "Could not find Cake.exe at '$CAKE_DLL'."
+    echo "Could not find Cake.dll at '$CAKE_DLL'."
     exit 1
 fi
 
-###########################################################################
-# RUN BUILD SCRIPT
-###########################################################################
-
 # Start Cake
-exec dotnet "$CAKE_DLL" "$@"
+dotnet "$CAKE_DLL" --verbosity="$VERBOSITY" --configuration="$CONFIGURATION" --target="$TARGET" $DRYRUN "${CAKE_ARGUMENTS[@]}"


### PR DESCRIPTION
This PR updates the build loader script to better comply to the default Cake build loader scripts. In the process, I've fixed two issues:

- Easier passing of single exercise argument
- Install .NET Core 1.0.4 runtime