### PR TITLE
Handle deprecated exercises

### DIFF
--- a/generators/Common.fs
+++ b/generators/Common.fs
@@ -89,6 +89,8 @@ module String =
     let replace (oldValue: string) (newValue: string) (str: string) =
         str.Replace(oldValue, newValue)    
 
+    let toLower (str: string) = str.ToLowerInvariant()
+
 module Json =
     let rec parentsAndSelf (currentToken: JToken) =
         let rec helper acc (token: JToken) =

--- a/generators/Generators.fsproj
+++ b/generators/Generators.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="Common.fs" />
     <Compile Include="Options.fs" />
     <Compile Include="CanonicalData.fs" />
+    <Compile Include="Track.fs" />
     <Compile Include="Formatting.fs" />
     <Compile Include="Rendering.fs" />
     <Compile Include="Exercise.fs" />

--- a/generators/Options.fs
+++ b/generators/Options.fs
@@ -8,6 +8,7 @@ type Status =
     | Implemented
     | Unimplemented
     | MissingData
+    | Deprecated
     | Custom
 
 type CommandLineOptions = 
@@ -47,6 +48,7 @@ let private normalizeStatus status =
     | Some "unimplemented" -> Some Unimplemented
     | Some "missingdata"   -> Some MissingData
     | Some "custom"        -> Some Custom
+    | Some "deprecated"    -> Some Deprecated
     | Some "all"           -> None
     | Some _               -> failwith "Invalid status" 
     | None                 -> Some Implemented

--- a/generators/Options.fs
+++ b/generators/Options.fs
@@ -36,13 +36,18 @@ let private normalizeCanonicalDataDirectory canonicalDataDirectory =
         
 let private normalizeExercise exercise = Option.ofNonEmptyString exercise
 
-let private normalizeStatus status = 
-    match Option.ofNonEmptyString status with
-    | Some "Implemented"   -> Some Implemented
-    | Some "Unimplemented" -> Some Unimplemented
-    | Some "MissingData"   -> Some MissingData
-    | Some "Custom"        -> Some Custom
-    | Some "All"           -> None
+let private normalizeStatus status =
+    let normalizedStatus = 
+        status 
+        |> Option.ofNonEmptyString 
+        |> Option.map String.toLower
+
+    match normalizedStatus with
+    | Some "implemented"   -> Some Implemented
+    | Some "unimplemented" -> Some Unimplemented
+    | Some "missingdata"   -> Some MissingData
+    | Some "custom"        -> Some Custom
+    | Some "all"           -> None
     | Some _               -> failwith "Invalid status" 
     | None                 -> Some Implemented
 

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -16,6 +16,7 @@ let private isNotFilteredByStatus options (exercise: Exercise) =
     | Some Status.Implemented,   Exercise.Generator _     -> true
     | Some Status.Unimplemented, Exercise.Unimplemented _ -> true
     | Some Status.MissingData,   Exercise.MissingData _   -> true
+    | Some Status.Deprecated,    Exercise.Deprecated _    -> true
     | Some Status.Custom,        Exercise.Custom _        -> true
     | _ -> false
 
@@ -34,6 +35,8 @@ let private regenerateTestClass options =
             Log.Error("{Exercise}: missing test generator", unimplemented.Name)
         | Exercise.MissingData missingData ->
             Log.Warning("{Exercise}: missing canonical data", missingData.Name)
+        | Exercise.Deprecated deprecated ->
+            Log.Warning("{Exercise}: deprecated", deprecated.Name)
         | Exercise.Generator generator ->
             let canonicalData = parseCanonicalData' generator.Name
             generator.Regenerate(canonicalData)

--- a/generators/Track.fs
+++ b/generators/Track.fs
@@ -1,0 +1,26 @@
+module Generators.Track
+
+open System.IO
+open Newtonsoft.Json
+
+type ConfigExercise = 
+    { Slug: string
+      Deprecated: bool }
+
+type Config = 
+    { Exercises: ConfigExercise list }
+
+let private convertTrackConfig trackConfigContents = JsonConvert.DeserializeObject<Config>(trackConfigContents)
+
+let private trackConfigFile = Path.Combine("..", "config.json")
+
+let private readTrackConfig = File.ReadAllText trackConfigFile
+
+let private parseTrackConfig = convertTrackConfig readTrackConfig
+
+let isDeprecated =
+    let config = parseTrackConfig
+
+    fun exercise -> 
+        config.Exercises
+        |> List.exists (fun x -> x.Slug = exercise && x.Deprecated)


### PR DESCRIPTION
This PR adds support for two things:

1. Make the status filter for generators case-insensitive
1. Allow filtering on deprecated exercises (which were previously listed in the "Unimplemented" section)