### PR TITLE
Adding test generation got pascals-triangle

### DIFF
--- a/exercises/pascals-triangle/Example.fs
+++ b/exercises/pascals-triangle/Example.fs
@@ -1,8 +1,8 @@
 ﻿module PascalsTriangle
-    
-let triangle rows : int list list option = 
+open System    
+let triangle rows = 
     match rows with 
-    | r when r < 0 -> None
+    | r when r < 0 -> raise (ArgumentOutOfRangeException())
     | _ ->
         let row i = 
             [1 .. i - 1] 
@@ -10,4 +10,3 @@ let triangle rows : int list list option =
 
         [1..rows] 
         |> List.map row 
-        |> Some

--- a/exercises/pascals-triangle/Example.fs
+++ b/exercises/pascals-triangle/Example.fs
@@ -1,12 +1,13 @@
 ﻿module PascalsTriangle
 
-let triangle rows = 
-    match rows with 
-    | r when r < 0 -> raise (System.ArgumentOutOfRangeException())
+let rows numberOfRows : int list list option = 
+    match numberOfRows with 
+    | r when r < 0 -> None
     | _ ->
         let row i = 
             [1 .. i - 1] 
             |> List.scan (fun acc j -> acc * (i - j) / j) 1 
 
-        [1..rows] 
-        |> List.map row 
+        [1..numberOfRows] 
+        |> List.map row
+        |> Some

--- a/exercises/pascals-triangle/Example.fs
+++ b/exercises/pascals-triangle/Example.fs
@@ -1,9 +1,13 @@
 ﻿module PascalsTriangle
     
-let triangle rows = 
-    let row i = 
-        [1 .. i - 1] 
-        |> List.scan (fun acc j -> acc * (i - j) / j) 1 
-   
-    [1..rows] 
-    |> List.map row 
+let triangle rows : int list list option = 
+    match rows with 
+    | r when r < 0 -> None
+    | _ ->
+        let row i = 
+            [1 .. i - 1] 
+            |> List.scan (fun acc j -> acc * (i - j) / j) 1 
+
+        [1..rows] 
+        |> List.map row 
+        |> Some

--- a/exercises/pascals-triangle/Example.fs
+++ b/exercises/pascals-triangle/Example.fs
@@ -1,8 +1,7 @@
 ﻿module PascalsTriangle
-open System    
 let triangle rows = 
     match rows with 
-    | r when r < 0 -> raise (ArgumentOutOfRangeException())
+    | r when r < 0 -> raise (System.ArgumentOutOfRangeException())
     | _ ->
         let row i = 
             [1 .. i - 1] 

--- a/exercises/pascals-triangle/Example.fs
+++ b/exercises/pascals-triangle/Example.fs
@@ -1,4 +1,5 @@
 ﻿module PascalsTriangle
+
 let triangle rows = 
     match rows with 
     | r when r < 0 -> raise (System.ArgumentOutOfRangeException())

--- a/exercises/pascals-triangle/PascalsTriangle.fs
+++ b/exercises/pascals-triangle/PascalsTriangle.fs
@@ -1,2 +1,3 @@
 ﻿module PascalsTriangle
+
 let triangle rows = failwith "You need to implement this function."

--- a/exercises/pascals-triangle/PascalsTriangle.fs
+++ b/exercises/pascals-triangle/PascalsTriangle.fs
@@ -1,2 +1,2 @@
 ﻿module PascalsTriangle
-let triangle rows : int list list option = failwith "You need to implement this function."
+let triangle rows = failwith "You need to implement this function."

--- a/exercises/pascals-triangle/PascalsTriangle.fs
+++ b/exercises/pascals-triangle/PascalsTriangle.fs
@@ -1,3 +1,3 @@
 ﻿module PascalsTriangle
-    
+open System
 let triangle rows : int list list option = failwith "You need to implement this function."

--- a/exercises/pascals-triangle/PascalsTriangle.fs
+++ b/exercises/pascals-triangle/PascalsTriangle.fs
@@ -1,3 +1,3 @@
 ﻿module PascalsTriangle
 
-let triangle rows = failwith "You need to implement this function."
+let rows numberOfRows : int list list option = failwith "You need to implement this function."

--- a/exercises/pascals-triangle/PascalsTriangle.fs
+++ b/exercises/pascals-triangle/PascalsTriangle.fs
@@ -1,3 +1,2 @@
 ﻿module PascalsTriangle
-open System
 let triangle rows : int list list option = failwith "You need to implement this function."

--- a/exercises/pascals-triangle/PascalsTriangle.fs
+++ b/exercises/pascals-triangle/PascalsTriangle.fs
@@ -1,3 +1,3 @@
 ﻿module PascalsTriangle
     
