### PR TITLE
Adding clock Test Generator

### DIFF
--- a/exercises/clock/Clock.fs
+++ b/exercises/clock/Clock.fs
@@ -1,6 +1,6 @@
 module Clock
 
-let mkClock hours minutes = failwith "You need to implement this function."
+let create hours minutes = failwith "You need to implement this function."
 
 let add minutes clock = failwith "You need to implement this function."
 

--- a/exercises/clock/ClockTest.fs
+++ b/exercises/clock/ClockTest.fs
@@ -1,96 +1,290 @@
+// This file was auto-generated based on version 1.0.1 of the canonical data.
+
 module ClockTest
 
-open System
-open Xunit
 open FsUnit.Xunit
+open Xunit
+
 open Clock
 
 [<Fact>]
-let ``Prints 8 o'clock`` () =
-    let clock = mkClock 8 0
-    display clock |> should equal "08:00"
-
-[<Fact(Skip = "Remove to run test")>]     
-let ``Prints 9 o'clock`` () =
-    let clock = mkClock 9 0
-    display clock |> should equal "09:00"
-
-[<Fact(Skip = "Remove to run test")>]     
-let ``Can print single-digit minutes`` () =
-    let clock = mkClock 11 9
-    display clock |> should equal "11:09"
+let ``On the hour`` () =
+    let clock = create 8 0
+    clock |> display  |> should equal "08:00"
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Can print double-digit minutes`` () =
-    let clock = mkClock 11 19
-    display clock |> should equal "11:19"
+let ``Past the hour`` () =
+    let clock = create 11 9
+    clock |> display  |> should equal "11:09"
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Can add minutes`` () =
-    let clock = mkClock 10 0
-    let added = clock |> add 3
-    display added |> should equal "10:03"
+let ``Midnight is zero hours`` () =
+    let clock = create 24 0
+    clock |> display  |> should equal "00:00"
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Can add over an hour`` () =
-    let clock = mkClock 10 0
-    let added = clock |> add 63
-    display added |> should equal "11:03"
+let ``Hour rolls over`` () =
+    let clock = create 25 0
+    clock |> display  |> should equal "01:00"
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Can add over more than one day`` () =
-    let clock = mkClock 10 0
-    let added = clock |> add 7224
-    display added |> should equal "10:24"
-
-[<Fact(Skip = "Remove to run test")>]
-let ``Can subtract minutes`` () =
-    let clock = mkClock 10 3
-    let subtracted = clock |> subtract 3
-    display subtracted |> should equal "10:00"
-
-[<Fact(Skip = "Remove to run test")>]
-let ``Can subtract to previous hour`` () =
-    let clock = mkClock 10 3
-    let subtracted = clock |> subtract 30
-    display subtracted |> should equal "09:33"
-
-[<Fact(Skip = "Remove to run test")>]
-let ``Can subtract over an hour`` () =
-    let clock = mkClock 10 3
-    let subtracted = clock |> subtract 70
-    display subtracted |> should equal "08:53"
-
-[<Fact(Skip = "Remove to run test")>]
-let ``Wraps around midnight`` () =
-    let clock = mkClock 23 59
-    let added = clock |> add 2
-    display added |> should equal "00:01"
-
-[<Fact(Skip = "Remove to run test")>]
-let ``Wraps around midnight backwards`` () =
-    let clock = mkClock 0 1
-    let subtracted = clock |> subtract 2
-    display subtracted |> should equal "23:59"
-
-[<Fact(Skip = "Remove to run test")>]
-let ``Midnight is zero hundred hours`` () =
-    let clock = mkClock 24 0
-    display clock |> should equal "00:00"
+let ``Hour rolls over continuously`` () =
+    let clock = create 100 0
+    clock |> display  |> should equal "04:00"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Sixty minutes is next hour`` () =
-    let clock = mkClock 1 60
-    display clock |> should equal "02:00"
+    let clock = create 1 60
+    clock |> display  |> should equal "02:00"
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Clocks with same time are equal`` () =
-    let clock1 = mkClock 14 30
-    let clock2 = mkClock 14 30
-    clock1 |> should equal clock2
+let ``Minutes roll over`` () =
+    let clock = create 0 160
+    clock |> display  |> should equal "02:40"
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Overflown clocks with same time are equal`` () =
-    let clock1 = mkClock 14 30
-    let clock2 = mkClock 38 30
-    clock1 |> should equal clock2
+let ``Minutes roll over continuously`` () =
+    let clock = create 0 1723
+    clock |> display  |> should equal "04:43"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Hour and minutes roll over`` () =
+    let clock = create 25 160
+    clock |> display  |> should equal "03:40"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Hour and minutes roll over continuously`` () =
+    let clock = create 201 3001
+    clock |> display  |> should equal "11:01"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Hour and minutes roll over to exactly midnight`` () =
+    let clock = create 72 8640
+    clock |> display  |> should equal "00:00"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Negative hour`` () =
+    let clock = create -1 15
+    clock |> display  |> should equal "23:15"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Negative hour rolls over`` () =
+    let clock = create -25 0
+    clock |> display  |> should equal "23:00"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Negative hour rolls over continuously`` () =
+    let clock = create -91 0
+    clock |> display  |> should equal "05:00"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Negative minutes`` () =
+    let clock = create 1 -40
+    clock |> display  |> should equal "00:20"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Negative minutes roll over`` () =
+    let clock = create 1 -160
+    clock |> display  |> should equal "22:20"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Negative minutes roll over continuously`` () =
+    let clock = create 1 -4820
+    clock |> display  |> should equal "16:40"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Negative hour and minutes both roll over`` () =
+    let clock = create -25 -160
+    clock |> display  |> should equal "20:20"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Negative hour and minutes both roll over continuously`` () =
+    let clock = create -121 -5810
+    clock |> display  |> should equal "22:10"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Add minutes`` () =
+    let clock = create 10 0
+    let minutesToAdd = 3
+    add minutesToAdd clock |> display  |> should equal "10:03"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Add no minutes`` () =
+    let clock = create 6 41
+    let minutesToAdd = 0
+    add minutesToAdd clock |> display  |> should equal "06:41"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Add to next hour`` () =
+    let clock = create 0 45
+    let minutesToAdd = 40
+    add minutesToAdd clock |> display  |> should equal "01:25"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Add more than one hour`` () =
+    let clock = create 10 0
+    let minutesToAdd = 61
+    add minutesToAdd clock |> display  |> should equal "11:01"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Add more than two hours with carry`` () =
+    let clock = create 0 45
+    let minutesToAdd = 160
+    add minutesToAdd clock |> display  |> should equal "03:25"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Add across midnight`` () =
+    let clock = create 23 59
+    let minutesToAdd = 2
+    add minutesToAdd clock |> display  |> should equal "00:01"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Add more than one day (1500 min = 25 hrs)`` () =
+    let clock = create 5 32
+    let minutesToAdd = 1500
+    add minutesToAdd clock |> display  |> should equal "06:32"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Add more than two days`` () =
+    let clock = create 1 1
+    let minutesToAdd = 3500
+    add minutesToAdd clock |> display  |> should equal "11:21"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Subtract minutes`` () =
+    let clock = create 10 3
+    let minutesToAdd = -3
+    add minutesToAdd clock |> display  |> should equal "10:00"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Subtract to previous hour`` () =
+    let clock = create 10 3
+    let minutesToAdd = -30
+    add minutesToAdd clock |> display  |> should equal "09:33"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Subtract more than an hour`` () =
+    let clock = create 10 3
+    let minutesToAdd = -70
+    add minutesToAdd clock |> display  |> should equal "08:53"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Subtract across midnight`` () =
+    let clock = create 0 3
+    let minutesToAdd = -4
+    add minutesToAdd clock |> display  |> should equal "23:59"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Subtract more than two hours`` () =
+    let clock = create 0 0
+    let minutesToAdd = -160
+    add minutesToAdd clock |> display  |> should equal "21:20"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Subtract more than two hours with borrow`` () =
+    let clock = create 6 15
+    let minutesToAdd = -160
+    add minutesToAdd clock |> display  |> should equal "03:35"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Subtract more than one day (1500 min = 25 hrs)`` () =
+    let clock = create 5 32
+    let minutesToAdd = -1500
+    add minutesToAdd clock |> display  |> should equal "04:32"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Subtract more than two days`` () =
+    let clock = create 2 20
+    let minutesToAdd = -3000
+    add minutesToAdd clock |> display  |> should equal "00:20"
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Clocks with same time`` () =
+    let clock1 = create 15 37
+    let clock2 = create 15 37
+    clock1 = clock2  |> should equal true
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Clocks a minute apart`` () =
+    let clock1 = create 15 36
+    let clock2 = create 15 37
+    clock1 = clock2  |> should equal false
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Clocks an hour apart`` () =
+    let clock1 = create 14 37
+    let clock2 = create 15 37
+    clock1 = clock2  |> should equal false
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Clocks with hour overflow`` () =
+    let clock1 = create 10 37
+    let clock2 = create 34 37
+    clock1 = clock2  |> should equal true
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Clocks with hour overflow by several days`` () =
+    let clock1 = create 3 11
+    let clock2 = create 99 11
+    clock1 = clock2  |> should equal true
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Clocks with negative hour`` () =
+    let clock1 = create 22 40
+    let clock2 = create -2 40
+    clock1 = clock2  |> should equal true
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Clocks with negative hour that wraps`` () =
+    let clock1 = create 17 3
+    let clock2 = create -31 3
+    clock1 = clock2  |> should equal true
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Clocks with negative hour that wraps multiple times`` () =
+    let clock1 = create 13 49
+    let clock2 = create -83 49
+    clock1 = clock2  |> should equal true
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Clocks with minute overflow`` () =
+    let clock1 = create 0 1
+    let clock2 = create 0 1441
+    clock1 = clock2  |> should equal true
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Clocks with minute overflow by several days`` () =
+    let clock1 = create 2 2
+    let clock2 = create 2 4322
+    clock1 = clock2  |> should equal true
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Clocks with negative minute`` () =
+    let clock1 = create 2 40
+    let clock2 = create 3 -20
+    clock1 = clock2  |> should equal true
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Clocks with negative minute that wraps`` () =
+    let clock1 = create 4 10
+    let clock2 = create 5 -1490
+    clock1 = clock2  |> should equal true
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Clocks with negative minute that wraps multiple times`` () =
+    let clock1 = create 6 15
+    let clock2 = create 6 -4305
+    clock1 = clock2  |> should equal true
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Clocks with negative hours and minutes`` () =
+    let clock1 = create 7 32
+    let clock2 = create -12 -268
+    clock1 = clock2  |> should equal true
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Clocks with negative hours and minutes that wrap`` () =
+    let clock1 = create 18 7
+    let clock2 = create -54 -11513
+    clock1 = clock2  |> should equal true
+

