### PR TITLE
Removed generic types from accumulate function.

### DIFF
--- a/exercises/accumulate/Accumulate.fs
+++ b/exercises/accumulate/Accumulate.fs
@@ -1,3 +1,3 @@
 ﻿module Accumulate
 
-let accumulate<'a, 'b> (func: 'a -> 'b) (input: 'a list): 'b list = failwith "You need to implement this function."
+let accumulate (func: 'a -> 'b) (input: 'a list): 'b list = failwith "You need to implement this function."


### PR DESCRIPTION
@ErikSchierboom Here is a PR that removes the `<'a, 'b>` generic types from the `accumulate` function, as discussed on Slack.