### PR TITLE
Add back deleted, deprecated exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -1223,6 +1223,26 @@
       ],
       "unlocked_by": "two-fer",
       "uuid": "a6082751-98ca-45dc-aeed-cdd19a8da0ca"
+    },
+    {
+      "uuid": "df8f4106-c1ce-4c33-86b2-ad61ba5ccc4a",
+      "slug": "binary",
+      "deprecated": true
+    },
+    {
+      "uuid": "81904afe-a893-45be-99f8-2e074a6f1ad5",
+      "slug": "trinary",
+      "deprecated": true
+    },
+    {
+      "uuid": "f29f9e56-c79b-4ae4-a0d0-29db78c677e4",
+      "slug": "octal",
+      "deprecated": true
+    },
+    {
+      "uuid": "f4f80d57-a248-49d3-9329-587eb2643d4f",
+      "slug": "hexadecimal",
+      "deprecated": true
     }
   ],
   "foregone": [

--- a/exercises/binary/Binary.fs
+++ b/exercises/binary/Binary.fs
@@ -1,0 +1,3 @@
+﻿module Binary
+
+let toDecimal (input: string): int = failwith "You need to implement this function."

--- a/exercises/binary/Binary.fsproj
+++ b/exercises/binary/Binary.fsproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Binary.fs" />
+    <Compile Include="BinaryTest.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="FsUnit.xUnit" Version="3.0.0" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/exercises/binary/BinaryTest.fs
+++ b/exercises/binary/BinaryTest.fs
@@ -1,0 +1,67 @@
+module BinaryTest
+
+open FsUnit.Xunit
+open Xunit
+
+open Binary
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Binary_0_is_decimal_0`` () =
+    toDecimal "0" |> should equal 0
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Binary_1_is_decimal_1`` () =
+    toDecimal "1" |> should equal 1
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Binary_10_is_decimal_2`` () =
+    toDecimal "10" |> should equal 2
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Binary_11_is_decimal_3`` () =
+    toDecimal "11" |> should equal 3
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Binary_100_is_decimal_4`` () =
+    toDecimal "100" |> should equal 4
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Binary_1001_is_decimal_9`` () =
+    toDecimal "1001" |> should equal 9
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Binary_11010_is_decimal_26`` () =
+    toDecimal "11010" |> should equal 26
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Binary_10001101000_is_decimal_1128`` () =
+    toDecimal "10001101000" |> should equal 1128
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Binary_ignores_leading_zeros`` () =
+    toDecimal "000011111" |> should equal 31
+
+[<Fact(Skip = "Remove to run test")>]
+let ``2_is_not_a_valid_binary_digit`` () =
+    toDecimal "2" |> should equal 0
+
+[<Fact(Skip = "Remove to run test")>]
+let ``A_number_containing_a_non_binary_digit_is_invalid`` () =
+    toDecimal "01201" |> should equal 0
+
+[<Fact(Skip = "Remove to run test")>]
+let ``A_number_with_trailing_non_binary_characters_is_invalid`` () =
+    toDecimal "10nope" |> should equal 0
+
+[<Fact(Skip = "Remove to run test")>]
+let ``A_number_with_leading_non_binary_characters_is_invalid`` () =
+    toDecimal "nope10" |> should equal 0
+
+[<Fact(Skip = "Remove to run test")>]
+let ``A_number_with_internal_non_binary_characters_is_invalid`` () =
+    toDecimal "10nope10" |> should equal 0
+
+[<Fact(Skip = "Remove to run test")>]
+let ``A_number_and_a_word_whitespace_separated_is_invalid`` () =
+    toDecimal "001 nope" |> should equal 0
+

--- a/exercises/binary/Example.fs
+++ b/exercises/binary/Example.fs
@@ -1,0 +1,13 @@
+﻿module Binary
+
+let isValid char = 
+    match char with
+    | '0' | '1' -> true
+    | _  -> false
+
+let charToDecimal char = (int)char - (int)'0'
+
+let toDecimal(input: string) = 
+    let chars = input.ToCharArray()
+    if Array.forall isValid chars then Array.fold (fun acc c -> acc * 2 + charToDecimal c) 0 chars
+    else 0

--- a/exercises/binary/Program.fs
+++ b/exercises/binary/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -1,0 +1,35 @@
+# Binary
+
+Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles.
+
+Implement binary to decimal conversion. Given a binary input
+string, your program should produce a decimal output. The
+program should handle invalid inputs.
+
+## Note
+- Implement the conversion yourself.
+  Do not use something else to perform the conversion for you.
+
+## About Binary (Base-2)
+Decimal is a base-10 system.
+
+A number 23 in base 10 notation can be understood
+as a linear combination of powers of 10:
+
+- The rightmost digit gets multiplied by 10^0 = 1
+- The next number gets multiplied by 10^1 = 10
+- ...
+- The *n*th number gets multiplied by 10^*(n-1)*.
+- All these values are summed.
+
+So: `23 => 2*10^1 + 3*10^0 => 2*10 + 3*1 = 23 base 10`
+
+Binary is similar, but uses powers of 2 rather than powers of 10.
+
+So: `101 => 1*2^2 + 0*2^1 + 1*2^0 => 1*4 + 0*2 + 1*1 => 4 + 1 => 5 base 10`.
+## Source
+
+All of Computer Science [http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-](http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hexadecimal/Example.fs
+++ b/exercises/hexadecimal/Example.fs
@@ -1,0 +1,14 @@
+﻿module Hexadecimal
+
+open System
+
+let private isValid char = "0123456789ABCDEF".Contains(string char)
+
+let private charToDecimal (char: char) =
+    if Char.IsDigit(char) then (int)char - (int)'0'
+    else (int)(char) - (int)'A' + 10
+
+let toDecimal(input: string) = 
+    let chars = input.ToUpperInvariant().ToCharArray()
+    if Array.forall isValid chars then Array.fold (fun acc c -> acc * 16 + charToDecimal c) 0 chars
+    else 0

--- a/exercises/hexadecimal/Hexadecimal.fs
+++ b/exercises/hexadecimal/Hexadecimal.fs
@@ -1,0 +1,3 @@
+﻿module Hexadecimal
+
+let toDecimal (input: string): int = failwith "You need to implement this function."

--- a/exercises/hexadecimal/Hexadecimal.fsproj
+++ b/exercises/hexadecimal/Hexadecimal.fsproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Hexadecimal.fs" />
+    <Compile Include="HexadecimalTest.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="FsUnit.xUnit" Version="3.0.0" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/exercises/hexadecimal/HexadecimalTest.fs
+++ b/exercises/hexadecimal/HexadecimalTest.fs
@@ -1,0 +1,47 @@
+module HexadecimalTest
+
+open FsUnit.Xunit
+open Xunit
+
+open Hexadecimal
+
+[<Fact>]
+let ``Hexadecimal 1 is decimal 1`` () =
+    toDecimal "1" |> should equal 1
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Hexadecimal c is decimal 12`` () =
+    toDecimal "c" |> should equal 12
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Hexadecimal 10 is decimal 16`` () =
+    toDecimal "10" |> should equal 16
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Hexadecimal af is decimal 175`` () =
+    toDecimal "af" |> should equal 175
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Hexadecimal 100 is decimal 256`` () =
+    toDecimal "100" |> should equal 256
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Hexadecimal 19ace is decimal 105166`` () =
+    toDecimal "19ace" |> should equal 105166
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Hexadecimal 000000 is decimal 0`` () =
+    toDecimal "000000" |> should equal 0
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Hexadecimal ffffff is decimal 16777215`` () =
+    toDecimal "ffffff" |> should equal 16777215
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Hexadecimal ffff00 is decimal 16776960`` () =
+    toDecimal "ffff00" |> should equal 16776960
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Hexadecimal carrot is decimal 0`` () =
+    toDecimal "carrot" |> should equal 0
+

--- a/exercises/hexadecimal/Program.fs
+++ b/exercises/hexadecimal/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -1,0 +1,14 @@
+# Hexadecimal
+
+Convert a hexadecimal number, represented as a string (e.g. "10af8c"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).
+
+On the web we use hexadecimal to represent colors, e.g. green: 008000,
+teal: 008080, navy: 000080).
+
+The program should handle invalid hexadecimal strings.
+## Source
+
+All of Computer Science [http://www.wolframalpha.com/examples/NumberBases.html](http://www.wolframalpha.com/examples/NumberBases.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/octal/Example.fs
+++ b/exercises/octal/Example.fs
@@ -1,0 +1,10 @@
+﻿module Octal
+
+let isValid char = char >= '0' && char <= '7'
+
+let charToDecimal char = (int)char - (int)'0'
+
+let toDecimal (input: string) = 
+    let chars = input.ToCharArray()
+    if Array.forall isValid chars then Array.fold (fun acc c -> acc * 8 + charToDecimal c) 0 chars
+    else 0

--- a/exercises/octal/Octal.fs
+++ b/exercises/octal/Octal.fs
@@ -1,0 +1,3 @@
+﻿module Octal
+
+let toDecimal (input: string): int = failwith "You need to implement this function."

--- a/exercises/octal/Octal.fsproj
+++ b/exercises/octal/Octal.fsproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Octal.fs" />
+    <Compile Include="OctalTest.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="FsUnit.xUnit" Version="3.0.0" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/exercises/octal/OctalTest.fs
+++ b/exercises/octal/OctalTest.fs
@@ -1,0 +1,59 @@
+module OctalTest
+
+open FsUnit.Xunit
+open Xunit
+
+open Octal
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Octal 1 is decimal 1`` () =
+    toDecimal "1" |> should equal 1
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Octal 10 is decimal 8`` () =
+    toDecimal "10" |> should equal 8
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Octal 17 is decimal 15`` () =
+    toDecimal "17" |> should equal 15
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Octal 11 is decimal 9`` () =
+    toDecimal "11" |> should equal 9
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Octal 130 is decimal 88`` () =
+    toDecimal "130" |> should equal 88
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Octal 2047 is decimal 1063`` () =
+    toDecimal "2047" |> should equal 1063
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Octal 7777 is decimal 4095`` () =
+    toDecimal "7777" |> should equal 4095
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Octal 1234567 is decimal 342391`` () =
+    toDecimal "1234567" |> should equal 342391
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Invalid Octal carrot is decimal 0`` () =
+    toDecimal "carrot" |> should equal 0
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Invalid Octal 8 is decimal 0`` () =
+    toDecimal "8" |> should equal 0
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Invalid Octal 9 is decimal 0`` () =
+    toDecimal "9" |> should equal 0
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Invalid Octal 6789 is decimal 0`` () =
+    toDecimal "6789" |> should equal 0
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Invalid Octal abc1z is decimal 0`` () =
+    toDecimal "abc1z" |> should equal 0
+

--- a/exercises/octal/Program.fs
+++ b/exercises/octal/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0

--- a/exercises/octal/README.md
+++ b/exercises/octal/README.md
@@ -1,0 +1,49 @@
+# Octal
+
+Convert an octal number, represented as a string (e.g. '1735263'), to its
+decimal equivalent using first principles (i.e. no, you may not use built-in or
+external libraries to accomplish the conversion).
+
+Implement octal to decimal conversion.  Given an octal input
+string, your program should produce a decimal output.
+
+## Note
+- Implement the conversion yourself.
+  Do not use something else to perform the conversion for you.
+- Treat invalid input as octal 0.
+
+## About Octal (Base-8)
+Decimal is a base-10 system.
+
+A number 233 in base 10 notation can be understood
+as a linear combination of powers of 10:
+
+- The rightmost digit gets multiplied by 10^0 = 1
+- The next number gets multiplied by 10^1 = 10
+- ...
+- The *n*th number gets multiplied by 10^*(n-1)*.
+- All these values are summed.
+
+So:
+```
+   233 # decimal
+ = 2*10^2 + 3*10^1 + 3*10^0
+ = 2*100  + 3*10   + 3*1
+```
+
+Octal is similar, but uses powers of 8 rather than powers of 10.
+
+So:
+```
+   233 # octal
+ = 2*8^2 + 3*8^1 + 3*8^0
+ = 2*64  + 3*8   + 3*1
+ = 128   + 24    + 3
+ = 155
+```
+## Source
+
+All of Computer Science [http://www.wolframalpha.com/input/?i=base+8](http://www.wolframalpha.com/input/?i=base+8)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/transpose/TrinaryTest.fs
+++ b/exercises/transpose/TrinaryTest.fs
@@ -1,0 +1,24 @@
+﻿module TrinaryTest
+
+open NUnit.Framework
+open Trinary
+    
+[<TestCase("1", ExpectedResult = 1)>]
+[<TestCase("2", ExpectedResult = 2, Ignore = "Remove to run test case")>]
+[<TestCase("10", ExpectedResult = 3, Ignore = "Remove to run test case")>]
+[<TestCase("11", ExpectedResult = 4, Ignore = "Remove to run test case")>]
+[<TestCase("100", ExpectedResult = 9, Ignore = "Remove to run test case")>]
+[<TestCase("112", ExpectedResult = 14, Ignore = "Remove to run test case")>]
+[<TestCase("222", ExpectedResult = 26, Ignore = "Remove to run test case")>]
+[<TestCase("1122000120", ExpectedResult = 32091, Ignore = "Remove to run test case")>]
+let ``Binary converts to decimal`` input =
+    toDecimal input
+
+[<TestCase("carrot", Ignore = "Remove to run test case")>]
+[<TestCase("3", Ignore = "Remove to run test case")>]
+[<TestCase("6", Ignore = "Remove to run test case")>]
+[<TestCase("9", Ignore = "Remove to run test case")>]
+[<TestCase("124578", Ignore = "Remove to run test case")>]
+[<TestCase("abc1z", Ignore = "Remove to run test case")>]
+let ``Invalid binary is decimal 0`` input =
+    Assert.That(toDecimal input, Is.EqualTo(0))

--- a/exercises/trinary/Example.fs
+++ b/exercises/trinary/Example.fs
@@ -1,0 +1,13 @@
+﻿module Trinary
+
+let isValid char = 
+    match char with
+    | '0' | '1' | '2' -> true
+    | _  -> false
+
+let charToDecimal char = (int)char - (int)'0'
+
+let toDecimal(input: string) = 
+    let chars = input.ToCharArray()
+    if Array.forall isValid chars then Array.fold (fun acc c -> acc * 3 + charToDecimal c) 0 chars
+    else 0

--- a/exercises/trinary/Program.fs
+++ b/exercises/trinary/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -1,0 +1,28 @@
+# Trinary
+
+Convert a trinary number, represented as a string (e.g. '102012'), to its
+decimal equivalent using first principles.
+
+The program should consider strings specifying an invalid trinary as the
+value 0.
+
+Trinary numbers contain three symbols: 0, 1, and 2.
+
+The last place in a trinary number is the 1's place. The second to last
+is the 3's place, the third to last is the 9's place, etc.
+
+```bash
+# "102012"
+    1       0       2       0       1       2    # the number
+1*3^5 + 0*3^4 + 2*3^3 + 0*3^2 + 1*3^1 + 2*3^0    # the value
+  243 +     0 +    54 +     0 +     3 +     2 =  302
+```
+
+If your language provides a method in the standard library to perform the
+conversion, pretend it doesn't exist and implement it yourself.
+## Source
+
+All of Computer Science [http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-](http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/trinary/Trinary.fs
+++ b/exercises/trinary/Trinary.fs
@@ -1,0 +1,3 @@
+﻿module Trinary
+
+let toDecimal (input: string): int = failwith "You need to implement this function."

--- a/exercises/trinary/Trinary.fsproj
+++ b/exercises/trinary/Trinary.fsproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Trinary.fs" />
+    <Compile Include="TrinaryTest.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="FsUnit.xUnit" Version="3.0.0" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/exercises/trinary/TrinaryTest.fs
+++ b/exercises/trinary/TrinaryTest.fs
@@ -1,0 +1,51 @@
+module TrinaryTest
+
+open FsUnit.Xunit
+open Xunit
+
+open Trinary
+
+[<Fact>]
+let ``Trinary_1_is_decimal_1`` () =
+    toDecimal "1" |> should equal 1
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Trinary_2_is_decimal_2`` () =
+    toDecimal "2" |> should equal 2
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Trinary_10_is_decimal_3`` () =
+    toDecimal "10" |> should equal 3
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Trinary_11_is_decimal_4`` () =
+    toDecimal "11" |> should equal 4
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Trinary_100_is_decimal_9`` () =
+    toDecimal "100" |> should equal 9
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Trinary_112_is_decimal_14`` () =
+    toDecimal "112" |> should equal 14
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Trinary_222_is_decimal_26`` () =
+    toDecimal "222" |> should equal 26
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Trinary_1122000120_is_decimal_32091`` () =
+    toDecimal "1122000120" |> should equal 32091
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Invalid_trinary_digits_returns_0`` () =
+    toDecimal "1234" |> should equal 0
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Invalid_word_as_input_returns_0`` () =
+    toDecimal "carrot" |> should equal 0
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Invalid_numbers_with_letters_as_input_returns_0`` () =
+    toDecimal "0a1b2c" |> should equal 0
+


### PR DESCRIPTION
When migrating the data from v1 to v2, we will lose all the solutions submitted to
deprecated exercises, unless they exist in the track configuration.

This adds the deprecated binary, trinary, octal, and hexadecimal exercises back,
 leaving them deprecated so that they don't actively show up as part of the track.

I've tried to follow the new project format, adding the `Project.fs` and `$slug.fsproj`, as well as a solution stub. The solution stub in particular is likely to not be valid F#, as I just looked at other exercises and made some guesses.

We can delete them from the track again after we launch v2, if we want to.