--- a/exercises/clock/ClockTest.fs
+++ b/exercises/clock/ClockTest.fs
@@ -10,281 +10,265 @@ open Clock
 [<Fact>]
 let ``On the hour`` () =
     let clock = create 8 0
-    clock |> display  |> should equal "08:00"
+    display clock |> should equal "08:00"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Past the hour`` () =
     let clock = create 11 9
-    clock |> display  |> should equal "11:09"
+    display clock |> should equal "11:09"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Midnight is zero hours`` () =
     let clock = create 24 0
-    clock |> display  |> should equal "00:00"
+    display clock |> should equal "00:00"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Hour rolls over`` () =
     let clock = create 25 0
-    clock |> display  |> should equal "01:00"
+    display clock |> should equal "01:00"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Hour rolls over continuously`` () =
     let clock = create 100 0
-    clock |> display  |> should equal "04:00"
+    display clock |> should equal "04:00"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Sixty minutes is next hour`` () =
     let clock = create 1 60
-    clock |> display  |> should equal "02:00"
+    display clock |> should equal "02:00"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Minutes roll over`` () =
     let clock = create 0 160
-    clock |> display  |> should equal "02:40"
+    display clock |> should equal "02:40"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Minutes roll over continuously`` () =
     let clock = create 0 1723
