### PR TITLE
Convert Yacht exercise to use discriminated union for dice values (closes #577)

### DIFF
--- a/exercises/yacht/Example.fs
+++ b/exercises/yacht/Example.fs
@@ -14,6 +14,21 @@ type Category =
     | Choice
     | Yacht
 
+type DieValue =
+    | One 
+    | Two 
+    | Three
+    | Four 
+    | Five 
+    | Six
+    static member eval = function
+        | One -> 1 
+        | Two -> 2 
+        | Three -> 3
+        | Four -> 4 
+        | Five -> 5 
+        | Six -> 6
+
 let private diceWithCount dice = 
     dice
     |> List.countBy id
@@ -24,39 +39,39 @@ let private valueScore value dice =
         dice 
         |> List.filter ((=) value) 
         |> List.length 
-    count * value
+    count * (DieValue.eval value)
 
 let private fullHouseScore dice =
     match diceWithCount dice with
-    | [(_, 3); (_, 2)] -> List.sum dice
+    | [(_, 3); (_, 2)] -> (List.sumBy DieValue.eval dice)
     | _ -> 0
 
 let private fourOfAKindScore dice =
     match diceWithCount dice with
-    | [(value, 4); _] -> value * 4
-    | [(value, 5)]    -> value * 4
+    | [(d, 4); _] -> (DieValue.eval d) * 4
+    | [(d, 5)]    -> (DieValue.eval d) * 4
     | _ -> 0
 
 let private littleStraightScore dice =
-    if List.sort dice = [1; 2; 3; 4; 5] then 30 else 0
+    if List.sort dice = [One; Two; Three; Four; Five] then 30 else 0
 
 let private bigStraightScore dice =
-    if List.sort dice = [2; 3; 4; 5; 6] then 30 else 0
+    if List.sort dice = [Two; Three; Four; Five; Six] then 30 else 0
 
 let private choiceScore dice = 
-    List.sum dice
+    List.sumBy DieValue.eval dice 
 
 let private yachtScore dice = 
     if dice |> List.distinct |> List.length = 1 then 50 else 0
 
 let score category dice = 
     match category with
-    | Ones           -> valueScore 1 dice
-    | Twos           -> valueScore 2 dice
-    | Threes         -> valueScore 3 dice
-    | Fours          -> valueScore 4 dice
-    | Fives          -> valueScore 5 dice
-    | Sixes          -> valueScore 6 dice
+    | Ones           -> valueScore One dice
+    | Twos           -> valueScore Two dice
+    | Threes         -> valueScore Three dice
+    | Fours          -> valueScore Four dice
+    | Fives          -> valueScore Five dice
+    | Sixes          -> valueScore Six dice
     | FullHouse      -> fullHouseScore dice
     | FourOfAKind    -> fourOfAKindScore dice
     | LittleStraight -> littleStraightScore dice

--- a/exercises/yacht/Example.fs
+++ b/exercises/yacht/Example.fs
@@ -14,7 +14,7 @@ type Category =
     | Choice
     | Yacht
 
-type DieValue =
+type Die =
     | One 
     | Two 
     | Three
@@ -39,17 +39,17 @@ let private valueScore value dice =
         dice 
         |> List.filter ((=) value) 
         |> List.length 
-    count * (DieValue.eval value)
+    count * (Die.eval value)
 
 let private fullHouseScore dice =
     match diceWithCount dice with
-    | [(_, 3); (_, 2)] -> (List.sumBy DieValue.eval dice)
+    | [(_, 3); (_, 2)] -> (List.sumBy Die.eval dice)
     | _ -> 0
 
 let private fourOfAKindScore dice =
     match diceWithCount dice with
-    | [(d, 4); _] -> (DieValue.eval d) * 4
-    | [(d, 5)]    -> (DieValue.eval d) * 4
+    | [(d, 4); _] -> (Die.eval d) * 4
+    | [(d, 5)]    -> (Die.eval d) * 4
     | _ -> 0
 
 let private littleStraightScore dice =
@@ -59,7 +59,7 @@ let private bigStraightScore dice =
     if List.sort dice = [Two; Three; Four; Five; Six] then 30 else 0
 
 let private choiceScore dice = 
-    List.sumBy DieValue.eval dice 
+    List.sumBy Die.eval dice 
 
 let private yachtScore dice = 
     if dice |> List.distinct |> List.length = 1 then 50 else 0

--- a/exercises/yacht/Yacht.fs
+++ b/exercises/yacht/Yacht.fs
@@ -14,4 +14,12 @@ type Category =
     | Choice
     | Yacht
 
+type DieValue =
+    | One 
+    | Two 
+    | Three
+    | Four 
+    | Five 
+    | Six
+
 let score category dice = failwith "You need to implement this function."

--- a/exercises/yacht/Yacht.fs
+++ b/exercises/yacht/Yacht.fs
@@ -14,7 +14,7 @@ type Category =
     | Choice
     | Yacht
 
-type DieValue =
+type Die =
     | One 
     | Two 
     | Three

--- a/exercises/yacht/YachtTest.fs
+++ b/exercises/yacht/YachtTest.fs
@@ -9,109 +9,109 @@ open Yacht
 
 [<Fact>]
 let ``Yacht`` () =
-    score Category.Yacht [DieValue.Five; DieValue.Five; DieValue.Five; DieValue.Five; DieValue.Five] |> should equal 50
+    score Category.Yacht [Die.Five; Die.Five; Die.Five; Die.Five; Die.Five] |> should equal 50
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Not Yacht`` () =
-    score Category.Yacht [DieValue.One; DieValue.Three; DieValue.Three; DieValue.Two; DieValue.Five] |> should equal 0
+    score Category.Yacht [Die.One; Die.Three; Die.Three; Die.Two; Die.Five] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Ones`` () =
-    score Category.Ones [DieValue.One; DieValue.One; DieValue.One; DieValue.Three; DieValue.Five] |> should equal 3
+    score Category.Ones [Die.One; Die.One; Die.One; Die.Three; Die.Five] |> should equal 3
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Ones, out of order`` () =
-    score Category.Ones [DieValue.Three; DieValue.One; DieValue.One; DieValue.Five; DieValue.One] |> should equal 3
+    score Category.Ones [Die.Three; Die.One; Die.One; Die.Five; Die.One] |> should equal 3
 
 [<Fact(Skip = "Remove to run test")>]
 let ``No ones`` () =
-    score Category.Ones [DieValue.Four; DieValue.Three; DieValue.Six; DieValue.Five; DieValue.Five] |> should equal 0
+    score Category.Ones [Die.Four; Die.Three; Die.Six; Die.Five; Die.Five] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Twos`` () =
-    score Category.Twos [DieValue.Two; DieValue.Three; DieValue.Four; DieValue.Five; DieValue.Six] |> should equal 2
+    score Category.Twos [Die.Two; Die.Three; Die.Four; Die.Five; Die.Six] |> should equal 2
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Fours`` () =
-    score Category.Fours [DieValue.One; DieValue.Four; DieValue.One; DieValue.Four; DieValue.One] |> should equal 8
+    score Category.Fours [Die.One; Die.Four; Die.One; Die.Four; Die.One] |> should equal 8
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Yacht counted as threes`` () =
-    score Category.Threes [DieValue.Three; DieValue.Three; DieValue.Three; DieValue.Three; DieValue.Three] |> should equal 15
+    score Category.Threes [Die.Three; Die.Three; Die.Three; Die.Three; Die.Three] |> should equal 15
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Yacht of 3s counted as fives`` () =
-    score Category.Fives [DieValue.Three; DieValue.Three; DieValue.Three; DieValue.Three; DieValue.Three] |> should equal 0
+    score Category.Fives [Die.Three; Die.Three; Die.Three; Die.Three; Die.Three] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Sixes`` () =
-    score Category.Sixes [DieValue.Two; DieValue.Three; DieValue.Four; DieValue.Five; DieValue.Six] |> should equal 6
+    score Category.Sixes [Die.Two; Die.Three; Die.Four; Die.Five; Die.Six] |> should equal 6
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Full house two small, three big`` () =
-    score Category.FullHouse [DieValue.Two; DieValue.Two; DieValue.Four; DieValue.Four; DieValue.Four] |> should equal 16
+    score Category.FullHouse [Die.Two; Die.Two; Die.Four; Die.Four; Die.Four] |> should equal 16
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Full house three small, two big`` () =
-    score Category.FullHouse [DieValue.Five; DieValue.Three; DieValue.Three; DieValue.Five; DieValue.Three] |> should equal 19
+    score Category.FullHouse [Die.Five; Die.Three; Die.Three; Die.Five; Die.Three] |> should equal 19
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Two pair is not a full house`` () =
-    score Category.FullHouse [DieValue.Two; DieValue.Two; DieValue.Four; DieValue.Four; DieValue.Five] |> should equal 0
+    score Category.FullHouse [Die.Two; Die.Two; Die.Four; Die.Four; Die.Five] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Four of a kind is not a full house`` () =
-    score Category.FullHouse [DieValue.One; DieValue.Four; DieValue.Four; DieValue.Four; DieValue.Four] |> should equal 0
+    score Category.FullHouse [Die.One; Die.Four; Die.Four; Die.Four; Die.Four] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Yacht is not a full house`` () =
-    score Category.FullHouse [DieValue.Two; DieValue.Two; DieValue.Two; DieValue.Two; DieValue.Two] |> should equal 0
+    score Category.FullHouse [Die.Two; Die.Two; Die.Two; Die.Two; Die.Two] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Four of a Kind`` () =
-    score Category.FourOfAKind [DieValue.Six; DieValue.Six; DieValue.Four; DieValue.Six; DieValue.Six] |> should equal 24
+    score Category.FourOfAKind [Die.Six; Die.Six; Die.Four; Die.Six; Die.Six] |> should equal 24
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Yacht can be scored as Four of a Kind`` () =
-    score Category.FourOfAKind [DieValue.Three; DieValue.Three; DieValue.Three; DieValue.Three; DieValue.Three] |> should equal 12
+    score Category.FourOfAKind [Die.Three; Die.Three; Die.Three; Die.Three; Die.Three] |> should equal 12
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Full house is not Four of a Kind`` () =
-    score Category.FourOfAKind [DieValue.Three; DieValue.Three; DieValue.Three; DieValue.Five; DieValue.Five] |> should equal 0
+    score Category.FourOfAKind [Die.Three; Die.Three; Die.Three; Die.Five; Die.Five] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Little Straight`` () =
-    score Category.LittleStraight [DieValue.Three; DieValue.Five; DieValue.Four; DieValue.One; DieValue.Two] |> should equal 30
+    score Category.LittleStraight [Die.Three; Die.Five; Die.Four; Die.One; Die.Two] |> should equal 30
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Little Straight as Big Straight`` () =
-    score Category.BigStraight [DieValue.One; DieValue.Two; DieValue.Three; DieValue.Four; DieValue.Five] |> should equal 0
+    score Category.BigStraight [Die.One; Die.Two; Die.Three; Die.Four; Die.Five] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Four in order but not a little straight`` () =
-    score Category.LittleStraight [DieValue.One; DieValue.One; DieValue.Two; DieValue.Three; DieValue.Four] |> should equal 0
+    score Category.LittleStraight [Die.One; Die.One; Die.Two; Die.Three; Die.Four] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``No pairs but not a little straight`` () =
-    score Category.LittleStraight [DieValue.One; DieValue.Two; DieValue.Three; DieValue.Four; DieValue.Six] |> should equal 0
+    score Category.LittleStraight [Die.One; Die.Two; Die.Three; Die.Four; Die.Six] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Minimum is 1, maximum is 5, but not a little straight`` () =
-    score Category.LittleStraight [DieValue.One; DieValue.One; DieValue.Three; DieValue.Four; DieValue.Five] |> should equal 0
+    score Category.LittleStraight [Die.One; Die.One; Die.Three; Die.Four; Die.Five] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Big Straight`` () =
-    score Category.BigStraight [DieValue.Four; DieValue.Six; DieValue.Two; DieValue.Five; DieValue.Three] |> should equal 30
+    score Category.BigStraight [Die.Four; Die.Six; Die.Two; Die.Five; Die.Three] |> should equal 30
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Big Straight as little straight`` () =
-    score Category.LittleStraight [DieValue.Six; DieValue.Five; DieValue.Four; DieValue.Three; DieValue.Two] |> should equal 0
+    score Category.LittleStraight [Die.Six; Die.Five; Die.Four; Die.Three; Die.Two] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Choice`` () =
-    score Category.Choice [DieValue.Three; DieValue.Three; DieValue.Five; DieValue.Six; DieValue.Six] |> should equal 23
+    score Category.Choice [Die.Three; Die.Three; Die.Five; Die.Six; Die.Six] |> should equal 23
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Yacht as choice`` () =
-    score Category.Choice [DieValue.Two; DieValue.Two; DieValue.Two; DieValue.Two; DieValue.Two] |> should equal 10
+    score Category.Choice [Die.Two; Die.Two; Die.Two; Die.Two; Die.Two] |> should equal 10
 

--- a/exercises/yacht/YachtTest.fs
+++ b/exercises/yacht/YachtTest.fs
@@ -9,109 +9,109 @@ open Yacht
 
 [<Fact>]
 let ``Yacht`` () =
-    score Category.Yacht [5; 5; 5; 5; 5] |> should equal 50
+    score Category.Yacht [DieValue.Five; DieValue.Five; DieValue.Five; DieValue.Five; DieValue.Five] |> should equal 50
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Not Yacht`` () =
-    score Category.Yacht [1; 3; 3; 2; 5] |> should equal 0
+    score Category.Yacht [DieValue.One; DieValue.Three; DieValue.Three; DieValue.Two; DieValue.Five] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Ones`` () =
-    score Category.Ones [1; 1; 1; 3; 5] |> should equal 3
+    score Category.Ones [DieValue.One; DieValue.One; DieValue.One; DieValue.Three; DieValue.Five] |> should equal 3
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Ones, out of order`` () =
-    score Category.Ones [3; 1; 1; 5; 1] |> should equal 3
+    score Category.Ones [DieValue.Three; DieValue.One; DieValue.One; DieValue.Five; DieValue.One] |> should equal 3
 
 [<Fact(Skip = "Remove to run test")>]
 let ``No ones`` () =
-    score Category.Ones [4; 3; 6; 5; 5] |> should equal 0
+    score Category.Ones [DieValue.Four; DieValue.Three; DieValue.Six; DieValue.Five; DieValue.Five] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Twos`` () =
-    score Category.Twos [2; 3; 4; 5; 6] |> should equal 2
+    score Category.Twos [DieValue.Two; DieValue.Three; DieValue.Four; DieValue.Five; DieValue.Six] |> should equal 2
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Fours`` () =
-    score Category.Fours [1; 4; 1; 4; 1] |> should equal 8
+    score Category.Fours [DieValue.One; DieValue.Four; DieValue.One; DieValue.Four; DieValue.One] |> should equal 8
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Yacht counted as threes`` () =
-    score Category.Threes [3; 3; 3; 3; 3] |> should equal 15
+    score Category.Threes [DieValue.Three; DieValue.Three; DieValue.Three; DieValue.Three; DieValue.Three] |> should equal 15
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Yacht of 3s counted as fives`` () =
-    score Category.Fives [3; 3; 3; 3; 3] |> should equal 0
+    score Category.Fives [DieValue.Three; DieValue.Three; DieValue.Three; DieValue.Three; DieValue.Three] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Sixes`` () =
-    score Category.Sixes [2; 3; 4; 5; 6] |> should equal 6
+    score Category.Sixes [DieValue.Two; DieValue.Three; DieValue.Four; DieValue.Five; DieValue.Six] |> should equal 6
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Full house two small, three big`` () =
-    score Category.FullHouse [2; 2; 4; 4; 4] |> should equal 16
+    score Category.FullHouse [DieValue.Two; DieValue.Two; DieValue.Four; DieValue.Four; DieValue.Four] |> should equal 16
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Full house three small, two big`` () =
-    score Category.FullHouse [5; 3; 3; 5; 3] |> should equal 19
+    score Category.FullHouse [DieValue.Five; DieValue.Three; DieValue.Three; DieValue.Five; DieValue.Three] |> should equal 19
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Two pair is not a full house`` () =
-    score Category.FullHouse [2; 2; 4; 4; 5] |> should equal 0
+    score Category.FullHouse [DieValue.Two; DieValue.Two; DieValue.Four; DieValue.Four; DieValue.Five] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Four of a kind is not a full house`` () =
-    score Category.FullHouse [1; 4; 4; 4; 4] |> should equal 0
+    score Category.FullHouse [DieValue.One; DieValue.Four; DieValue.Four; DieValue.Four; DieValue.Four] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Yacht is not a full house`` () =
-    score Category.FullHouse [2; 2; 2; 2; 2] |> should equal 0
+    score Category.FullHouse [DieValue.Two; DieValue.Two; DieValue.Two; DieValue.Two; DieValue.Two] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Four of a Kind`` () =
-    score Category.FourOfAKind [6; 6; 4; 6; 6] |> should equal 24
+    score Category.FourOfAKind [DieValue.Six; DieValue.Six; DieValue.Four; DieValue.Six; DieValue.Six] |> should equal 24
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Yacht can be scored as Four of a Kind`` () =
-    score Category.FourOfAKind [3; 3; 3; 3; 3] |> should equal 12
+    score Category.FourOfAKind [DieValue.Three; DieValue.Three; DieValue.Three; DieValue.Three; DieValue.Three] |> should equal 12
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Full house is not Four of a Kind`` () =
-    score Category.FourOfAKind [3; 3; 3; 5; 5] |> should equal 0
+    score Category.FourOfAKind [DieValue.Three; DieValue.Three; DieValue.Three; DieValue.Five; DieValue.Five] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Little Straight`` () =
-    score Category.LittleStraight [3; 5; 4; 1; 2] |> should equal 30
+    score Category.LittleStraight [DieValue.Three; DieValue.Five; DieValue.Four; DieValue.One; DieValue.Two] |> should equal 30
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Little Straight as Big Straight`` () =
-    score Category.BigStraight [1; 2; 3; 4; 5] |> should equal 0
+    score Category.BigStraight [DieValue.One; DieValue.Two; DieValue.Three; DieValue.Four; DieValue.Five] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Four in order but not a little straight`` () =
-    score Category.LittleStraight [1; 1; 2; 3; 4] |> should equal 0
+    score Category.LittleStraight [DieValue.One; DieValue.One; DieValue.Two; DieValue.Three; DieValue.Four] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``No pairs but not a little straight`` () =
-    score Category.LittleStraight [1; 2; 3; 4; 6] |> should equal 0
+    score Category.LittleStraight [DieValue.One; DieValue.Two; DieValue.Three; DieValue.Four; DieValue.Six] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Minimum is 1, maximum is 5, but not a little straight`` () =
-    score Category.LittleStraight [1; 1; 3; 4; 5] |> should equal 0
+    score Category.LittleStraight [DieValue.One; DieValue.One; DieValue.Three; DieValue.Four; DieValue.Five] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Big Straight`` () =
-    score Category.BigStraight [4; 6; 2; 5; 3] |> should equal 30
+    score Category.BigStraight [DieValue.Four; DieValue.Six; DieValue.Two; DieValue.Five; DieValue.Three] |> should equal 30
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Big Straight as little straight`` () =
-    score Category.LittleStraight [6; 5; 4; 3; 2] |> should equal 0
+    score Category.LittleStraight [DieValue.Six; DieValue.Five; DieValue.Four; DieValue.Three; DieValue.Two] |> should equal 0
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Choice`` () =
-    score Category.Choice [3; 3; 5; 6; 6] |> should equal 23
+    score Category.Choice [DieValue.Three; DieValue.Three; DieValue.Five; DieValue.Six; DieValue.Six] |> should equal 23
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Yacht as choice`` () =
-    score Category.Choice [2; 2; 2; 2; 2] |> should equal 10
+    score Category.Choice [DieValue.Two; DieValue.Two; DieValue.Two; DieValue.Two; DieValue.Two] |> should equal 10
 

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -1509,7 +1509,7 @@ type Yacht() =
         let listValues = 
             value.ToObject<int list>()
             |> List.map dieValueToEnumName
-            |> List.map (Obj.renderEnum "DieValue")
+            |> List.map (Obj.renderEnum "Die")
             |> String.concat "; "
         in
         "[" + listValues + "]"

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -1496,9 +1496,27 @@ type Wordy() =
 type Yacht() =
     inherit GeneratorExercise()
 
+    let dieValueToEnumName = function
+        | 1 -> "One"
+        | 2 -> "Two"
+        | 3 -> "Three"
+        | 4 -> "Four"
+        | 5 -> "Five"
+        | 6 -> "Six"
+        | n -> failwith ("Invalid die value: " + n.ToString())
+
+    let formatDieList (value: JToken) =
+        let listValues = 
+            value.ToObject<int list>()
+            |> List.map dieValueToEnumName
+            |> List.map (Obj.renderEnum "DieValue")
+            |> String.concat "; "
+        in
+        "[" + listValues + "]"
     override __.RenderInput (canonicalDataCase, key, value) =
         match key with
         | "category" -> Obj.renderEnum "Category" value
+        | "dice" -> formatDieList value
         | _ -> base.RenderInput (canonicalDataCase, key, value)
 
 type ZebraPuzzle() =

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -1496,27 +1496,19 @@ type Wordy() =
 type Yacht() =
     inherit GeneratorExercise()
 
-    let dieValueToEnumName = function
-        | 1 -> "One"
-        | 2 -> "Two"
-        | 3 -> "Three"
-        | 4 -> "Four"
-        | 5 -> "Five"
-        | 6 -> "Six"
+    let renderDieEnum = function
+        | 1 -> "Die.One"
+        | 2 -> "Die.Two"
+        | 3 -> "Die.Three"
+        | 4 -> "Die.Four"
+        | 5 -> "Die.Five"
+        | 6 -> "Die.Six"
         | n -> failwith ("Invalid die value: " + n.ToString())
 
-    let formatDieList (value: JToken) =
-        let listValues = 
-            value.ToObject<int list>()
-            |> List.map dieValueToEnumName
-            |> List.map (Obj.renderEnum "Die")
-            |> String.concat "; "
-        in
-        "[" + listValues + "]"
     override __.RenderInput (canonicalDataCase, key, value) =
         match key with
         | "category" -> Obj.renderEnum "Category" value
-        | "dice" -> formatDieList value
+        | "dice" -> List.mapRender renderDieEnum (value.ToObject<int list>())
         | _ -> base.RenderInput (canonicalDataCase, key, value)
 
 type ZebraPuzzle() =


### PR DESCRIPTION
Closes #577 by converting the Yacht exercise to use a discriminated union (strictly 1 through 6) for dice values instead of integers (which are more-or-less unbounded and thus can have invalid dice values).