### PR TITLE
Really enforce sorted student names in roster

### DIFF
--- a/exercises/grade-school/GradeSchoolTest.fs
+++ b/exercises/grade-school/GradeSchoolTest.fs
@@ -57,10 +57,11 @@ let ``Student names and grades in roster are sorted`` () =
         |> add "Kareem" 6
         |> add "Christopher" 4
         |> add "Kyle" 3
+        |> add "Zoe" 4
 
     let expected = 
         [(3, ["Kyle"]);
-         (4, ["Christopher"; "Jennifer"]);
+         (4, ["Christopher"; "Jennifer"; "Zoe"]);
          (6, ["Kareem"])]
 
     roster school |> should equal expected


### PR DESCRIPTION
By adding three names in neither ascending, nor descending alphabetical order, we can guarantee that the roster has been sorted.

The former way of testing could miss implementations that `cons`ed instead of `append`.

FIX #358 