-    clock |> display  |> should equal "04:43"
+    display clock |> should equal "04:43"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Hour and minutes roll over`` () =
     let clock = create 25 160
-    clock |> display  |> should equal "03:40"
+    display clock |> should equal "03:40"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Hour and minutes roll over continuously`` () =
     let clock = create 201 3001
-    clock |> display  |> should equal "11:01"
+    display clock |> should equal "11:01"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Hour and minutes roll over to exactly midnight`` () =
     let clock = create 72 8640
-    clock |> display  |> should equal "00:00"
+    display clock |> should equal "00:00"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Negative hour`` () =
     let clock = create -1 15
-    clock |> display  |> should equal "23:15"
+    display clock |> should equal "23:15"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Negative hour rolls over`` () =
     let clock = create -25 0
-    clock |> display  |> should equal "23:00"
+    display clock |> should equal "23:00"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Negative hour rolls over continuously`` () =
     let clock = create -91 0
-    clock |> display  |> should equal "05:00"
+    display clock |> should equal "05:00"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Negative minutes`` () =
     let clock = create 1 -40
-    clock |> display  |> should equal "00:20"
+    display clock |> should equal "00:20"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Negative minutes roll over`` () =
     let clock = create 1 -160
-    clock |> display  |> should equal "22:20"
+    display clock |> should equal "22:20"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Negative minutes roll over continuously`` () =
     let clock = create 1 -4820
