### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -51,6 +51,7 @@
       "difficulty": 1,
       "topics": [
         "lists",
+        "math",
         "transforming"
       ]
     },
@@ -120,7 +121,7 @@
         "control_flow_conditionals",
         "control_flow_loops",
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -131,7 +132,7 @@
       "difficulty": 2,
       "topics": [
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -252,7 +253,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "integers"
+        "integers",
+        "math"
       ]
     },
     {
@@ -436,7 +438,7 @@
       "difficulty": 3,
       "topics": [
         "filtering",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -458,7 +460,8 @@
       "difficulty": 3,
       "topics": [
         "discriminated_unions",
-        "integers"
+        "integers",
+        "math"
       ]
     },
     {
@@ -579,6 +582,7 @@
       "difficulty": 4,
       "topics": [
         "integers",
+        "math",
         "transforming"
       ]
     },
@@ -590,6 +594,7 @@
       "difficulty": 4,
       "topics": [
         "integers",
+        "math",
         "strings",
         "transforming"
       ]
@@ -613,7 +618,7 @@
       "difficulty": 4,
       "topics": [
         "integers",
-        "mathematics",
+        "math",
         "records"
       ]
     },
@@ -636,7 +641,7 @@
       "difficulty": 4,
       "topics": [
         "lists",
-        "mathematics",
+        "math",
         "recursion"
       ]
     },
@@ -659,7 +664,7 @@
       "difficulty": 4,
       "topics": [
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -960,7 +965,7 @@
       "unlocked_by": "leap",
       "difficulty": 6,
       "topics": [
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -971,6 +976,7 @@
       "difficulty": 6,
       "topics": [
         "algorithms",
+        "math",
         "strings",
         "tuples"
       ]
@@ -982,7 +988,7 @@
       "unlocked_by": "leap",
       "difficulty": 6,
       "topics": [
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -992,7 +998,7 @@
       "unlocked_by": "leap",
       "difficulty": 6,
       "topics": [
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -1060,6 +1066,7 @@
       "topics": [
         "algorithms",
         "integers",
+        "math",
         "transforming"
       ]
     },


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110