### PR TITLE
Make exercises option take single name

### DIFF
--- a/generators/Common.fs
+++ b/generators/Common.fs
@@ -2,7 +2,6 @@
 module Generators.Common
 
 open System
-open System.IO
 open Serilog
 open Newtonsoft.Json.Linq
 
@@ -66,6 +65,11 @@ module Option =
         match value with
         | :? JToken as jToken when not (isNull jToken.["error"]) -> None
         | _ -> Some value
+
+    let ofNonEmptyString (value: string) =
+        match String.IsNullOrEmpty value with
+        | true  -> None
+        | false -> Some value
 
 module String =
     open Humanizer

--- a/generators/Exercise.fs
+++ b/generators/Exercise.fs
@@ -234,17 +234,19 @@ type Exercise() =
 
     default this.AdditionalNamespaces = []
 
-let createExercises filteredExercises =
+let createExercises filteredExercise =
 
     let isConcreteExercise (exerciseType: Type) = 
         not exerciseType.IsAbstract && typeof<Exercise>.IsAssignableFrom(exerciseType)
 
-    let isFilteredExercises (exerciseType: Type) =
-        Seq.isEmpty filteredExercises ||
-        Seq.exists (String.equals exerciseType.Name) filteredExercises ||
-        Seq.exists (String.equals (exerciseType.Name.Kebaberize())) filteredExercises
+    let isFilteredExercise exercise (exerciseType: Type) =
+        String.equals exercise exerciseType.Name || 
+        String.equals exercise (exerciseType.Name.Kebaberize())
 
-    let includeExercise (exerciseType: Type) = isConcreteExercise exerciseType && isFilteredExercises exerciseType
+    let includeExercise (exerciseType: Type) = 
+        match filteredExercise with
+        | None -> isConcreteExercise exerciseType
+        | Some exercise -> isConcreteExercise exerciseType && isFilteredExercise exercise exerciseType
 
     let assemblyTypes = Assembly.GetEntryAssembly().GetTypes()
 

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -2,7 +2,6 @@ module Generators.Generators
 
 open System
 open System.Globalization
-open Humanizer
 open Newtonsoft.Json.Linq
 open Output
 open Exercise

--- a/generators/Options.fs
+++ b/generators/Options.fs
@@ -3,15 +3,13 @@ module Generators.Options
 open System
 open System.IO
 open CommandLine
-open Serilog
-open Humanizer
 
 type Options = {
-  [<CommandLine.Option('e', "exercises", Required = false, 
-    HelpText = "Exercises to generate (if not specified, defaults to all exercises).")>] Exercises : seq<string>;
-  [<CommandLine.Option('d', "canonicaldatadirectory", Required = false, 
+  [<Option('e', "exercise", Required = false, 
+    HelpText = "Exercise to generate (if not specified, defaults to all exercises).")>] Exercise : string;
+  [<Option('d', "canonicaldatadirectory", Required = false, 
     HelpText = "Canonical data directory. If the directory does not exist, the canonical data will be downloaded.")>] CanonicalDataDirectory : string;
-  [<CommandLine.Option('s', "skipupdatecanonicaldata", Required = false,
+  [<Option('s', "skipupdatecanonicaldata", Required = false,
     HelpText = "Don't update the canonical data.")>] SkipUpdateCanonicalData : bool;
 }
 

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -16,8 +16,9 @@ let regenerateTestClasses options =
     Log.Information("Re-generating test classes...")
 
     let regenerateTestClass' = regenerateTestClass options
+    let filteredExercise = Option.ofNonEmptyString options.Exercise
 
-    createExercises options.Exercises
+    createExercises filteredExercise
     |> Seq.iter regenerateTestClass'
 
     Log.Information("Re-generated test classes.")
@@ -27,9 +28,9 @@ let main argv =
     Logging.setupLogger()
 
     match parseOptions argv with
-    | Result.Ok(options) -> 
+    | Ok(options) -> 
         regenerateTestClasses options
         0
-    | Result.Error(errors) -> 
+    | Error(errors) -> 
         Log.Error("Error(s) parsing commandline arguments: {Errors}", errors)
         1


### PR DESCRIPTION
There was currently a discrepancy between the option allowed in the build.(ps1|sh) file and the generators options. This PR fixes that by only allowing a single exercise in both cases. It also removes some unused namespaces.