-    clock |> display  |> should equal "16:40"
+    display clock |> should equal "16:40"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Negative hour and minutes both roll over`` () =
     let clock = create -25 -160
-    clock |> display  |> should equal "20:20"
+    display clock |> should equal "20:20"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Negative hour and minutes both roll over continuously`` () =
     let clock = create -121 -5810
-    clock |> display  |> should equal "22:10"
+    display clock |> should equal "22:10"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Add minutes`` () =
     let clock = create 10 0
-    let minutesToAdd = 3
-    add minutesToAdd clock |> display  |> should equal "10:03"
+    add 3 clock |> display |> should equal "10:03"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Add no minutes`` () =
     let clock = create 6 41
-    let minutesToAdd = 0
-    add minutesToAdd clock |> display  |> should equal "06:41"
+    add 0 clock |> display |> should equal "06:41"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Add to next hour`` () =
     let clock = create 0 45
-    let minutesToAdd = 40
-    add minutesToAdd clock |> display  |> should equal "01:25"
+    add 40 clock |> display |> should equal "01:25"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Add more than one hour`` () =
     let clock = create 10 0
-    let minutesToAdd = 61
-    add minutesToAdd clock |> display  |> should equal "11:01"
+    add 61 clock |> display |> should equal "11:01"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Add more than two hours with carry`` () =
     let clock = create 0 45
-    let minutesToAdd = 160
-    add minutesToAdd clock |> display  |> should equal "03:25"
+    add 160 clock |> display |> should equal "03:25"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Add across midnight`` () =
     let clock = create 23 59
-    let minutesToAdd = 2
-    add minutesToAdd clock |> display  |> should equal "00:01"
+    add 2 clock |> display |> should equal "00:01"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Add more than one day (1500 min = 25 hrs)`` () =
     let clock = create 5 32
-    let minutesToAdd = 1500
-    add minutesToAdd clock |> display  |> should equal "06:32"
+    add 1500 clock |> display |> should equal "06:32"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Add more than two days`` () =
     let clock = create 1 1
-    let minutesToAdd = 3500
-    add minutesToAdd clock |> display  |> should equal "11:21"
+    add 3500 clock |> display |> should equal "11:21"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Subtract minutes`` () =
     let clock = create 10 3
-    let minutesToAdd = -3
-    add minutesToAdd clock |> display  |> should equal "10:00"
+    add -3 clock |> display |> should equal "10:00"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Subtract to previous hour`` () =
     let clock = create 10 3
-    let minutesToAdd = -30
-    add minutesToAdd clock |> display  |> should equal "09:33"
+    add -30 clock |> display |> should equal "09:33"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Subtract more than an hour`` () =
     let clock = create 10 3
-    let minutesToAdd = -70
-    add minutesToAdd clock |> display  |> should equal "08:53"
+    add -70 clock |> display |> should equal "08:53"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Subtract across midnight`` () =
     let clock = create 0 3
-    let minutesToAdd = -4
-    add minutesToAdd clock |> display  |> should equal "23:59"
+    add -4 clock |> display |> should equal "23:59"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Subtract more than two hours`` () =
     let clock = create 0 0
-    let minutesToAdd = -160
-    add minutesToAdd clock |> display  |> should equal "21:20"
+    add -160 clock |> display |> should equal "21:20"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Subtract more than two hours with borrow`` () =
     let clock = create 6 15
