### PR TITLE
Simplify generators

### DIFF
--- a/exercises/all-your-base/AllYourBaseTest.fs
+++ b/exercises/all-your-base/AllYourBaseTest.fs
@@ -9,169 +9,169 @@ open AllYourBase
 
 [<Fact>]
 let ``Single bit one to decimal`` () =
-    let expected = Some [1]
     let inputBase = 2
     let inputDigits = [1]
     let outputBase = 10
+    let expected = Some [1]
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Binary to single decimal`` () =
-    let expected = Some [5]
     let inputBase = 2
     let inputDigits = [1; 0; 1]
     let outputBase = 10
+    let expected = Some [5]
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Single decimal to binary`` () =
-    let expected = Some [1; 0; 1]
     let inputBase = 10
     let inputDigits = [5]
     let outputBase = 2
+    let expected = Some [1; 0; 1]
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Binary to multiple decimal`` () =
-    let expected = Some [4; 2]
     let inputBase = 2
     let inputDigits = [1; 0; 1; 0; 1; 0]
     let outputBase = 10
+    let expected = Some [4; 2]
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Decimal to binary`` () =
-    let expected = Some [1; 0; 1; 0; 1; 0]
     let inputBase = 10
     let inputDigits = [4; 2]
     let outputBase = 2
+    let expected = Some [1; 0; 1; 0; 1; 0]
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Trinary to hexadecimal`` () =
-    let expected = Some [2; 10]
     let inputBase = 3
     let inputDigits = [1; 1; 2; 0]
     let outputBase = 16
+    let expected = Some [2; 10]
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Hexadecimal to trinary`` () =
-    let expected = Some [1; 1; 2; 0]
     let inputBase = 16
     let inputDigits = [2; 10]
     let outputBase = 3
+    let expected = Some [1; 1; 2; 0]
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``15-bit integer`` () =
-    let expected = Some [6; 10; 45]
     let inputBase = 97
     let inputDigits = [3; 46; 60]
     let outputBase = 73
+    let expected = Some [6; 10; 45]
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Empty list`` () =
-    let expected = None
     let inputBase = 2
     let inputDigits = []
     let outputBase = 10
+    let expected = None
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Single zero`` () =
-    let expected = None
     let inputBase = 10
     let inputDigits = [0]
     let outputBase = 2
+    let expected = None
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Multiple zeros`` () =
-    let expected = None
     let inputBase = 10
     let inputDigits = [0; 0; 0]
     let outputBase = 2
+    let expected = None
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Leading zeros`` () =
-    let expected = None
     let inputBase = 7
     let inputDigits = [0; 6; 0]
     let outputBase = 10
+    let expected = None
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``First base is one`` () =
-    let expected = None
     let inputBase = 1
     let inputDigits = []
     let outputBase = 10
+    let expected = None
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``First base is zero`` () =
-    let expected = None
     let inputBase = 0
     let inputDigits = []
     let outputBase = 10
+    let expected = None
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``First base is negative`` () =
-    let expected = None
     let inputBase = -2
     let inputDigits = [1]
     let outputBase = 10
+    let expected = None
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Negative digit`` () =
-    let expected = None
     let inputBase = 2
     let inputDigits = [1; -1; 1; 0; 1; 0]
     let outputBase = 10
+    let expected = None
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Invalid positive digit`` () =
-    let expected = None
     let inputBase = 2
     let inputDigits = [1; 2; 1; 0; 1; 0]
     let outputBase = 10
+    let expected = None
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Second base is one`` () =
-    let expected = None
     let inputBase = 2
     let inputDigits = [1; 0; 1; 0; 1; 0]
     let outputBase = 1
+    let expected = None
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Second base is zero`` () =
-    let expected = None
     let inputBase = 10
     let inputDigits = [7]
     let outputBase = 0
+    let expected = None
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Second base is negative`` () =
-    let expected = None
     let inputBase = 2
     let inputDigits = [1]
     let outputBase = -7
+    let expected = None
     rebase inputBase inputDigits outputBase |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Both bases are negative`` () =
-    let expected = None
     let inputBase = -2
     let inputDigits = [1]
     let outputBase = -7
