### PR TITLE
Bank account bug fix and improvement

### DIFF
--- a/exercises/bank-account/BankAccountTest.fs
+++ b/exercises/bank-account/BankAccountTest.fs
@@ -1,4 +1,4 @@
-// This file was created manually and its version is 1.0.1.
+// This file was created manually and its version is 2.0.1.
 
 module BankAccountTest
 
@@ -10,7 +10,7 @@ open BankAccount
 let ``Returns empty balance after opening`` () =
     let account = mkBankAccount() |> openAccount
 
-    getBalance account |> should equal (Some 0.0)
+    getBalance account |> should equal (Some 0.0m)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Check basic balance`` () =
@@ -19,11 +19,11 @@ let ``Check basic balance`` () =
 
     let updatedBalance = 
         account
-        |> updateBalance 10.0 
+        |> updateBalance 10.0m
         |> getBalance
 
-    openingBalance |> should equal (Some 0.0)
-    updatedBalance |> should equal (Some 10.0)
+    openingBalance |> should equal (Some 0.0m)
+    updatedBalance |> should equal (Some 10.0m)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Balance can increment or decrement`` () =    
@@ -32,17 +32,17 @@ let ``Balance can increment or decrement`` () =
 
     let addedBalance = 
         account 
-        |> updateBalance 10.0
+        |> updateBalance 10.0m
         |> getBalance
 
     let subtractedBalance = 
         account 
-        |> updateBalance -15.0
+        |> updateBalance -15.0m
         |> getBalance
 
-    openingBalance |> should equal (Some 0.0)
-    addedBalance |> should equal (Some 10.0)
-    subtractedBalance |> should equal (Some -5.0)
+    openingBalance |> should equal (Some 0.0m)
+    addedBalance |> should equal (Some 10.0m)
+    subtractedBalance |> should equal (Some -5.0m)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Account can be closed`` () =
@@ -63,7 +63,7 @@ let ``Account can be updated from multiple threads`` () =
     let updateAccountAsync =        
         async {                             
             account 
-            |> updateBalance 1.0
+            |> updateBalance 1.0m
             |> ignore
         }
 
@@ -73,4 +73,4 @@ let ``Account can be updated from multiple threads`` () =
     |> Async.RunSynchronously
     |> ignore
 
-    getBalance account |> should equal (Some 1000.0)
+    getBalance account |> should equal (Some 1000.0m)

--- a/exercises/bank-account/BankAccountTest.fs
+++ b/exercises/bank-account/BankAccountTest.fs
@@ -52,6 +52,7 @@ let ``Account can be closed`` () =
         |> closeAccount
 
     getBalance account |> should equal None
+    account |> should not' (equal None)
     
 [<Fact(Skip = "Remove to run test")>]
 let ``Account can be updated from multiple threads`` () =

--- a/exercises/bank-account/BankAccountTest.fs
+++ b/exercises/bank-account/BankAccountTest.fs
@@ -1,4 +1,4 @@
-// This file was created manually and its version is 1.0.0.
+// This file was created manually and its version is 1.0.1.
 
 module BankAccountTest
 
@@ -10,7 +10,7 @@ open BankAccount
 let ``Returns empty balance after opening`` () =
     let account = mkBankAccount() |> openAccount
 
-    getBalance account |> should equal <| Some 0.0
+    getBalance account |> should equal (Some 0.0)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Check basic balance`` () =
@@ -22,8 +22,8 @@ let ``Check basic balance`` () =
         |> updateBalance 10.0 
         |> getBalance
 
-    openingBalance |> should equal <| Some 0.0
-    updatedBalance |> should equal <| Some 10.0
+    openingBalance |> should equal (Some 0.0)
+    updatedBalance |> should equal (Some 10.0)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Balance can increment or decrement`` () =    
@@ -40,9 +40,9 @@ let ``Balance can increment or decrement`` () =
         |> updateBalance -15.0
         |> getBalance
 
-    openingBalance |> should equal <| Some 0.0
-    addedBalance |> should equal <| Some 10.0
-    subtractedBalance |> should equal <| Some -5.0
+    openingBalance |> should equal (Some 0.0)
+    addedBalance |> should equal (Some 10.0)
+    subtractedBalance |> should equal (Some -5.0)
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Account can be closed`` () =
@@ -72,4 +72,4 @@ let ``Account can be updated from multiple threads`` () =
     |> Async.RunSynchronously
     |> ignore
 
-    getBalance account |> should equal <| Some 1000.0
+    getBalance account |> should equal (Some 1000.0)

--- a/exercises/bank-account/Example.fs
+++ b/exercises/bank-account/Example.fs
@@ -4,13 +4,13 @@ open System
 
 type BankAccount() = 
     member val Lock = new Object()
-    member val Balance: float option = None with get,set
+    member val Balance: decimal option = None with get,set
 
 let mkBankAccount() = BankAccount()
 
 let openAccount (account: BankAccount) = 
     lock account.Lock (fun () ->
-        account.Balance <- Some 0.0
+        account.Balance <- Some 0.0m
         account
     )
 


### PR DESCRIPTION
 - Original tests had actual and expected swapped.
 - Added a double check so that `closeAccount` doesn't return None.
 - Switched to base 10 decimal type since that's the industry practice.