### PR TITLE
Simplify test generators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ paket-files
 .vs/
 .vscode/
 .dotnet
+*.fsproj.user

--- a/generators/Exercise.fs
+++ b/generators/Exercise.fs
@@ -17,58 +17,26 @@ let private exerciseNameFromType (exerciseType: Type) = exerciseType.Name.Kebabe
 [<AbstractClass>]
 type GeneratorExercise() =
 
-    // Allow changes in canonical data
-    abstract member MapCanonicalData : CanonicalData -> CanonicalData
-    abstract member MapCanonicalDataCase : CanonicalDataCase -> CanonicalDataCase
-    abstract member MapCanonicalDataCaseInput : CanonicalDataCase * Map<string, obj> -> Map<string, obj>
-    abstract member MapCanonicalDataCaseInputProperty : CanonicalDataCase * string * obj -> obj
-    abstract member MapCanonicalDataCaseExpected : CanonicalDataCase * string * obj -> obj
-
-    // Convert canonical data to representation used when rendering
-    abstract member ToTestFile : CanonicalData -> TestFile
-    abstract member ToTestMethod : int * CanonicalDataCase -> TestMethod
-    abstract member ToTestMethodBody : CanonicalDataCase -> TestMethodBody  
-    abstract member ToTestMethodBodyAssert : CanonicalDataCase -> TestMethodBodyAssert  
-
-    // Determine the templates to use when rendering
-    abstract member TestFileTemplate : string
-    abstract member TestMethodTemplate : int * CanonicalDataCase -> string
-    abstract member TestMethodBodyTemplate : CanonicalDataCase -> string
-    abstract member TestMethodBodyAssertTemplate : CanonicalDataCase -> string
-    abstract member TestFileFormat: TestFileFormat
-
-    // Rendering of canonical data
-    abstract member Render : CanonicalData -> string
-    abstract member RenderTestMethod : int * CanonicalDataCase -> string
-    abstract member RenderTestMethodBody : CanonicalDataCase -> string
-    abstract member RenderTestMethodName : CanonicalDataCase -> string
-    abstract member RenderSetup : CanonicalData -> string
-
-    // Generic value/identifier rendering methods
-    abstract member RenderValue : CanonicalDataCase * string * obj -> string
-    abstract member RenderValueOrIdentifier: CanonicalDataCase * string * obj -> string
-    abstract member RenderValueWithoutIdentifier: CanonicalDataCase * string * obj -> string
-    abstract member RenderValueWithIdentifier: CanonicalDataCase * string * obj -> string
-    abstract member RenderIdentifier: CanonicalDataCase * string * obj -> string
-    abstract member RenderIdentifierWithTypeAnnotation: CanonicalDataCase * string * obj -> string
-
-    // Canonical-data specific rendering methods
+    // Customize rendered output
     abstract member RenderExpected : CanonicalDataCase * string * obj -> string
     abstract member RenderInput : CanonicalDataCase * string * obj -> string
     abstract member RenderArrange : CanonicalDataCase -> string list
     abstract member RenderAssert : CanonicalDataCase -> string list
     abstract member RenderSut : CanonicalDataCase -> string
-    abstract member RenderSutParameters : CanonicalDataCase -> string list
-    abstract member RenderSutParameter : CanonicalDataCase * string * obj -> string
-    abstract member RenderSutProperty : CanonicalDataCase -> string
+    abstract member RenderSetup : CanonicalData -> string
+    abstract member RenderValue : CanonicalDataCase * string * obj -> string
     
     // Utility methods to customize rendered output
-    abstract member Properties : CanonicalDataCase -> string list
+    abstract member MapCanonicalDataCase : CanonicalDataCase -> CanonicalDataCase
     abstract member PropertiesUsedAsSutParameter : CanonicalDataCase -> string list
     abstract member PropertiesWithIdentifier : CanonicalDataCase -> string list
-    abstract member IdentifierTypeAnnotation: CanonicalDataCase * string * obj -> string option
+    abstract member IdentifierTypeAnnotation: CanonicalDataCase * string * obj -> string option    
+    abstract member AdditionalNamespaces : string list    
+    abstract member AssertTemplate : CanonicalDataCase -> string    
+    abstract member TestFileFormat: TestFileFormat
+    abstract member TestMethodName : CanonicalDataCase -> string
     abstract member UseFullMethodName : CanonicalDataCase -> bool
-    abstract member AdditionalNamespaces : string list
+    abstract member SkipTestMethod : int * CanonicalDataCase -> bool
 
     member this.Name = this.GetType() |> exerciseNameFromType 
     member this.TestModuleName = this.GetType().Name.Pascalize() |> sprintf "%sTest"