+    let expected = None
     rebase inputBase inputDigits outputBase |> should equal expected
 

--- a/exercises/kindergarten-garden/Example.fs
+++ b/exercises/kindergarten-garden/Example.fs
@@ -5,16 +5,17 @@ type Plant = Violets | Radishes | Clover | Grass
 let plantsPerChildPerRow = 2
 let rowSeparator = '\n'
 
-let private defaultChildren = ["Alice"; "Bob"; "Charlie"; "David";
-                               "Eve"; "Fred"; "Ginny"; "Harriet";
-                               "Ileana"; "Joseph"; "Kincaid"; "Larry"]
+let private children = 
+    [ "Alice"; "Bob"; "Charlie"; "David";
+      "Eve"; "Fred"; "Ginny"; "Harriet";
+      "Ileana"; "Joseph"; "Kincaid"; "Larry"]
 
 let private plantFromCode code =
     match code with
-    | 'V' -> Plant.Violets
-    | 'R' -> Plant.Radishes
-    | 'C' -> Plant.Clover
-    | 'G' -> Plant.Grass
+    | 'V' -> Violets
+    | 'R' -> Radishes
+    | 'C' -> Clover
+    | 'G' -> Grass
     | x -> failwithf "%c is an invalid plant code" x
 
 let private plantsInRow (row: string) = 
@@ -22,16 +23,14 @@ let private plantsInRow (row: string) =
     |> Seq.chunkBySize plantsPerChildPerRow
     |> Seq.map List.ofArray
 
-let toGarden children (windowSills: string) =     
+let toGarden (windowSills: string) =     
     let rows = windowSills.Split rowSeparator
     let row1 = plantsInRow rows.[0]
     let row2 = plantsInRow rows.[1]
-    Seq.zip3 (children |> List.sort) row1 row2 
+    Seq.zip3 children row1 row2 
     |> Seq.map (fun (child, plants1, plants2) -> (child, plants1 @ plants2))
     |> Map.ofSeq
 
-let plantsForCustomStudents diagram student students = 
-    let garden = toGarden students diagram
+let plants diagram student = 
+    let garden = toGarden diagram
     defaultArg (Map.tryFind student garden) []
-
-let plantsForDefaultStudents diagram student = plantsForCustomStudents diagram student defaultChildren

--- a/exercises/kindergarten-garden/KindergartenGarden.fs
+++ b/exercises/kindergarten-garden/KindergartenGarden.fs
@@ -2,6 +2,4 @@
 
 // TODO: define the Plant type
 
-let plantsForDefaultStudents diagram student = failwith "You need to implement this function."
-
-let plantsForCustomStudents diagram student students = failwith "You need to implement this function."
+let plants diagram student = failwith "You need to implement this function."

--- a/exercises/kindergarten-garden/KindergartenGardenTest.fs
+++ b/exercises/kindergarten-garden/KindergartenGardenTest.fs
@@ -12,93 +12,61 @@ let ``Partial garden - garden with single student`` () =
     let student = "Alice"
     let diagram = "RC\nGG"
     let expected = [Plant.Radishes; Plant.Clover; Plant.Grass; Plant.Grass]
-    plantsForDefaultStudents diagram student |> should equal expected
+    plants diagram student |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Partial garden - different garden with single student`` () =
     let student = "Alice"
     let diagram = "VC\nRC"
     let expected = [Plant.Violets; Plant.Clover; Plant.Radishes; Plant.Clover]
-    plantsForDefaultStudents diagram student |> should equal expected
+    plants diagram student |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Partial garden - garden with two students`` () =
     let student = "Bob"
     let diagram = "VVCG\nVVRC"
     let expected = [Plant.Clover; Plant.Grass; Plant.Radishes; Plant.Clover]
-    plantsForDefaultStudents diagram student |> should equal expected
+    plants diagram student |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Partial garden - multiple students for the same garden with three students - second student's garden`` () =
     let student = "Bob"
     let diagram = "VVCCGG\nVVCCGG"
     let expected = [Plant.Clover; Plant.Clover; Plant.Clover; Plant.Clover]
