### PR TITLE
config.json: Update exercise ordering

### DIFF
--- a/config.json
+++ b/config.json
@@ -126,14 +126,14 @@
       "uuid": "e7f74f6c-16ea-40d8-94f7-7034bc6ee938"
     },
     {
-      "core": false,
+      "core": true,
       "difficulty": 3,
       "slug": "beer-song",
       "topics": [
         "algorithms",
         "text_formatting"
       ],
-      "unlocked_by": "raindrops",
+      "unlocked_by": null,
       "uuid": "0ea0d92f-5510-4ba9-b419-3f5ad029b74f"
     },
     {
@@ -180,7 +180,7 @@
       "uuid": "ecae4faa-c516-4a71-8d55-9c53403d8826"
     },
     {
-      "core": false,
+      "core": true,
       "difficulty": 4,
       "slug": "allergies",
       "topics": [
@@ -188,7 +188,7 @@
         "enumerations",
         "filtering"
       ],
-      "unlocked_by": "kindergarten-garden",
+      "unlocked_by": null,
       "uuid": "221dff26-0495-4d4b-9363-14a5d7263271"
     },
     {
@@ -885,7 +885,7 @@
         "algorithms",
         "matrices"
       ],
-      "unlocked_by": "matrix",
+      "unlocked_by": "kindergarten-garden",
       "uuid": "52f8f299-b93b-4f44-bd5b-b445741b285d"
     },
     {

--- a/config.json
+++ b/config.json
@@ -53,7 +53,7 @@
         "optional_values",
         "strings"
       ],
-      "unlocked_by": "null",
+      "unlocked_by": null,
       "uuid": "2ee3cc7a-db3f-4668-9983-ed6d0fea95d1"
     },
     {


### PR DESCRIPTION
## Problem
While linting with the next release of [Configlet](https://github.com/exercism/configlet/releases/tag/v3.8.0) a number of exercises were still found to contain invalid unlocked_by configurations.

## What Changed?
The master config file was updated following manner:

1. Any exercise containing the unlocked_by value of `"null"` was updated with a null value.
1. The exercises allergies and beer-song were reverted back to core exercises and their unlocked_by values were set to null. Since core exercises that are dependent on other core exercises should have a higher difficulty, and appear after (exercise list order) then its unlocking core exercise user will still be required to complete raindrops and kindergarten-garden before they can attempt beer-song and allergies.
1. The exercise spiral-matrix is now set to be unlocked_by the core exercise `kindergarten-garden` as it currently unlocks the `matrix` exercise.

## Test Steps
1.Download the pre-release of Configlet [here](https://github.com/exercism/configlet/releases/tag/v3.8.0)
1.Run `configlet lint <path-to-fsharp-track>`
1.Validate that there are no lint errors.

closes #520