### PR TITLE
Largest series product

### DIFF
--- a/exercises/largest-series-product/Example.fs
+++ b/exercises/largest-series-product/Example.fs
@@ -17,20 +17,20 @@ let slices size list =
 
     List.init sliceCount slice
 
-let isInputHasAllDigits input =
+let allDigits input =
     input
     |> Seq.forall Char.IsDigit
     
-let isValidCase input seriesLength =
+let isInvalidCase input seriesLength =
     let inputLenth = String.length input
     
     inputLenth < seriesLength 
     || inputLenth = 0 && seriesLength > 0 
     || seriesLength < 0 
-    || not (isInputHasAllDigits input)
+    || not (allDigits input)
 
 let largestProduct input seriesLength = 
-    match isValidCase input seriesLength with 
+    match isInvalidCase input seriesLength with 
     | true -> -1
     | false ->   
         input 

--- a/exercises/largest-series-product/Example.fs
+++ b/exercises/largest-series-product/Example.fs
@@ -29,12 +29,13 @@ let isInvalidCase input seriesLength =
     || seriesLength < 0 
     || not (allDigits input)
 
-let largestProduct input seriesLength = 
+let largestProduct input seriesLength : int option = 
     match isInvalidCase input seriesLength with 
-    | true -> -1
+    | true -> None
     | false ->   
         input 
         |> digits 
         |> slices seriesLength
         |> List.map (List.fold (*) 1)
         |> List.max
+        |> Some

--- a/exercises/largest-series-product/Example.fs
+++ b/exercises/largest-series-product/Example.fs
@@ -16,16 +16,23 @@ let slices size list =
     let sliceCount = List.length list + 1 - size
 
     List.init sliceCount slice
+
 let isInputHasAllDigits input =
     input
     |> Seq.forall Char.IsDigit
+    
+let isValidCase input seriesLength =
+    let inputLenth = String.length input
+    
+    inputLenth < seriesLength 
+    || inputLenth = 0 && seriesLength > 0 
+    || seriesLength < 0 
+    || not (isInputHasAllDigits input)
+
 let largestProduct input seriesLength = 
-    match input with 
-    | l when String.length l < seriesLength -> -1
-    | l when String.length l = 0 && seriesLength > 0 -> -1
-    | l when seriesLength < 0 -> -1 
-    | l when isInputHasAllDigits l -> -1
-    | _ ->   
+    match isValidCase input seriesLength with 
+    | true -> -1
+    | false ->   
         input 
         |> digits 
         |> slices seriesLength

--- a/exercises/largest-series-product/Example.fs
+++ b/exercises/largest-series-product/Example.fs
@@ -16,10 +16,16 @@ let slices size list =
     let sliceCount = List.length list + 1 - size
 
     List.init sliceCount slice
-
+let isInputHasAllDigits input =
+    input
+    |> Seq.forall Char.IsDigit
 let largestProduct input seriesLength = 
-    if seriesLength > String.length input then failwith "Slice size is too big"
-    else 
+    match input with 
+    | l when String.length l < seriesLength -> -1
+    | l when String.length l = 0 && seriesLength > 0 -> -1
+    | l when seriesLength < 0 -> -1 
+    | l when isInputHasAllDigits l -> -1
+    | _ ->   
         input 
         |> digits 
         |> slices seriesLength

--- a/exercises/largest-series-product/LargestSeriesProduct.fs
+++ b/exercises/largest-series-product/LargestSeriesProduct.fs
@@ -1,3 +1,3 @@
 ﻿module LargestSeriesProduct
 
-let largestProduct input seriesLength = failwith "You need to implement this function."
+let largestProduct input seriesLength : int option = failwith "You need to implement this function."

--- a/exercises/largest-series-product/LargestSeriesProductTest.fs
+++ b/exercises/largest-series-product/LargestSeriesProductTest.fs
@@ -1,40 +1,84 @@
+// This file was auto-generated based on version 1.0.0 of the canonical data.
+
 module LargestSeriesProductTest
 
-open Xunit
 open FsUnit.Xunit
