### PR TITLE
Add Type alias to make Grade School API more clear

### DIFF
--- a/exercises/grade-school/.meta/hints.md
+++ b/exercises/grade-school/.meta/hints.md
@@ -1,4 +1,4 @@
 ## Hints
 For this exercise the following F# feature comes in handy:
 - The [Map](https://en.wikibooks.org/wiki/F_Sharp_Programming/Sets_and_Maps#Maps) type associates keys with values. It is very similar to .NET's `Dictionary<TKey, TValue>` type, but with one major difference: `Map` is [immutable](https://fsharpforfunandprofit.com/posts/correctness-immutability/).
-- A [type abbreviation (or alias)](https://fsharpforfunandprofit.com/posts/type-abbreviations/) to a `Map` type used as a `School` type. 
+- A [type abbreviation](https://fsharpforfunandprofit.com/posts/type-abbreviations/) is used to create a descriptive alias for a more complex type.

--- a/exercises/grade-school/.meta/hints.md
+++ b/exercises/grade-school/.meta/hints.md
@@ -1,3 +1,4 @@
 ## Hints
 For this exercise the following F# feature comes in handy:
 - The [Map](https://en.wikibooks.org/wiki/F_Sharp_Programming/Sets_and_Maps#Maps) type associates keys with values. It is very similar to .NET's `Dictionary<TKey, TValue>` type, but with one major difference: `Map` is [immutable](https://fsharpforfunandprofit.com/posts/correctness-immutability/).
+- A [type abbreviation (or alias)](https://fsharpforfunandprofit.com/posts/type-abbreviations/) to a `Map` type used as a `School` type. 

--- a/exercises/grade-school/GradeSchool.fs
+++ b/exercises/grade-school/GradeSchool.fs
@@ -1,9 +1,11 @@
 ﻿module GradeSchool
 
-let empty: Map<int, string list> = failwith "You need to implement this function."
+type School = Map<int, string list>
 
-let add (student: string) (grade: int) (school: Map<int, string list>): Map<int, string list> = failwith "You need to implement this function."
+let empty: School = failwith "You need to implement this function."
 
-let roster (school: Map<int, string list>): (int * string list) list = failwith "You need to implement this function."
+let add (student: string) (grade: int) (school: School): School = failwith "You need to implement this function."
 
-let grade (number: int) (school: Map<int, string list>): string list = failwith "You need to implement this function."
+let roster (school: School): (int * string list) list = failwith "You need to implement this function."
+
+let grade (number: int) (school: School): string list = failwith "You need to implement this function."


### PR DESCRIPTION
The `Map<int, string list>` is really just the defacto school implementation. The tests don't care what the school's type is. If we name the type, it becomes more obvious what these functions are doing. It has the added benefit of providing the implementer with a less error prone way of using a different type for the school.