@@ -88,25 +56,14 @@ type GeneratorExercise() =
 
     // Allow changes in canonical data    
 
-    default this.MapCanonicalData canonicalData = 
+    member this.MapCanonicalData canonicalData = 
         { canonicalData with Cases = List.map this.MapCanonicalDataCase canonicalData.Cases }
 
-    default this.MapCanonicalDataCase canonicalDataCase =
-        { canonicalDataCase with 
-            Input = this.MapCanonicalDataCaseInput (canonicalDataCase, canonicalDataCase.Input)
-            Expected = this.MapCanonicalDataCaseExpected (canonicalDataCase, "expected", canonicalDataCase.Expected) }
-
-    default this.MapCanonicalDataCaseInput (canonicalDataCase, properties) =
-        properties
-        |> Map.map (fun key value -> this.MapCanonicalDataCaseInputProperty (canonicalDataCase, key, value)) 
-
-    default __.MapCanonicalDataCaseInputProperty (_, _, value) = value
-
-    default __.MapCanonicalDataCaseExpected (_, _, value) = value
+    default __.MapCanonicalDataCase canonicalDataCase = canonicalDataCase
 
     // Convert canonical data to representation used when rendering
 
-    default this.ToTestFile canonicalData =
+    member this.ToTestFile canonicalData =
         let renderTestMethod i canonicalDataCase = this.RenderTestMethod(i, canonicalDataCase)
 
         { Version = canonicalData.Version              
@@ -117,37 +74,37 @@ type GeneratorExercise() =
           Methods = List.mapi renderTestMethod canonicalData.Cases
           Setup = this.RenderSetup canonicalData }
 
