### PR TITLE
exercises: Assert precision to two decimals

### DIFF
--- a/exercises/complex-numbers/ComplexNumbersTest.fs
+++ b/exercises/complex-numbers/ComplexNumbersTest.fs
@@ -11,8 +11,8 @@ open ComplexNumbers
 [<Fact>]
 let ``Imaginary unit`` () =
     let sut = mul (create 0.0 1.0) (create 0.0 1.0)
-    real sut |> should (equalWithin 0.000000001) -1.0
-    imaginary sut |> should (equalWithin 0.000000001) 0.0
+    real sut |> should (equalWithin 0.01) -1.0
+    imaginary sut |> should (equalWithin 0.01) 0.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Real part of a purely real number`` () =
@@ -41,74 +41,74 @@ let ``Imaginary part of a number with real and imaginary part`` () =
 [<Fact(Skip = "Remove to run test")>]
 let ``Add purely real numbers`` () =
     let sut = add (create 1.0 0.0) (create 2.0 0.0)
-    real sut |> should (equalWithin 0.000000001) 3.0
-    imaginary sut |> should (equalWithin 0.000000001) 0.0
+    real sut |> should (equalWithin 0.01) 3.0
+    imaginary sut |> should (equalWithin 0.01) 0.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Add purely imaginary numbers`` () =
     let sut = add (create 0.0 1.0) (create 0.0 2.0)
-    real sut |> should (equalWithin 0.000000001) 0.0
-    imaginary sut |> should (equalWithin 0.000000001) 3.0
+    real sut |> should (equalWithin 0.01) 0.0
+    imaginary sut |> should (equalWithin 0.01) 3.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Add numbers with real and imaginary part`` () =
     let sut = add (create 1.0 2.0) (create 3.0 4.0)
-    real sut |> should (equalWithin 0.000000001) 4.0
-    imaginary sut |> should (equalWithin 0.000000001) 6.0
+    real sut |> should (equalWithin 0.01) 4.0
+    imaginary sut |> should (equalWithin 0.01) 6.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Subtract purely real numbers`` () =
     let sut = sub (create 1.0 0.0) (create 2.0 0.0)
-    real sut |> should (equalWithin 0.000000001) -1.0
-    imaginary sut |> should (equalWithin 0.000000001) 0.0
+    real sut |> should (equalWithin 0.01) -1.0
+    imaginary sut |> should (equalWithin 0.01) 0.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Subtract purely imaginary numbers`` () =
     let sut = sub (create 0.0 1.0) (create 0.0 2.0)
-    real sut |> should (equalWithin 0.000000001) 0.0
-    imaginary sut |> should (equalWithin 0.000000001) -1.0
+    real sut |> should (equalWithin 0.01) 0.0
+    imaginary sut |> should (equalWithin 0.01) -1.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Subtract numbers with real and imaginary part`` () =
     let sut = sub (create 1.0 2.0) (create 3.0 4.0)
-    real sut |> should (equalWithin 0.000000001) -2.0
-    imaginary sut |> should (equalWithin 0.000000001) -2.0
+    real sut |> should (equalWithin 0.01) -2.0
+    imaginary sut |> should (equalWithin 0.01) -2.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Multiply purely real numbers`` () =
     let sut = mul (create 1.0 0.0) (create 2.0 0.0)
-    real sut |> should (equalWithin 0.000000001) 2.0
-    imaginary sut |> should (equalWithin 0.000000001) 0.0
+    real sut |> should (equalWithin 0.01) 2.0
+    imaginary sut |> should (equalWithin 0.01) 0.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Multiply purely imaginary numbers`` () =
     let sut = mul (create 0.0 1.0) (create 0.0 2.0)
-    real sut |> should (equalWithin 0.000000001) -2.0
-    imaginary sut |> should (equalWithin 0.000000001) 0.0
+    real sut |> should (equalWithin 0.01) -2.0
+    imaginary sut |> should (equalWithin 0.01) 0.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Multiply numbers with real and imaginary part`` () =
     let sut = mul (create 1.0 2.0) (create 3.0 4.0)