-let triangle rows = failwith "You need to implement this function."
+let triangle rows : int list list option = failwith "You need to implement this function."

--- a/exercises/pascals-triangle/PascalsTriangleTest.fs
+++ b/exercises/pascals-triangle/PascalsTriangleTest.fs
@@ -29,5 +29,5 @@ let ``Four rows`` () =
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Negative rows`` () =
-    triangle -1 |> should equal None
+    triangle -1 |> should throw typeof<ArgumentOutOfRangeException>
 

--- a/exercises/pascals-triangle/PascalsTriangleTest.fs
+++ b/exercises/pascals-triangle/PascalsTriangleTest.fs
@@ -9,25 +9,25 @@ open PascalsTriangle
 
 [<Fact>]
 let ``Zero rows`` () =
-    triangle 0 |> should be Empty
+    rows 0 |> should equal (Some ([]: int list list))
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Single row`` () =
-    triangle 1 |> should equal [[1]]
+    rows 1 |> should equal (Some [[1]])
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Two rows`` () =
-    triangle 2 |> should equal [[1]; [1; 1]]
+    rows 2 |> should equal (Some [[1]; [1; 1]])
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Three rows`` () =
-    triangle 3 |> should equal [[1]; [1; 1]; [1; 2; 1]]
+    rows 3 |> should equal (Some [[1]; [1; 1]; [1; 2; 1]])
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Four rows`` () =
-    triangle 4 |> should equal [[1]; [1; 1]; [1; 2; 1]; [1; 3; 3; 1]]
+    rows 4 |> should equal (Some [[1]; [1; 1]; [1; 2; 1]; [1; 3; 3; 1]])
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Negative rows`` () =
-    (fun () -> triangle -1 |> ignore) |> should throw typeof<System.ArgumentOutOfRangeException>
+    rows -1 |> should equal None
 

--- a/exercises/pascals-triangle/PascalsTriangleTest.fs
+++ b/exercises/pascals-triangle/PascalsTriangleTest.fs
@@ -13,21 +13,21 @@ let ``Zero rows`` () =
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Single row`` () =
-    triangle 1 |> should equal (Some [[1]])
+    triangle 1 |> should equal [[1]]
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Two rows`` () =
-    triangle 2 |> should equal (Some [[1]; [1; 1]])
+    triangle 2 |> should equal [[1]; [1; 1]]
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Three rows`` () =
-    triangle 3 |> should equal (Some [[1]; [1; 1]; [1; 2; 1]])
+    triangle 3 |> should equal [[1]; [1; 1]; [1; 2; 1]]
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Four rows`` () =
-    triangle 4 |> should equal (Some [[1]; [1; 1]; [1; 2; 1]; [1; 3; 3; 1]])
+    triangle 4 |> should equal [[1]; [1; 1]; [1; 2; 1]; [1; 3; 3; 1]]
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Negative rows`` () =
-    triangle -1 |> should throw typeof<ArgumentOutOfRangeException>
+    (fun () -> triangle -1 |> ignore) |> should throw typeof<System.ArgumentOutOfRangeException>
 

--- a/exercises/pascals-triangle/PascalsTriangleTest.fs
+++ b/exercises/pascals-triangle/PascalsTriangleTest.fs
@@ -1,30 +1,33 @@
+// This file was auto-generated based on version 1.1.0 of the canonical data.
+
 module PascalsTriangleTest
 
-open Xunit
 open FsUnit.Xunit
+open Xunit
 
 open PascalsTriangle
 
 [<Fact>]
-let ``One row`` () =
-    triangle 1 |> should equal [[1]]
-        
+let ``Zero rows`` () =
+    triangle 0 |> should be Empty
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Single row`` () =
+    triangle 1 |> should equal (Some [[1]])
+
 [<Fact(Skip = "Remove to run test")>]
 let ``Two rows`` () =
-    triangle 2 |> should equal [[1]; [1; 1]]
+    triangle 2 |> should equal (Some [[1]; [1; 1]])
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Three rows`` () =
-    triangle 3 |> should equal [[1]; [1; 1]; [1; 2; 1]]
+    triangle 3 |> should equal (Some [[1]; [1; 1]; [1; 2; 1]])
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Four rows`` () =
-    triangle 4 |> should equal [[1]; [1; 1]; [1; 2; 1]; [1; 3; 3; 1]]
+    triangle 4 |> should equal (Some [[1]; [1; 1]; [1; 2; 1]; [1; 3; 3; 1]])
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Five rows`` () =
-    triangle 5 |> should equal [[1]; [1; 1]; [1; 2; 1]; [1; 3; 3; 1]; [1; 4; 6; 4; 1]]
+let ``Negative rows`` () =
+    triangle -1 |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
-let ``Twenty rows`` () =
-    triangle 20 |> List.last |> should equal [1; 19; 171; 969; 3876; 11628; 27132; 50388; 75582; 92378; 92378; 75582; 50388; 27132; 11628; 3876; 969; 171; 19; 1]

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -200,21 +200,21 @@ type PerfectNumbers() =
 type PascalsTriangle() =
     inherit Exercise()
 