-    default this.ToTestMethod (index, canonicalDataCase) =
-        { Skip = index > 0
-          Name = this.RenderTestMethodName canonicalDataCase
+    member this.ToTestMethod (index, canonicalDataCase) =
+        { Skip = this.SkipTestMethod (index, canonicalDataCase)
+          Name = this.TestMethodName canonicalDataCase
           Body = this.RenderTestMethodBody canonicalDataCase }
 
-    default this.ToTestMethodBody canonicalDataCase =         
+    member this.ToTestMethodBody canonicalDataCase =         
         { Arrange = this.RenderArrange canonicalDataCase
           Assert = this.RenderAssert canonicalDataCase }
 
-    default this.ToTestMethodBodyAssert canonicalDataCase =         
+    member this.ToTestMethodBodyAssert canonicalDataCase =         
         { Sut = this.RenderValueOrIdentifier (canonicalDataCase, "sut", canonicalDataCase.Expected)
           Expected = this.RenderValueOrIdentifier (canonicalDataCase, "expected", canonicalDataCase.Expected) }
 
     // Determine the templates to use when rendering
 
-    default this.TestFileTemplate = 
+    member this.TestFileTemplate = 
         match this.TestFileFormat with
         | Module -> "TestModule"
         | Class  -> "TestClass"
     
-    default this.TestMethodTemplate (_, _) =
+    member this.TestMethodTemplate (_, _) =
         match this.TestFileFormat with
         | Module -> "TestFunction"
         | Class  -> "TestMember"
 
-    default this.TestMethodBodyTemplate _ =
+    member this.TestMethodBodyTemplate _ =
         match this.TestFileFormat with
         | Module -> "TestFunctionBody"
         | Class  -> "TestMemberBody"
 
-    default this.TestMethodBodyAssertTemplate canonicalDataCase =
+    default this.AssertTemplate canonicalDataCase =
         match canonicalDataCase.Expected with
         | :? JArray as jArray when jArray.Count = 0 && not (List.contains "expected" (this.PropertiesWithIdentifier canonicalDataCase)) -> "AssertEmpty"
         | _ -> "AssertEqual"
@@ -156,26 +113,26 @@ type GeneratorExercise() =
 
     // Rendering of canonical data
 
-    default this.Render canonicalData =
+    member this.Render canonicalData =
         canonicalData
         |> this.ToTestFile
         |> renderPartialTemplate this.TestFileTemplate
 
-    default this.RenderTestMethod (index, canonicalDataCase) = 
+    member this.RenderTestMethod (index, canonicalDataCase) = 
         let template = this.TestMethodTemplate (index, canonicalDataCase)
 
         (index, canonicalDataCase)
         |> this.ToTestMethod 
         |> renderPartialTemplate template
 
-    default this.RenderTestMethodBody canonicalDataCase = 
+    member this.RenderTestMethodBody canonicalDataCase = 
         let template = this.TestMethodBodyTemplate canonicalDataCase
 
         canonicalDataCase
         |> this.ToTestMethodBody
         |> renderPartialTemplate template
 
-    default this.RenderTestMethodName canonicalDataCase = 
+    default this.TestMethodName canonicalDataCase = 
         match this.UseFullMethodName canonicalDataCase with
         | false ->
             String.upperCaseFirst canonicalDataCase.Description
@@ -190,27 +147,27 @@ type GeneratorExercise() =
 
     default __.RenderValue (_, _, value) = formatValue value
 
-    default this.RenderValueOrIdentifier (canonicalDataCase, key, value) =
+    member this.RenderValueOrIdentifier (canonicalDataCase, key, value) =
         let properties = this.PropertiesWithIdentifier canonicalDataCase
 
         match List.contains key properties with
         | true  -> this.RenderIdentifier (canonicalDataCase, key, value)
         | false -> this.RenderValueWithoutIdentifier (canonicalDataCase, key, value)
 
-    default this.RenderValueWithoutIdentifier (canonicalDataCase, key, value) = 
+    member this.RenderValueWithoutIdentifier (canonicalDataCase, key, value) = 
         match key with
         | "expected" -> this.RenderExpected (canonicalDataCase, key, value)
         | "sut" -> this.RenderSut canonicalDataCase
         | _  -> this.RenderInput (canonicalDataCase, key, value)
 
-    default this.RenderValueWithIdentifier (canonicalDataCase, key, value) = 
+    member this.RenderValueWithIdentifier (canonicalDataCase, key, value) = 
         let identifier = this.RenderIdentifierWithTypeAnnotation (canonicalDataCase, key, value)
         let value = this.RenderValueWithoutIdentifier (canonicalDataCase, key, value)
         sprintf "let %s = %s" identifier value  
 
-    default __.RenderIdentifier (_, key, _) = String.camelize key
+    member __.RenderIdentifier (_, key, _) = String.camelize key
 
-    default this.RenderIdentifierWithTypeAnnotation (canonicalDataCase, key, value) = 
+    member this.RenderIdentifierWithTypeAnnotation (canonicalDataCase, key, value) = 
         let identifier = this.RenderIdentifier (canonicalDataCase, key, value)
     
         match this.IdentifierTypeAnnotation (canonicalDataCase, key, value) with
@@ -248,31 +205,31 @@ type GeneratorExercise() =
         |> List.choose renderArrangeProperty
 
     default this.RenderAssert canonicalDataCase = 
-        let template = this.TestMethodBodyAssertTemplate canonicalDataCase                
+        let template = this.AssertTemplate canonicalDataCase                
 
         canonicalDataCase
         |> this.ToTestMethodBodyAssert
         |> renderPartialTemplate template
         |> List.singleton
 
-    default this.RenderSut canonicalDataCase = 
+    default this.RenderSut canonicalDataCase =
         let parameters = this.RenderSutParameters canonicalDataCase
         let prop = this.RenderSutProperty canonicalDataCase
         prop :: parameters |> String.concat " "
 
-    default this.RenderSutParameters canonicalDataCase =
+    member this.RenderSutParameters canonicalDataCase =
         let sutParameterProperties = this.PropertiesUsedAsSutParameter canonicalDataCase
         let renderSutParameter key = this.RenderSutParameter (canonicalDataCase, key, Map.find key canonicalDataCase.Input)
 
         sutParameterProperties
         |> List.map renderSutParameter
     
-    default this.RenderSutParameter (canonicalDataCase, key, value) =
+    member this.RenderSutParameter (canonicalDataCase, key, value) =
         this.RenderValueOrIdentifier (canonicalDataCase, key, value) 
 
-    default __.RenderSutProperty canonicalDataCase = string canonicalDataCase.Property
+    member __.RenderSutProperty canonicalDataCase = string canonicalDataCase.Property
 
-    default this.Properties canonicalDataCase =
+    member this.Properties canonicalDataCase =
         List.append (this.PropertiesUsedAsSutParameter canonicalDataCase) ["expected"]
 
     default __.PropertiesUsedAsSutParameter canonicalDataCase = 
@@ -289,6 +246,8 @@ type GeneratorExercise() =
     default __.UseFullMethodName _ = false
 
     default __.AdditionalNamespaces = []
+
+    default __.SkipTestMethod (index, _) = index > 0
     
 type CustomExercise() =
 


### PR DESCRIPTION
In this PR, I've tried to restrict the number of method a test generator can override to a minimum. This should make it easier to create new libraries, as there are less options. As a nice side-effect, it will also make writing the documentation easier :)

Closes #529.