-    real sut |> should (equalWithin 0.000000001) -5.0
-    imaginary sut |> should (equalWithin 0.000000001) 10.0
+    real sut |> should (equalWithin 0.01) -5.0
+    imaginary sut |> should (equalWithin 0.01) 10.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Divide purely real numbers`` () =
     let sut = div (create 1.0 0.0) (create 2.0 0.0)
-    real sut |> should (equalWithin 0.000000001) 0.5
-    imaginary sut |> should (equalWithin 0.000000001) 0.0
+    real sut |> should (equalWithin 0.01) 0.5
+    imaginary sut |> should (equalWithin 0.01) 0.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Divide purely imaginary numbers`` () =
     let sut = div (create 0.0 1.0) (create 0.0 2.0)
-    real sut |> should (equalWithin 0.000000001) 0.5
-    imaginary sut |> should (equalWithin 0.000000001) 0.0
+    real sut |> should (equalWithin 0.01) 0.5
+    imaginary sut |> should (equalWithin 0.01) 0.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Divide numbers with real and imaginary part`` () =
     let sut = div (create 1.0 2.0) (create 3.0 4.0)
-    real sut |> should (equalWithin 0.000000001) 0.44
-    imaginary sut |> should (equalWithin 0.000000001) 0.08
+    real sut |> should (equalWithin 0.01) 0.44
+    imaginary sut |> should (equalWithin 0.01) 0.08
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Absolute value of a positive purely real number`` () =
@@ -133,42 +133,42 @@ let ``Absolute value of a number with real and imaginary part`` () =
 [<Fact(Skip = "Remove to run test")>]
 let ``Conjugate a purely real number`` () =
     let sut = conjugate (create 5.0 0.0)
-    real sut |> should (equalWithin 0.000000001) 5.0
-    imaginary sut |> should (equalWithin 0.000000001) 0.0
+    real sut |> should (equalWithin 0.01) 5.0
+    imaginary sut |> should (equalWithin 0.01) 0.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Conjugate a purely imaginary number`` () =
     let sut = conjugate (create 0.0 5.0)
-    real sut |> should (equalWithin 0.000000001) 0.0
-    imaginary sut |> should (equalWithin 0.000000001) -5.0
+    real sut |> should (equalWithin 0.01) 0.0
+    imaginary sut |> should (equalWithin 0.01) -5.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Conjugate a number with real and imaginary part`` () =
     let sut = conjugate (create 1.0 1.0)
-    real sut |> should (equalWithin 0.000000001) 1.0
-    imaginary sut |> should (equalWithin 0.000000001) -1.0
+    real sut |> should (equalWithin 0.01) 1.0
+    imaginary sut |> should (equalWithin 0.01) -1.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Euler's identity/formula`` () =
     let sut = exp (create 0.0 Math.PI)
-    real sut |> should (equalWithin 0.000000001) -1.0
-    imaginary sut |> should (equalWithin 0.000000001) 0.0
+    real sut |> should (equalWithin 0.01) -1.0
+    imaginary sut |> should (equalWithin 0.01) 0.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Exponential of 0`` () =
     let sut = exp (create 0.0 0.0)
-    real sut |> should (equalWithin 0.000000001) 1.0
-    imaginary sut |> should (equalWithin 0.000000001) 0.0
+    real sut |> should (equalWithin 0.01) 1.0
+    imaginary sut |> should (equalWithin 0.01) 0.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Exponential of a purely real number`` () =
     let sut = exp (create 1.0 0.0)
-    real sut |> should (equalWithin 0.000000001) Math.E
-    imaginary sut |> should (equalWithin 0.000000001) 0.0
+    real sut |> should (equalWithin 0.01) Math.E
+    imaginary sut |> should (equalWithin 0.01) 0.0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Exponential of a number with real and imaginary part`` () =
     let sut = exp (create (Math.Log(2.0)) Math.PI)