-    plantsForDefaultStudents diagram student |> should equal expected
+    plants diagram student |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Partial garden - multiple students for the same garden with three students - third student's garden`` () =
     let student = "Charlie"
     let diagram = "VVCCGG\nVVCCGG"
     let expected = [Plant.Grass; Plant.Grass; Plant.Grass; Plant.Grass]
-    plantsForDefaultStudents diagram student |> should equal expected
+    plants diagram student |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Full garden - first student's garden`` () =
     let student = "Alice"
     let diagram = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"
     let expected = [Plant.Violets; Plant.Radishes; Plant.Violets; Plant.Radishes]
-    plantsForDefaultStudents diagram student |> should equal expected
+    plants diagram student |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Full garden - second student's garden`` () =
     let student = "Bob"
     let diagram = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"
     let expected = [Plant.Clover; Plant.Grass; Plant.Clover; Plant.Clover]
-    plantsForDefaultStudents diagram student |> should equal expected
+    plants diagram student |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Full garden - second to last student's garden`` () =
     let student = "Kincaid"
     let diagram = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"
     let expected = [Plant.Grass; Plant.Clover; Plant.Clover; Plant.Grass]
-    plantsForDefaultStudents diagram student |> should equal expected
+    plants diagram student |> should equal expected
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Full garden - last student's garden`` () =
     let student = "Larry"
     let diagram = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"
     let expected = [Plant.Grass; Plant.Violets; Plant.Clover; Plant.Violets]
-    plantsForDefaultStudents diagram student |> should equal expected
-
-[<Fact(Skip = "Remove to run test")>]
-let ``Non-alphabetical student list - first student's garden`` () =
-    let student = "Patricia"
-    let students = ["Samantha"; "Patricia"; "Xander"; "Roger"]
-    let diagram = "VCRRGVRG\nRVGCCGCV"
-    let expected = [Plant.Violets; Plant.Clover; Plant.Radishes; Plant.Violets]
-    plantsForCustomStudents diagram student students |> should equal expected
-
-[<Fact(Skip = "Remove to run test")>]
-let ``Non-alphabetical student list - second student's garden`` () =
-    let student = "Roger"
-    let students = ["Samantha"; "Patricia"; "Xander"; "Roger"]
-    let diagram = "VCRRGVRG\nRVGCCGCV"
-    let expected = [Plant.Radishes; Plant.Radishes; Plant.Grass; Plant.Clover]
-    plantsForCustomStudents diagram student students |> should equal expected
-
-[<Fact(Skip = "Remove to run test")>]
-let ``Non-alphabetical student list - third student's garden`` () =
-    let student = "Samantha"
-    let students = ["Samantha"; "Patricia"; "Xander"; "Roger"]
-    let diagram = "VCRRGVRG\nRVGCCGCV"
-    let expected = [Plant.Grass; Plant.Violets; Plant.Clover; Plant.Grass]
-    plantsForCustomStudents diagram student students |> should equal expected
-
-[<Fact(Skip = "Remove to run test")>]
-let ``Non-alphabetical student list - fourth (last) student's garden`` () =
-    let student = "Xander"
-    let students = ["Samantha"; "Patricia"; "Xander"; "Roger"]
-    let diagram = "VCRRGVRG\nRVGCCGCV"
-    let expected = [Plant.Radishes; Plant.Grass; Plant.Clover; Plant.Violets]
-    plantsForCustomStudents diagram student students |> should equal expected
+    plants diagram student |> should equal expected
 

--- a/exercises/phone-number/PhoneNumberTest.fs
+++ b/exercises/phone-number/PhoneNumberTest.fs
@@ -9,49 +9,49 @@ open PhoneNumber
 
 [<Fact>]
 let ``Cleans the number`` () =