-open System
+open Xunit
+
 open LargestSeriesProduct
-    
-[<Theory(Skip = "Remove to run test")>]
-[<InlineData("01234567890", 2, 72)>]
-[<InlineData("1027839564", 3, 270)>]
-let ``Gets the largest product``(digits: string) (seriesLength: int) (expected: int) =
-    largestProduct digits seriesLength |> should equal expected
 
-    
-[<Fact(Skip = "Remove to run test")>]
-let ``Largest product works for small numbers`` () =
-    largestProduct "19" 2 |> should equal 9
-    
-[<Fact(Skip = "Remove to run test")>]
-let ``Largest product works for large numbers`` () =
-    let LARGE_NUMBER = "73167176531330624919225119674426574742355349194934"
-    largestProduct LARGE_NUMBER 6 |> should equal 23520
-    
-[<Theory(Skip = "Remove to run test")>]
-[<InlineData("0000", 2, 0)>]
-[<InlineData("99099", 3, 0)>]
-let ``Largest product works if all spans contain zero``(digits: string) (seriesLength: int) (expected: int) =
-    largestProduct digits seriesLength |> should equal expected
+[<Fact>]
+let ``Finds the largest product if span equals length`` () =
+    let digits = "29"
+    largestProduct digits 2 |> should equal 18
 
-    
-[<Theory(Skip = "Remove to run test")>]
-[<InlineData("", 1)>]
-[<InlineData("123", 1)>]
-let ``Largest product for empty span is 1``(digits: string) (expected: int) =
-    largestProduct digits 0 |> should equal expected
-
-    
 [<Fact(Skip = "Remove to run test")>]
-let ``Cannot slice empty string with nonzero span`` () =
-    (fun () -> largestProduct "" 1 |> ignore) |> should throw typeof<Exception>
+let ``Can find the largest product of 2 with numbers in order`` () =
+    let digits = "0123456789"
+    largestProduct digits 2 |> should equal 72
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Can find the largest product of 2`` () =
+    let digits = "576802143"
+    largestProduct digits 2 |> should equal 48
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Can find the largest product of 3 with numbers in order`` () =
+    let digits = "0123456789"
+    largestProduct digits 3 |> should equal 504
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Can find the largest product of 3`` () =
+    let digits = "1027839564"
+    largestProduct digits 3 |> should equal 270
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Can find the largest product of 5 with numbers in order`` () =
+    let digits = "0123456789"
+    largestProduct digits 5 |> should equal 15120
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Can get the largest product of a big number`` () =
+    let digits = "73167176531330624919225119674426574742355349194934"
+    largestProduct digits 6 |> should equal 23520
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Reports zero if the only digits are zero`` () =
+    let digits = "0000"
+    largestProduct digits 2 |> should equal 0
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Reports zero if all spans include zero`` () =
+    let digits = "99099"
+    largestProduct digits 3 |> should equal 0
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Rejects span longer than string length`` () =
+    let digits = "123"
+    largestProduct digits 4 |> should equal -1
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Reports 1 for empty string and empty product (0 span)`` () =
+    let digits = ""
+    largestProduct digits 0 |> should equal 1
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Reports 1 for nonempty string and empty product (0 span)`` () =
+    let digits = "123"
+    largestProduct digits 0 |> should equal 1
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Rejects empty string and nonzero span`` () =
+    let digits = ""
+    largestProduct digits 1 |> should equal -1
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Rejects invalid character in digits`` () =
+    let digits = "1234a5"
+    largestProduct digits 2 |> should equal -1
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Rejects negative span`` () =
+    let digits = "12345"
+    largestProduct digits -1 |> should equal -1
+

--- a/exercises/largest-series-product/LargestSeriesProductTest.fs
+++ b/exercises/largest-series-product/LargestSeriesProductTest.fs
@@ -10,75 +10,75 @@ open LargestSeriesProduct
 [<Fact>]
 let ``Finds the largest product if span equals length`` () =
     let digits = "29"
