### PR TITLE
The nucleotideCounts function signature does not match the unit tests…

### DIFF
--- a/exercises/nucleotide-count/NucleotideCount.fs
+++ b/exercises/nucleotide-count/NucleotideCount.fs
@@ -1,3 +1,3 @@
 ﻿module NucleotideCount
 
-let nucleotideCounts (strand: string): Map<char, int> =  failwith "You need to implement this function."
+let nucleotideCounts (strand: string): Option<Map<char, int>> =  failwith "You need to implement this function."


### PR DESCRIPTION
The nucleotideCounts function signature does not match the unit tests.  Added the Option type to wrap the Map.