-    clean "(223) 456-7890" |> should equal <| Some "2234567890"
+    clean "(223) 456-7890" |> should equal (Some "2234567890")
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Cleans numbers with dots`` () =
-    clean "223.456.7890" |> should equal <| Some "2234567890"
+    clean "223.456.7890" |> should equal (Some "2234567890")
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Cleans numbers with multiple spaces`` () =
-    clean "223 456   7890   " |> should equal <| Some "2234567890"
+    clean "223 456   7890   " |> should equal (Some "2234567890")
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Invalid when 9 digits`` () =
-    clean "123456789" |> should equal <| None
+    clean "123456789" |> should equal None
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Invalid when 11 digits does not start with a 1`` () =
-    clean "22234567890" |> should equal <| None
+    clean "22234567890" |> should equal None
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Valid when 11 digits and starting with 1`` () =
-    clean "12234567890" |> should equal <| Some "2234567890"
+    clean "12234567890" |> should equal (Some "2234567890")
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Valid when 11 digits and starting with 1 even with punctuation`` () =
-    clean "+1 (223) 456-7890" |> should equal <| Some "2234567890"
+    clean "+1 (223) 456-7890" |> should equal (Some "2234567890")
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Invalid when more than 11 digits`` () =
-    clean "321234567890" |> should equal <| None
+    clean "321234567890" |> should equal None
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Invalid with letters`` () =
-    clean "123-abc-7890" |> should equal <| None
+    clean "123-abc-7890" |> should equal None
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Invalid with punctuations`` () =
-    clean "123-@:!-7890" |> should equal <| None
+    clean "123-@:!-7890" |> should equal None
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Invalid if area code does not start with 2-9`` () =
-    clean "(123) 456-7890" |> should equal <| None
+    clean "(123) 456-7890" |> should equal None
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Invalid if exchange code does not start with 2-9`` () =
-    clean "(223) 056-7890" |> should equal <| None
+    clean "(223) 056-7890" |> should equal None
 

--- a/exercises/rna-transcription/RnaTranscriptionTest.fs
+++ b/exercises/rna-transcription/RnaTranscriptionTest.fs
@@ -9,33 +9,33 @@ open RnaTranscription
 
 [<Fact>]
 let ``RNA complement of cytosine is guanine`` () =
-    toRna "C" |> should equal <| Some "G"
+    toRna "C" |> should equal (Some "G")
 
 [<Fact(Skip = "Remove to run test")>]
 let ``RNA complement of guanine is cytosine`` () =
-    toRna "G" |> should equal <| Some "C"
+    toRna "G" |> should equal (Some "C")
 
 [<Fact(Skip = "Remove to run test")>]
 let ``RNA complement of thymine is adenine`` () =
-    toRna "T" |> should equal <| Some "A"
+    toRna "T" |> should equal (Some "A")
 
 [<Fact(Skip = "Remove to run test")>]
 let ``RNA complement of adenine is uracil`` () =
-    toRna "A" |> should equal <| Some "U"
+    toRna "A" |> should equal (Some "U")
 
 [<Fact(Skip = "Remove to run test")>]
 let ``RNA complement`` () =
-    toRna "ACGTGGTCTTAA" |> should equal <| Some "UGCACCAGAAUU"
+    toRna "ACGTGGTCTTAA" |> should equal (Some "UGCACCAGAAUU")
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Correctly handles invalid input (RNA instead of DNA)`` () =
-    toRna "U" |> should equal <| None
+    toRna "U" |> should equal None
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Correctly handles completely invalid DNA input`` () =
-    toRna "XXX" |> should equal <| None
+    toRna "XXX" |> should equal None
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Correctly handles partially invalid DNA input`` () =
-    toRna "ACGTXXXCTTAA" |> should equal <| None
+    toRna "ACGTXXXCTTAA" |> should equal None
 

--- a/generators/Common.fs
+++ b/generators/Common.fs
@@ -57,6 +57,16 @@ module Option =
         | :? int32 as i -> if i < 0  then None else Some value
         | _ -> None
 
+    let ofNonFalse (value: obj) =
+        match value with
+        | :? bool as b when not b -> None
+        | _ -> Some value
+
+    let ofNonError (value: obj) =
+        match value with
+        | :? JToken as jToken when not (isNull jToken.["error"]) -> None
+        | _ -> Some value
+
 module String =
     open Humanizer
 

--- a/generators/Exercise.fs
+++ b/generators/Exercise.fs
@@ -50,6 +50,7 @@ type Exercise() =
     abstract member RenderSutProperty : CanonicalDataCase -> string
     
     // Utility methods to customize rendered output