-    let minutesToAdd = -160
-    add minutesToAdd clock |> display  |> should equal "03:35"
+    add -160 clock |> display |> should equal "03:35"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Subtract more than one day (1500 min = 25 hrs)`` () =
     let clock = create 5 32
-    let minutesToAdd = -1500
-    add minutesToAdd clock |> display  |> should equal "04:32"
+    add -1500 clock |> display |> should equal "04:32"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Subtract more than two days`` () =
     let clock = create 2 20
-    let minutesToAdd = -3000
-    add minutesToAdd clock |> display  |> should equal "00:20"
+    add -3000 clock |> display |> should equal "00:20"
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Clocks with same time`` () =
     let clock1 = create 15 37
     let clock2 = create 15 37
-    clock1 = clock2  |> should equal true
+    clock1 = clock2 |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Clocks a minute apart`` () =
     let clock1 = create 15 36
     let clock2 = create 15 37
-    clock1 = clock2  |> should equal false
+    clock1 = clock2 |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Clocks an hour apart`` () =
     let clock1 = create 14 37
     let clock2 = create 15 37
-    clock1 = clock2  |> should equal false
+    clock1 = clock2 |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Clocks with hour overflow`` () =
     let clock1 = create 10 37
     let clock2 = create 34 37
-    clock1 = clock2  |> should equal true
+    clock1 = clock2 |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Clocks with hour overflow by several days`` () =
     let clock1 = create 3 11
     let clock2 = create 99 11
-    clock1 = clock2  |> should equal true
+    clock1 = clock2 |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Clocks with negative hour`` () =
     let clock1 = create 22 40
     let clock2 = create -2 40
-    clock1 = clock2  |> should equal true
+    clock1 = clock2 |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Clocks with negative hour that wraps`` () =
     let clock1 = create 17 3
     let clock2 = create -31 3
-    clock1 = clock2  |> should equal true
+    clock1 = clock2 |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Clocks with negative hour that wraps multiple times`` () =
     let clock1 = create 13 49
     let clock2 = create -83 49
-    clock1 = clock2  |> should equal true
+    clock1 = clock2 |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Clocks with minute overflow`` () =
     let clock1 = create 0 1
     let clock2 = create 0 1441
-    clock1 = clock2  |> should equal true
+    clock1 = clock2 |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Clocks with minute overflow by several days`` () =
     let clock1 = create 2 2
     let clock2 = create 2 4322
-    clock1 = clock2  |> should equal true
+    clock1 = clock2 |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Clocks with negative minute`` () =
     let clock1 = create 2 40
     let clock2 = create 3 -20
-    clock1 = clock2  |> should equal true
+    clock1 = clock2 |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Clocks with negative minute that wraps`` () =
     let clock1 = create 4 10
     let clock2 = create 5 -1490
-    clock1 = clock2  |> should equal true
+    clock1 = clock2 |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Clocks with negative minute that wraps multiple times`` () =
     let clock1 = create 6 15
     let clock2 = create 6 -4305
-    clock1 = clock2  |> should equal true
+    clock1 = clock2 |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Clocks with negative hours and minutes`` () =
     let clock1 = create 7 32
     let clock2 = create -12 -268
-    clock1 = clock2  |> should equal true
+    clock1 = clock2 |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Clocks with negative hours and minutes that wrap`` () =
     let clock1 = create 18 7
     let clock2 = create -54 -11513
-    clock1 = clock2  |> should equal true
+    clock1 = clock2 |> should equal true
 

--- a/exercises/clock/Example.fs
+++ b/exercises/clock/Example.fs
@@ -6,15 +6,15 @@ type Clock = { hours: int; minutes: int }
 
 let modulo x y = (int)(((x % y) + y) % y)
 
-let mkClock hours minutes =
+let create hours minutes =
     let totalMinutes = hours * 60 + minutes
     let normalizedHours = modulo ((double)totalMinutes / 60.0) 24.0
     let normalizedMinutes = modulo ((double)minutes) 60.0
 
     { hours = normalizedHours; minutes = normalizedMinutes }
 
-let add minutes clock = mkClock clock.hours (clock.minutes + minutes)
+let add minutes clock = create clock.hours (clock.minutes + minutes)
 