-    override this.RenderSutProperty canonicalDataCase = "triangle"
-
     override this.RenderExpected (canonicalDataCase, key, value) = 
         match value with
         | :? JArray  ->
-            value :?> JArray 
-            |> normalizeJArray
-            |> Seq.map formatValue
-            |> formatList
-        | _ -> "System.ArgumentOutOfRangeException"
+            match value :?> JArray |> Seq.isEmpty  with
+            | true -> "(Some ([]: int list list))"
+            | false ->
+                value :?> JArray
+                |> normalizeJArray
+                |> Seq.map formatValue
+                |> formatList
+                |> sprintf "(Some %s)"
 
-    override this.ToTestMethodBodyAssertTemplate canonicalDataCase =
-         match canonicalDataCase.Expected with
-         | :? JArray -> base.ToTestMethodBodyAssertTemplate canonicalDataCase
-         | _ -> "AssertThrows"
+        | _ -> "None"
+
+    override this.ToTestMethodBodyAssertTemplate canonicalDataCase = "AssertEqual"
 
 type PhoneNumber() =
     inherit Exercise()

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -203,14 +203,13 @@ type PascalsTriangle() =
     override this.RenderSutProperty canonicalDataCase = "triangle"
 
     override this.RenderExpected (canonicalDataCase, key, value) = 
-        match string value with
-        | "-1" -> "ArgumentOutOfRangeException"
-        | _ ->
+        match value with
+        | :? JArray  ->
             value :?> JArray 
             |> normalizeJArray
             |> Seq.map formatValue
             |> formatList
-            |> sprintf "(Some %s)"
+        | _ -> "System.ArgumentOutOfRangeException"
 
     override this.ToTestMethodBodyAssertTemplate canonicalDataCase =
          match canonicalDataCase.Expected with

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -204,14 +204,19 @@ type PascalsTriangle() =
 
     override this.RenderExpected (canonicalDataCase, key, value) = 
         match string value with
-        | "-1" -> "None"
+        | "-1" -> "ArgumentOutOfRangeException"
         | _ ->
             value :?> JArray 
             |> normalizeJArray
             |> Seq.map formatValue
             |> formatList
             |> sprintf "(Some %s)"
-        
+
+    override this.ToTestMethodBodyAssertTemplate canonicalDataCase =
+         match canonicalDataCase.Expected with
+         | :? JArray -> base.ToTestMethodBodyAssertTemplate canonicalDataCase
+         | _ -> "AssertThrows"
+
 type PhoneNumber() =
     inherit Exercise()
     

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -197,6 +197,21 @@ type PerfectNumbers() =
         | "deficient" -> "(Some Deficient)"
         | _ -> "None"
 
+type PascalsTriangle() =
+    inherit Exercise()
+
+    override this.RenderSutProperty canonicalDataCase = "triangle"
+
+    override this.RenderExpected (canonicalDataCase, key, value) = 
+        match string value with
+        | "-1" -> "None"
+        | _ ->
+            value :?> JArray 
+            |> normalizeJArray
+            |> Seq.map formatValue
+            |> formatList
+            |> sprintf "(Some %s)"
+        
 type PhoneNumber() =
     inherit Exercise()
     

--- a/generators/Templates/_AssertThrows.liquid
+++ b/generators/Templates/_AssertThrows.liquid
@@ -1,1 +1,1 @@
-{{ Sut }} |> should throw typeof<{{ Expected }}>
+(fun () -> {{ Sut }} |> ignore) |> should throw typeof<{{ Expected }}>

--- a/generators/Templates/_AssertThrows.liquid
+++ b/generators/Templates/_AssertThrows.liquid
@@ -1,0 +1,1 @@
+{{ Sut }} |> should throw typeof<{{ Expected }}>


### PR DESCRIPTION
Adding test generation got pascals-triangle, issue #390.
In this case we have to handle 3 types of expected outputs, which are Empty, valid and invalid input case. So experimented with exception rather than using option type.

- I tried introducing a new template for test throwing exception in the case of invalid input. 
- In the example we are raising ArgumentOutOfRangeException in case of invalid input.
- Overriding `ToTestMethodBodyAssertTemplate` to identify the exception throwing cases and choose  template for exception.
- Kept the name of method as "triangle" rather than changing it to "row".

I am not sure is this the right way to tackle the issue. @ErikSchierboom , Could you please share your thoughts?