+    abstract member Properties : CanonicalDataCase -> string list
     abstract member PropertiesUsedAsSutParameter : CanonicalDataCase -> string list
     abstract member PropertiesWithIdentifier : CanonicalDataCase -> string list
     abstract member IdentifierTypeAnnotation: CanonicalDataCase * string * obj -> string option
@@ -214,11 +215,14 @@ type Exercise() =
 
     default this.RenderSutProperty canonicalDataCase = string canonicalDataCase.Property
 
+    default this.Properties canonicalDataCase =
+        List.append (this.PropertiesUsedAsSutParameter canonicalDataCase) ["expected"]
+
     default this.PropertiesUsedAsSutParameter canonicalDataCase = 
         canonicalDataCase.Properties
         |> Map.toList
         |> List.map fst
-        |> List.except ["property"; "expected"; "description"; "comments"]
+        |> List.except ["expected"; "property"; "description"; "comments"]
     
     // Utility methods to customize rendered output
 

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -80,13 +80,9 @@ type BracketPush() =
 type Change() =
     inherit Exercise()
 
-    override this.MapCanonicalDataCaseProperty (canonicalDataCase, key, value) = 
-        match key with 
-        | "expected" -> 
-            match value with 
-            | :? JArray -> Option.ofObj value |> box
-            | _ -> value |> Option.ofNonNegativeInt |> box
-        | _ -> base.MapCanonicalDataCaseProperty (canonicalDataCase, key, value)
+    override this.RenderExpected (canonicalDataCase, key, value) =
+        let convertToOption = if value :? JArray then Option.ofObj else Option.ofNonNegativeInt
+        value |> convertToOption |> formatValue
 
     override this.PropertiesWithIdentifier canonicalDataCase = this.Properties canonicalDataCase
 
@@ -154,9 +150,10 @@ type LargestSeriesProduct() =
      override this.PropertiesWithIdentifier canonicalDataCase = ["digits"]
 
     override this.RenderExpected (canonicalDataCase, key, value) = 
-        match value :?> int64 with 
-        | -1L -> "None"
-        | _ -> value :?> int64 |> sprintf "(Some %d)"
+        value 
+        |> Option.ofNonNegativeInt 
+        |> formatValue 
+        |> parenthesizeOption
 
 type Leap() =
     inherit Exercise()
@@ -184,9 +181,10 @@ type NthPrime() =
     inherit Exercise()
 
     override this.RenderExpected (canonicalDataCase, key, value) = 
-        match string value with 
-        | "False" -> "None"
-        | _ ->  value :?> int64 |> sprintf "(Some %d)"
+        value 
+        |> Option.ofNonFalse 
+        |> formatValue 
+        |> parenthesizeOption
 
 type Pangram() =
     inherit Exercise()
@@ -194,12 +192,14 @@ type Pangram() =
 type PerfectNumbers() =
     inherit Exercise()
 
+    let toClassification value = string value |> String.humanize
+
     override this.RenderExpected (canonicalDataCase, key, value) = 
-        match value |> string with 
-        | "perfect" -> "(Some Perfect)"
-        | "abundant" -> "(Some Abundant)"
-        | "deficient" -> "(Some Deficient)"
-        | _ -> "None"
+        value 
+        |> Option.ofNonError  
+        |> Option.map toClassification 
+        |> formatOption 
+        |> parenthesizeOption
 
 type PascalsTriangle() =
     inherit Exercise()
@@ -224,7 +224,10 @@ type PhoneNumber() =
     inherit Exercise()
     
     override this.RenderExpected (canonicalDataCase, key, value) =
-        value |> Option.ofObj |> formatValue |> backwardPipe
+        value 
+        |> Option.ofObj 
+        |> formatValue
+        |> parenthesizeOption
 
 type PigLatin() =
     inherit Exercise()
@@ -268,7 +271,7 @@ type RnaTranscription() =
     inherit Exercise()
 
     override this.RenderExpected (canonicalDataCase, key, value) =
-        value |> Option.ofObj |> formatValue |> backwardPipe
+        value |> Option.ofObj |> formatValue |> parenthesizeOption
 
 type RunLengthEncoding() =
     inherit Exercise()

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -18,7 +18,7 @@ type AllYourBase() =
 
     override this.RenderExpected (canonicalDataCase, key, value) = value |> Option.ofObj |> formatValue
 
