### PR TITLE
generator: fail when no exercises matched the given options

### DIFF
--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -49,6 +49,9 @@ let private regenerateTestClasses options =
     
     createExercises options
     |> List.filter (shouldBeIncluded options)
+    |> (function
+        | [] -> failwith "no exercises matched given options"
+        | x -> x )
     |> List.iter regenerateTestClass'
 
     Log.Information("Re-generated test classes.")

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -51,8 +51,8 @@ let private regenerateTestClasses options =
     |> List.filter (shouldBeIncluded options)
     |> function
         | [] -> Log.Error "No exercises matched given options."
-        | x ->
-            List.iter regenerateTestClass' x
+        | exercises ->
+            List.iter regenerateTestClass' exercises
             Log.Information("Re-generated test classes.")
 
 [<EntryPoint>]

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -50,7 +50,7 @@ let private regenerateTestClasses options =
     createExercises options
     |> List.filter (shouldBeIncluded options)
     |> function
-        | [] -> Log.Error "No exercises matched given options."
+        | [] -> Log.Warning"No exercises matched given options."
         | exercises ->
             List.iter regenerateTestClass' exercises
             Log.Information("Re-generated test classes.")

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -49,12 +49,11 @@ let private regenerateTestClasses options =
     
     createExercises options
     |> List.filter (shouldBeIncluded options)
-    |> (function
-        | [] -> failwith "no exercises matched given options"
-        | x -> x )
-    |> List.iter regenerateTestClass'
-
-    Log.Information("Re-generated test classes.")
+    |> function
+        | [] -> Log.Error "No exercises matched given options."
+        | x ->
+            List.iter regenerateTestClass' x
+            Log.Information("Re-generated test classes.")
 
 [<EntryPoint>]
 let main argv = 


### PR DESCRIPTION
Here's an extremely simple solution to https://github.com/exercism/fsharp/issues/621

I don't know if anyone or anything was relying on the existing _generate-nothing-and-throw-no-errors_ behavior, but thought I'd start the discussion and try to improve the experience for other people that land here via Hacktoberfest. I'm totally open to other, better ways of improving this!