### PR TITLE
Test case generator for NthPrime

### DIFF
--- a/exercises/nth-prime/Example.fs
+++ b/exercises/nth-prime/Example.fs
@@ -20,4 +20,7 @@ let primes =
         yield! Seq.filter isPrime (possiblePrimes 6)
     }
 
-let nthPrime nth = Seq.item (nth - 1) primes
+let prime nth : int option = 
+    match nth with 
+    | n when n < 1 -> None
+    | _ -> Some (Seq.item (nth - 1) primes)

--- a/exercises/nth-prime/NthPrime.fs
+++ b/exercises/nth-prime/NthPrime.fs
@@ -1,3 +1,3 @@
 ﻿module NthPrime
 
-let nthPrime nth = failwith "You need to implement this function."
+let prime nth : int option = failwith "You need to implement this function."

--- a/exercises/nth-prime/NthPrimeTest.fs
+++ b/exercises/nth-prime/NthPrimeTest.fs
@@ -1,49 +1,29 @@
+// This file was auto-generated based on version 1.0.0 of the canonical data.
+
 module NthPrimeTest
 
-open Xunit
 open FsUnit.Xunit
+open Xunit
+
 open NthPrime
 
 [<Fact>]
 let ``First prime`` () =
-    nthPrime 1 |> should equal 2
+    prime 1 |> should equal (Some 2)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Second prime`` () =
-    nthPrime 2 |> should equal 3
+    prime 2 |> should equal (Some 3)
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Third prime`` () =
-    nthPrime 3 |> should equal 5
+let ``Sixth prime`` () =
+    prime 6 |> should equal (Some 13)
 
 [<Fact(Skip = "Remove to run test")>]
-let ``4th prime`` () =
-    nthPrime 4 |> should equal 7
+let ``Big prime`` () =
+    prime 10001 |> should equal (Some 104743)
 
 [<Fact(Skip = "Remove to run test")>]
-let ``5th prime`` () =
-    nthPrime 5 |> should equal 11
+let ``There is no zeroth prime`` () =
+    prime 0 |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
-let ``6th prime`` () =
-    nthPrime 6 |> should equal 13
-
-[<Fact(Skip = "Remove to run test")>]
-let ``7th prime`` () =
-    nthPrime 7 |> should equal 17
-
-[<Fact(Skip = "Remove to run test")>]
-let ``8th prime`` () =
-    nthPrime 8 |> should equal 19
-
-[<Fact(Skip = "Remove to run test")>]
-let ``1000th prime`` () =
-    nthPrime 1000 |> should equal 7919
-
-[<Fact(Skip = "Remove to run test")>]
-let ``10000th prime`` () =
-    nthPrime 10000 |> should equal 104729
-
-[<Fact(Skip = "Remove to run test")>]
-let ``10001th prime`` () =
-    nthPrime 10001 |> should equal 104743

--- a/exercises/pangram/PangramTest.fs
+++ b/exercises/pangram/PangramTest.fs
@@ -1,4 +1,4 @@
-// This file was auto-generated based on version 1.2.0 of the canonical data.
+// This file was auto-generated based on version 1.3.0 of the canonical data.
 
 module PangramTest
 
@@ -24,8 +24,8 @@ let ``Missing character 'x'`` () =
     isPangram "a quick movement of the enemy will jeopardize five gunboats" |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Another missing character 'x'`` () =
-    isPangram "the quick brown fish jumps over the lazy dog" |> should equal false
+let ``Another missing character, e.g. 'h'`` () =
+    isPangram "five boxing wizards jump quickly at it" |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Pangram with underscores`` () =

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -176,9 +176,17 @@ type Minesweeper() =
         | true  -> Some "string list"
         | false -> None
 
-type Pangram() =
+type NthPrime() =
     inherit Exercise()
 
+    override this.RenderExpected (canonicalDataCase, key, value) = 
+        match string value with 
+        | "False" -> "None"
+        | _ ->  value :?> int64 |> sprintf "(Some %d)"
+
+type Pangram() =
+    inherit Exercise()
+    
 type PerfectNumbers() =
     inherit Exercise()
 


### PR DESCRIPTION
Adding the test case generator for Nth-Prime. Fix for #386.

- Renamed nthPrime to prime
- Returning a` int option` value and `None` for invalid nth index.
- Regenerated PangramTest.fs. with latest data.