-    override this.PropertiesWithIdentifier canonicalDataCase = ["expected"; "input_base"; "input_digits"; "output_base"]
+    override this.PropertiesWithIdentifier canonicalDataCase = this.Properties canonicalDataCase
 
 type Allergies() =
     inherit Exercise()
@@ -72,8 +72,7 @@ type BookStore() =
     override this.RenderExpected (canonicalDataCase, key, value) = formatFloat value
 
     override this.PropertiesUsedAsSutParameter canonicalDataCase =
-        base.PropertiesUsedAsSutParameter canonicalDataCase
-        |> List.except ["targetgrouping"; "expected"; "description"]
+        base.PropertiesUsedAsSutParameter canonicalDataCase |> List.except ["targetgrouping"]
 
 type BracketPush() =
     inherit Exercise()
@@ -89,7 +88,7 @@ type Change() =
             | _ -> value |> Option.ofNonNegativeInt |> box
         | _ -> base.MapCanonicalDataCaseProperty (canonicalDataCase, key, value)
 
-    override this.PropertiesWithIdentifier canonicalDataCase = ["coins"; "target"; "expected"]
+    override this.PropertiesWithIdentifier canonicalDataCase = this.Properties canonicalDataCase
 
     override this.IdentifierTypeAnnotation (canonicalDataCase, key, value) = 
         match key with 
@@ -174,7 +173,7 @@ type Minesweeper() =
         |> Seq.map formatValue
         |> formatMultiLineList
 
-    override this.PropertiesWithIdentifier canonicalDataCase = ["input"; "expected"]
+    override this.PropertiesWithIdentifier canonicalDataCase = this.Properties canonicalDataCase
 
     override this.IdentifierTypeAnnotation (canonicalDataCase, key, value) = 
         match value :?> JArray |> Seq.isEmpty with 
@@ -258,9 +257,9 @@ type QueenAttack() =
 type RailFenceCipher() =
     inherit Exercise()
 
-    override this.PropertiesWithIdentifier canonicalDataCase = ["rails"; "msg"; "expected"]
-
     override this.PropertiesUsedAsSutParameter canonicalDataCase = ["rails"; "msg"]
+
+    override this.PropertiesWithIdentifier canonicalDataCase = this.Properties canonicalDataCase
 
 type Raindrops() =
     inherit Exercise()

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -145,12 +145,7 @@ type KindergartenGarden() =
         |> Seq.map toPlant
         |> formatList
 
-    override this.RenderSutProperty canonicalDataCase =
-        match Map.containsKey "students" canonicalDataCase.Properties with
-        | true  -> "plantsForCustomStudents"
-        | false -> "plantsForDefaultStudents"
-
-    override this.PropertiesWithIdentifier canonicalDataCase = ["student"; "students"; "diagram"; "expected"]
+    override this.PropertiesWithIdentifier canonicalDataCase = ["student"; "diagram"; "expected"]
 
     override this.UseFullMethodName canonicalDataCase = true
 

--- a/generators/Output.fs
+++ b/generators/Output.fs
@@ -16,9 +16,14 @@ let indent level value =
 
 let parenthesize value = sprintf "(%s)" value
 
+let parenthesizeOption value = 
+    match value with
+    | "None" -> value
+    | _ -> parenthesize value
+
 let backwardPipe value = sprintf "<| %s" value
 
-let backwardPipeConditional test value = if test value then backwardPipe value else value
+let backwardPipeIf test value = if test value then backwardPipe value else value
 
 let addTypeAnnotation typeAnnotation value = sprintf "%s: %s" value typeAnnotation
 


### PR DESCRIPTION
This PR does a couple of things:

1. It updates the kindergarten-garden generator and implementation to the updated canonical data.
1. It simplifies identifier handling by providing a method to retrieve all data-related properties.
1. The order of the identifiers is such that the expected value is always last (if present).
1. It simplifies formatting option values and make its usage consistent over all generators.
1. Option values are now parenthesized instead of using the backward pipe (`<|`) character, as the latter is harder to understand.

Additional note: don't squash this PR, as the three commits should be retained IMHO.