-    real sut |> should (equalWithin 0.000000001) -2.0
-    imaginary sut |> should (equalWithin 0.000000001) 0.0
+    real sut |> should (equalWithin 0.01) -2.0
+    imaginary sut |> should (equalWithin 0.01) 0.0
 

--- a/exercises/rational-numbers/RationalNumbersTest.fs
+++ b/exercises/rational-numbers/RationalNumbersTest.fs
@@ -117,15 +117,15 @@ let ``Raise a negative rational number to the power of zero`` () =
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Raise a real number to a positive rational number`` () =
-    expreal (create 4 3) 8 |> should (equalWithin 0.000000001) 16
+    expreal (create 4 3) 8 |> should (equalWithin 0.01) 16
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Raise a real number to a negative rational number`` () =
-    expreal (create -1 2) 9 |> should (equalWithin 0.000000001) 0.333333333333333
+    expreal (create -1 2) 9 |> should (equalWithin 0.01) 0.333333333333333
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Raise a real number to a zero rational number`` () =
-    expreal (create 0 1) 2 |> should (equalWithin 0.000000001) 1
+    expreal (create 0 1) 2 |> should (equalWithin 0.01) 1
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Reduce a positive rational number to lowest terms`` () =

--- a/exercises/space-age/SpaceAgeTest.fs
+++ b/exercises/space-age/SpaceAgeTest.fs
@@ -9,33 +9,33 @@ open SpaceAge
 
 [<Fact>]
 let ``Age on Earth`` () =
-    age Earth 1000000000L |> should equal 31.69
+    age Earth 1000000000L |> should (equalWithin 0.01) 31.69
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Age on Mercury`` () =
-    age Mercury 2134835688L |> should equal 280.88
+    age Mercury 2134835688L |> should (equalWithin 0.01) 280.88
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Age on Venus`` () =
-    age Venus 189839836L |> should equal 9.78
+    age Venus 189839836L |> should (equalWithin 0.01) 9.78
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Age on Mars`` () =
-    age Mars 2329871239L |> should equal 39.25
+    age Mars 2329871239L |> should (equalWithin 0.01) 39.25
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Age on Jupiter`` () =
-    age Jupiter 901876382L |> should equal 2.41
+    age Jupiter 901876382L |> should (equalWithin 0.01) 2.41
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Age on Saturn`` () =
-    age Saturn 3000000000L |> should equal 3.23
+    age Saturn 3000000000L |> should (equalWithin 0.01) 3.23
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Age on Uranus`` () =
-    age Uranus 3210123456L |> should equal 1.21
+    age Uranus 3210123456L |> should (equalWithin 0.01) 1.21
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Age on Neptune`` () =
-    age Neptune 8210123456L |> should equal 1.58
+    age Neptune 8210123456L |> should (equalWithin 0.01) 1.58
 

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -1336,6 +1336,8 @@ type SpaceAge() =
         | JTokenType.Integer -> sprintf "%dL" (value.ToObject<int64>())
         | _ -> base.RenderInput (canonicalDataCase, key, value)
 
+    override __.AssertTemplate _ = "AssertEqualWithin"
+
 type SpiralMatrix() =
     inherit GeneratorExercise()
 

--- a/generators/Templates/_AssertEqualWithin.liquid
+++ b/generators/Templates/_AssertEqualWithin.liquid
@@ -1,1 +1,1 @@
-{{ Sut }} |> should (equalWithin 0.000000001) {{ Expected }}
+{{ Sut }} |> should (equalWithin 0.01) {{ Expected }}


### PR DESCRIPTION
While mentoring some space-age solutions, I found that it sometimes failed due to a missing precision specifier. This PR adds a precision check and sets the existing ones to two decimals.

Closes #562.