-    largestProduct digits 2 |> should equal 18
+    largestProduct digits 2 |> should equal (Some 18)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Can find the largest product of 2 with numbers in order`` () =
     let digits = "0123456789"
-    largestProduct digits 2 |> should equal 72
+    largestProduct digits 2 |> should equal (Some 72)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Can find the largest product of 2`` () =
     let digits = "576802143"
-    largestProduct digits 2 |> should equal 48
+    largestProduct digits 2 |> should equal (Some 48)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Can find the largest product of 3 with numbers in order`` () =
     let digits = "0123456789"
-    largestProduct digits 3 |> should equal 504
+    largestProduct digits 3 |> should equal (Some 504)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Can find the largest product of 3`` () =
     let digits = "1027839564"
-    largestProduct digits 3 |> should equal 270
+    largestProduct digits 3 |> should equal (Some 270)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Can find the largest product of 5 with numbers in order`` () =
     let digits = "0123456789"
-    largestProduct digits 5 |> should equal 15120
+    largestProduct digits 5 |> should equal (Some 15120)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Can get the largest product of a big number`` () =
     let digits = "73167176531330624919225119674426574742355349194934"
-    largestProduct digits 6 |> should equal 23520
+    largestProduct digits 6 |> should equal (Some 23520)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Reports zero if the only digits are zero`` () =
     let digits = "0000"
-    largestProduct digits 2 |> should equal 0
+    largestProduct digits 2 |> should equal (Some 0)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Reports zero if all spans include zero`` () =
     let digits = "99099"
-    largestProduct digits 3 |> should equal 0
+    largestProduct digits 3 |> should equal (Some 0)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Rejects span longer than string length`` () =
     let digits = "123"
-    largestProduct digits 4 |> should equal -1
+    largestProduct digits 4 |> should equal None
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Reports 1 for empty string and empty product (0 span)`` () =
     let digits = ""
-    largestProduct digits 0 |> should equal 1
+    largestProduct digits 0 |> should equal (Some 1)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Reports 1 for nonempty string and empty product (0 span)`` () =
     let digits = "123"
-    largestProduct digits 0 |> should equal 1
+    largestProduct digits 0 |> should equal (Some 1)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Rejects empty string and nonzero span`` () =
     let digits = ""
-    largestProduct digits 1 |> should equal -1
+    largestProduct digits 1 |> should equal None
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Rejects invalid character in digits`` () =
     let digits = "1234a5"
-    largestProduct digits 2 |> should equal -1
+    largestProduct digits 2 |> should equal None
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Rejects negative span`` () =
     let digits = "12345"
-    largestProduct digits -1 |> should equal -1
+    largestProduct digits -1 |> should equal None
 

--- a/generators/Exercise.fs
+++ b/generators/Exercise.fs
@@ -218,7 +218,7 @@ type Exercise() =
         canonicalDataCase.Properties
         |> Map.toList
         |> List.map fst
-        |> List.except ["property"; "expected"; "description"]
+        |> List.except ["property"; "expected"; "description"; "comments"]
     
     // Utility methods to customize rendered output
 

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -159,6 +159,11 @@ type LargestSeriesProduct() =
 
      override this.PropertiesWithIdentifier canonicalDataCase = ["digits"]
 
+    override this.RenderExpected (canonicalDataCase, key, value) = 
+        match value :?> int64 with 
+        | -1L -> "None"
+        | _ -> value :?> int64 |> sprintf "(Some %d)"
+
 type Leap() =
     inherit Exercise()
 

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -154,6 +154,11 @@ type KindergartenGarden() =
 
     override this.UseFullMethodName canonicalDataCase = true
 
+type LargestSeriesProduct() =
+    inherit Exercise()
+
+     override this.PropertiesWithIdentifier canonicalDataCase = ["digits"]
+
 type Leap() =
     inherit Exercise()
 


### PR DESCRIPTION
Adding test case generator for largest series product . Fix for #382.
- Added "digit" as a properties with Identifier since it is very long some times.
- Added property "comment" in excluded list.
- Fixed example to handle invalid cases.
 