### PR TITLE
pov: Annotate type of graph in `graphToList`

### DIFF
--- a/exercises/pov/PovTest.fs
+++ b/exercises/pov/PovTest.fs
@@ -7,7 +7,7 @@ open Xunit
 
 open Pov
 
-let rec graphToList graph = 
+let rec graphToList (graph: Graph<'a>) =
     let right =
         graph.children
         |> List.sortBy (fun x -> x.value)


### PR DESCRIPTION
As discussed in https://github.com/exercism/fsharp/issues/522

The advantage of this is that it allows the student to have `children`
be a member function while using a different internal representation of
children (say, a Map).

The disadvantage is that it is now **required** that `Graph` be generic;
before this annotation it would have been feasible to create a `Graph`
that only accepts String values.

We find the tradeoff acceptable because it allows increased flexibility
in `children`. The decreased flexibility (must be generic) is balanced
by the fact that it forces the student to think about how the graph
might be made generic, which seems like a good idea anyway! As a result,
potential users of such a `Graph` will have more options.

Closes https://github.com/exercism/fsharp/issues/522