-let subtract minutes clock = mkClock clock.hours (clock.minutes - minutes)
+let subtract minutes clock = create clock.hours (clock.minutes - minutes)
 
 let display clock = sprintf "%02i:%02i" clock.hours clock.minutes

--- a/exercises/leap/LeapTest.fs
+++ b/exercises/leap/LeapTest.fs
@@ -1,4 +1,4 @@
-// This file was auto-generated based on version 1.1.0 of the canonical data.
+// This file was auto-generated based on version 1.2.0 of the canonical data.
 
 module LeapTest
 
@@ -13,7 +13,7 @@ let ``Year not divisible by 4: common year`` () =
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Year divisible by 4, not divisible by 100: leap year`` () =
-    leapYear 2020 |> should equal true
+    leapYear 1996 |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Year divisible by 100, not divisible by 400: common year`` () =

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -96,46 +96,41 @@ type Change() =
 
 type Clock() =
     inherit Exercise()
+
     let createClock (value:obj) clockId =
         let clock = value :?> JObject
-        sprintf "let %s = create %s %s" clockId (clock.["hour"].ToObject<string>()) (clock.["minute"].ToObject<string>())
+        let hour = clock.["hour"].ToObject<string>()
+        let minute = clock.["minute"].ToObject<string>()
+        sprintf "let %s = create %s %s" clockId hour minute
 
-    override this.PropertiesWithIdentifier canonicalDataCase = 
-        this.PropertiesUsedAsSutParameter canonicalDataCase 
+    member private this.renderPropertyValue canonicalDataCase property =
+        this.RenderSutParameter (canonicalDataCase, property, Map.find property canonicalDataCase.Properties)
+
+    override this.PropertiesWithIdentifier canonicalDataCase = ["clock1"; "clock2"]
 
     override this.RenderValueWithIdentifier (canonicalDataCase, key, value) =
-        match key with 
+        match key with
         | "clock1" | "clock2" -> createClock value key
         | _ -> base.RenderValueWithIdentifier (canonicalDataCase, key, value)
     
     override this.RenderArrange canonicalDataCase =
-        let renderArrangeProperty property: string option = 
-            match Map.tryFind property canonicalDataCase.Properties with
-            | None -> None
-            | Some value -> Some (this.RenderValueWithIdentifier (canonicalDataCase, property, value))
-            
         match canonicalDataCase.Property with
-        | "create" | "add" ->
-            let clock = sprintf "let clock = create %s %s" (canonicalDataCase.Properties.["hour"] |> formatValue ) (canonicalDataCase.Properties.["minute"] |>formatValue) 
-            clock:: (canonicalDataCase
-                |> this.PropertiesWithIdentifier |> List.except ["hour";"minute"]
-                |> List.choose renderArrangeProperty)
-        | _ ->  (canonicalDataCase
-                |> this.PropertiesWithIdentifier 
-                |> List.choose renderArrangeProperty)
-    
-    override this.RenderIdentifier (canonicalDataCase, key, value) = 
-        match key with 
-        | "add" -> "minutesToAdd"
-        | _ -> base.RenderIdentifier (canonicalDataCase, key, value)
+        | "create" | "add" -> 
+            let hour = this.renderPropertyValue canonicalDataCase "hour"
+            let minute = this.renderPropertyValue canonicalDataCase "minute"
+            [sprintf "let clock = create %s %s" hour minute]
+        | _ -> 
+            base.RenderArrange canonicalDataCase
 
     override this.RenderSut canonicalDataCase =
         match canonicalDataCase.Property with
-        | "create" ->
+        | "create" -> 
             sprintf "display clock"
-        | "add" ->
-            sprintf "add minutesToAdd clock |> display" 
-        | "equal" -> "clock1 = clock2" 
+        | "add" -> 
+            this.renderPropertyValue canonicalDataCase "add"
+            |> sprintf "add %s clock |> display" 
+        | "equal" -> 
+            "clock1 = clock2" 
         | _ -> 
             base.RenderSut canonicalDataCase
 


### PR DESCRIPTION
Adding clock Test Generator. Fix #370
- Renamed "mkClock" to "Create".
- Properties "clock1" and "clock2" kept as identifier.
- Overriding `RenderArrange` to use `clock create  hour minute` by combining properties "hour" and "minute"
- Overriding `RenderSut` to set 'Sut' based on value of "Property"