### PR TITLE
Generator lists outdated exercises

### DIFF
--- a/generators/Exercise.fs
+++ b/generators/Exercise.fs
@@ -57,9 +57,18 @@ type GeneratorExercise() =
         |> this.MapCanonicalData
         |> this.Render  
         |> this.WriteToFile
+        
+    member this.ReadVersion () =
+        let testFilePath = Path.Combine("..", "exercises", this.Name, sprintf "%s.fs" this.TestModuleName)
+        // todo: handle absent test
+        
+        // This file was auto-generated based on version 1.2.0 of the canonical data.
+        let line = (File.ReadLines testFilePath) |> Seq.head
+        let isNum c = c >= '0' && c <= '9'
+        let version = line |> String.split " " |> Seq.find (fun s -> s.[0] |> isNum) 
+        version
 
     // Allow changes in canonical data    
-
     member this.MapCanonicalData canonicalData = 
         { canonicalData with Cases = List.map this.MapCanonicalDataCase canonicalData.Cases }
 

--- a/generators/Exercise.fs
+++ b/generators/Exercise.fs
@@ -76,7 +76,7 @@ type GeneratorExercise() =
         |> Seq.find (fun s -> s.[0] |> isNum)
 
     // Allow changes in canonical data    
-    
+
     member this.MapCanonicalData canonicalData = 
         { canonicalData with Cases = List.map this.MapCanonicalDataCase canonicalData.Cases }
 

--- a/generators/Exercise.fs
+++ b/generators/Exercise.fs
@@ -76,6 +76,7 @@ type GeneratorExercise() =
         |> Seq.find (fun s -> s.[0] |> isNum)
 
     // Allow changes in canonical data    
+    
     member this.MapCanonicalData canonicalData = 
         { canonicalData with Cases = List.map this.MapCanonicalDataCase canonicalData.Cases }
 

--- a/generators/Exercise.fs
+++ b/generators/Exercise.fs
@@ -67,13 +67,12 @@ type GeneratorExercise() =
             Read from the top of the file e.g.
             "// This file was auto-generated based on version 1.2.0 of the canonical data."
         *)
-        let isNum c = c >= '0' && c <= '9'
         
         this.TestFilePath ()
         |> File.ReadLines
         |> Seq.head
         |> String.split " "
-        |> Seq.find (fun s -> s.[0] |> isNum)
+        |> Seq.find (fun s -> s.[0] |> System.Char.IsDigit)
 
     // Allow changes in canonical data    
 

--- a/generators/Exercise.fs
+++ b/generators/Exercise.fs
@@ -46,8 +46,12 @@ type GeneratorExercise() =
     member this.TestModuleName = this.GetType().Name.Pascalize() |> sprintf "%sTest"
     member this.TestedModuleName = this.GetType().Name.Pascalize()
 
+        
+    member this.TestFilePath () =
+        Path.Combine("..", "exercises", this.Name, sprintf "%s.fs" this.TestModuleName)
+        
     member this.WriteToFile contents =
-        let testFilePath = Path.Combine("..", "exercises", this.Name, sprintf "%s.fs" this.TestModuleName)
+        let testFilePath = this.TestFilePath ()
 
         Directory.CreateDirectory(Path.GetDirectoryName(testFilePath)) |> ignore
         File.WriteAllText(testFilePath, contents)
@@ -59,14 +63,17 @@ type GeneratorExercise() =
         |> this.WriteToFile
         
     member this.ReadVersion () =
-        let testFilePath = Path.Combine("..", "exercises", this.Name, sprintf "%s.fs" this.TestModuleName)
-        // todo: handle absent test
-        
-        // This file was auto-generated based on version 1.2.0 of the canonical data.
-        let line = (File.ReadLines testFilePath) |> Seq.head
+        (*
+            Read from the top of the file e.g.
+            "// This file was auto-generated based on version 1.2.0 of the canonical data."
+        *)
         let isNum c = c >= '0' && c <= '9'
-        let version = line |> String.split " " |> Seq.find (fun s -> s.[0] |> isNum) 
-        version
+        
+        this.TestFilePath ()
+        |> File.ReadLines
+        |> Seq.head
+        |> String.split " "
+        |> Seq.find (fun s -> s.[0] |> isNum)
 
     // Allow changes in canonical data    
     member this.MapCanonicalData canonicalData = 

--- a/generators/Generators.fsproj
+++ b/generators/Generators.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="Templates.fs" />
     <Compile Include="Exercise.fs" />
     <Compile Include="Generators.fs" />
+    <Compile Include="Reporting.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/generators/Generators.fsproj
+++ b/generators/Generators.fsproj
@@ -28,4 +28,18 @@
     <PackageReference Include="serilog.sinks.literate" Version="3.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="Templates\Generators\_GrepSetup.liquid" />
+    <Content Include="Templates\_AssertEmpty.liquid" />
+    <Content Include="Templates\_AssertEqual.liquid" />
+    <Content Include="Templates\_AssertEqualWithin.liquid" />
+    <Content Include="Templates\_AssertThrows.liquid" />
+    <Content Include="Templates\_TestClass.liquid" />
+    <Content Include="Templates\_TestFunction.liquid" />
+    <Content Include="Templates\_TestFunctionBody.liquid" />
+    <Content Include="Templates\_TestMember.liquid" />
+    <Content Include="Templates\_TestMemberBody.liquid" />
+    <Content Include="Templates\_TestModule.liquid" />
+  </ItemGroup>
+
 </Project>

--- a/generators/Generators.fsproj
+++ b/generators/Generators.fsproj
@@ -28,18 +28,4 @@
     <PackageReference Include="serilog.sinks.literate" Version="3.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="Templates\Generators\_GrepSetup.liquid" />
-    <Content Include="Templates\_AssertEmpty.liquid" />
-    <Content Include="Templates\_AssertEqual.liquid" />
-    <Content Include="Templates\_AssertEqualWithin.liquid" />
-    <Content Include="Templates\_AssertThrows.liquid" />
-    <Content Include="Templates\_TestClass.liquid" />
-    <Content Include="Templates\_TestFunction.liquid" />
-    <Content Include="Templates\_TestFunctionBody.liquid" />
-    <Content Include="Templates\_TestMember.liquid" />
-    <Content Include="Templates\_TestMemberBody.liquid" />
-    <Content Include="Templates\_TestModule.liquid" />
-  </ItemGroup>
-
 </Project>

--- a/generators/Options.fs
+++ b/generators/Options.fs
@@ -68,7 +68,7 @@ let private normalizeStatus status =
     | Some "deprecated"    -> Some Deprecated
     | Some "all"           -> None
     | Some _               -> failwith "Invalid status" 
-    | None                 -> Some Implemented
+    | None                 -> None
 
 let private mapOptions (options: CommandLineOptions) =
     { Exercise = normalizeExercise options.Exercise
@@ -84,8 +84,6 @@ let conflictingStatusAndExerciseParams (parsed:Parsed<CommandLineOptions>) =
 let parseOptions argv =  
     let result = CommandLine.Parser.Default.ParseArguments<CommandLineOptions>(argv)
     match result with
-    | :? Parsed<CommandLineOptions> as parsed when parsed |> conflictingStatusAndExerciseParams ->  
-        Result.Error(["Cannot have both -e and -s"] |> Seq.ofList)
     | :? Parsed<CommandLineOptions> as parsed -> 
         Result.Ok(mapOptions parsed.Value)
     | :? NotParsed<CommandLineOptions> as notParsed -> 

--- a/generators/Options.fs
+++ b/generators/Options.fs
@@ -19,13 +19,16 @@ type CommandLineOptions =
       [<Option('d', "canonicaldatadirectory", Required = false, 
         HelpText = "Canonical data directory. If the directory does not exist, the canonical data will be downloaded.")>] CanonicalDataDirectory : string;
       [<Option('c', "cachecanonicaldata", Required = false,
-        HelpText = "Use the cached canonical data and don't update the data.")>] CacheCanonicalData : bool; }
+        HelpText = "Use the cached canonical data and don't update the data.")>] CacheCanonicalData : bool; 
+      [<Option('o', "outdated", Required = false,
+        HelpText = "Check for outdated exercises")>] CheckOutdated: bool; }
 
 type Options =
     { Exercise : string option
       Status : Status option
       CanonicalDataDirectory : string
-      CacheCanonicalData : bool }
+      CacheCanonicalData : bool
+      CheckOutdated: bool }
 
 let private normalizeCanonicalDataDirectory canonicalDataDirectory = 
     if not (String.IsNullOrWhiteSpace(canonicalDataDirectory)) then
@@ -57,7 +60,8 @@ let private mapOptions (options: CommandLineOptions) =
     { Exercise = normalizeExercise options.Exercise
       Status = normalizeStatus options.Status
       CanonicalDataDirectory = normalizeCanonicalDataDirectory options.CanonicalDataDirectory
-      CacheCanonicalData = options.CacheCanonicalData }
+      CacheCanonicalData = options.CacheCanonicalData
+      CheckOutdated = options.CheckOutdated }
 
 let parseOptions argv =  
     let result = CommandLine.Parser.Default.ParseArguments<CommandLineOptions>(argv)

--- a/generators/Options.fs
+++ b/generators/Options.fs
@@ -12,6 +12,7 @@ type Status =
     | Deprecated
     | Custom
     | Outdated
+    | All
 
 type CommandLineOptions =
     { [<Option('e', "exercise", Required = false, 
@@ -68,7 +69,7 @@ let private normalizeStatus status =
     | Some "custom"        -> Some Custom
     | Some "deprecated"    -> Some Deprecated
     | Some "outdated"      -> Some Outdated
-    | Some "all"           -> None
+    | Some "all"           -> Some All
     | Some _               -> failwith "Invalid status" 
     | None                 -> None
 

--- a/generators/Options.fs
+++ b/generators/Options.fs
@@ -80,9 +80,9 @@ let private mapOptions (options: CommandLineOptions) =
       CacheCanonicalData = options.CacheCanonicalData }
 
 let conflictingStatusAndExerciseParams (parsed:Parsed<CommandLineOptions>) =
-    let s = parsed.Value.Status |> String.IsNullOrWhiteSpace |> not
-    let e = parsed.Value.Exercise |> String.IsNullOrWhiteSpace |> not
-    s && e
+    let statusParameterSpecified = parsed.Value.Status |> String.IsNullOrWhiteSpace |> not
+    let exerciseParameterSpecified = parsed.Value.Exercise |> String.IsNullOrWhiteSpace |> not
+    statusParameterSpecified && exerciseParameterSpecified
     
 let parseOptions argv =  
     let result = CommandLine.Parser.Default.ParseArguments<CommandLineOptions>(argv)

--- a/generators/Options.fs
+++ b/generators/Options.fs
@@ -11,6 +11,7 @@ type Status =
     | MissingData
     | Deprecated
     | Custom
+    | Outdated
 
 type CommandLineOptions =
     { [<Option('e', "exercise", Required = false, 
@@ -66,6 +67,7 @@ let private normalizeStatus status =
     | Some "missingdata"   -> Some MissingData
     | Some "custom"        -> Some Custom
     | Some "deprecated"    -> Some Deprecated
+    | Some "outdated"      -> Some Outdated
     | Some "all"           -> None
     | Some _               -> failwith "Invalid status" 
     | None                 -> None

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -55,11 +55,30 @@ let private regenerateTestClasses options =
             List.iter regenerateTestClass' exercises
             Log.Information("Re-generated test classes.")
 
+let private checkOutdated options =
+    Log.Information("Checking for outdated test classes...")
+    
+    let e = createExercises options
+    e |> List.iter (fun ex ->
+        match ex with
+        | Generator g -> 
+            let what = g.Properties
+            printfn "generator test: %s" g.Name
+        | _ -> ()
+//        printfn "%s %s" ex.
+    )
+    let parseCanonicalData' = parseCanonicalData options
+    ()
+    
+
 [<EntryPoint>]
 let main argv = 
     Logging.setupLogger()
 
     match parseOptions argv with
+    | Ok(options) when options.CheckOutdated ->
+        checkOutdated options
+        0
     | Ok(options) -> 
         regenerateTestClasses options
         0

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -87,48 +87,48 @@ let private listExercises options =
         | exercises ->
             exercises |> List.iter (summarizeExercise options)
 
-type ExerciseVersionStatus =
-        | UpToDate
-        | OutDated of string * string * string
+//type ExerciseVersionStatus =
+//        | UpToDate
+//        | OutDated of string * string * string
         
-let private checkOutdated options parseCanonicalData' =
-    Log.Information("Checking for outdated test classes...")
-    
-    
-    let results = 
-        createExercises options
-        |> List.choose (function
-                            | Generator g -> Some g
-                            | _ -> None )
-        |> List.map (fun exercise ->
-            let cData = parseCanonicalData' exercise.Name
-            
-            match cData.Version,exercise.ReadVersion() with
-            | canonVersion,exerciseVersion when canonVersion.Equals exerciseVersion -> UpToDate
-            | canonVersion,exerciseVersion -> OutDated (exercise.Name,canonVersion,exerciseVersion)
-        )
-    
-    let numUpToDate = results |> List.where (fun s -> s = UpToDate) |> List.length
-    
-    Log.Information (sprintf "%d exercises up to date." numUpToDate)
-    
-    let outdated = results |> List.choose (fun s ->
-        match s with 
-        | OutDated (x,y,z) -> Some (x,y,z)
-        | UpToDate -> None
-    )
-    
-    Log.Information (sprintf "%d exercises outdated / mismatched:" outdated.Length)
-    
-    let longestNameLength = outdated |> List.map (fun (a,_,_) -> a.Length) |> List.max
-    
-    outdated |> List.iter (fun (name,canonVersion,exerciseVersion) ->
-        let numSpaces = longestNameLength - name.Length + 2
-        let indentation = String.replicate numSpaces " "
-        Log.Information (sprintf "%s%s%s -> %s" name indentation exerciseVersion canonVersion)
-    )
-    
-    ()
+//let private checkOutdated options parseCanonicalData' =
+//    Log.Information("Checking for outdated test classes...")
+//    
+//    
+//    let results = 
+//        createExercises options
+//        |> List.choose (function
+//                            | Generator g -> Some g
+//                            | _ -> None )
+//        |> List.map (fun exercise ->
+//            let cData = parseCanonicalData' exercise.Name
+//            
+//            match cData.Version,exercise.ReadVersion() with
+//            | canonVersion,exerciseVersion when canonVersion.Equals exerciseVersion -> UpToDate
+//            | canonVersion,exerciseVersion -> OutDated (exercise.Name,canonVersion,exerciseVersion)
+//        )
+//    
+//    let numUpToDate = results |> List.where (fun s -> s = UpToDate) |> List.length
+//    
+//    Log.Information (sprintf "%d exercises up to date." numUpToDate)
+//    
+//    let outdated = results |> List.choose (fun s ->
+//        match s with 
+//        | OutDated (x,y,z) -> Some (x,y,z)
+//        | UpToDate -> None
+//    )
+//    
+//    Log.Information (sprintf "%d exercises outdated / mismatched:" outdated.Length)
+//    
+//    let longestNameLength = outdated |> List.map (fun (a,_,_) -> a.Length) |> List.max
+//    
+//    outdated |> List.iter (fun (name,canonVersion,exerciseVersion) ->
+//        let numSpaces = longestNameLength - name.Length + 2
+//        let indentation = String.replicate numSpaces " "
+//        Log.Information (sprintf "%s%s%s -> %s" name indentation exerciseVersion canonVersion)
+//    )
+//    
+//    ()
     
 
 [<EntryPoint>]

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -11,23 +11,6 @@ let private isNotFilteredByName options (exercise: Exercise) =
     | Some filteredExerciseName -> filteredExerciseName = exerciseName exercise
     | None -> true
     
-let private isOutdated (exercise: GeneratorExercise) options (parseCanonicalData':string -> CanonicalData) =
-    let cData = parseCanonicalData' exercise.Name
-    match cData.Version,exercise.ReadVersion() with
-    | canonVersion,exerciseVersion when canonVersion.Equals exerciseVersion -> false
-    | _,_ -> true
-    
-let private filterByStatus options (parseCanonicalData':string -> CanonicalData) (exercise: Exercise) =
-    match options.Status, exercise with
-    | None, _ -> true
-    | Some Status.Implemented,   Exercise.Generator _     -> true
-    | Some Status.Unimplemented, Exercise.Unimplemented _ -> true
-    | Some Status.MissingData,   Exercise.MissingData _   -> true
-    | Some Status.Deprecated,    Exercise.Deprecated _    -> true
-    | Some Status.Custom,        Exercise.Custom _        -> true
-    | Some Status.Outdated,      Exercise.Generator exercise when isOutdated exercise options parseCanonicalData' -> true
-    | Some Status.All,           _                        -> true
-    | _ -> false
 
 let private regenerateTestClass options =
     let parseCanonicalData' = parseCanonicalData options
@@ -61,69 +44,7 @@ let private regenerateTestClasses options =
             Log.Information("Re-generated test classes.")
             
             
-type SummaryTypes =
-    | Custom of string
-    | Unimplemented of string
-    | MissingData of string
-    | Deprecated of string
-    | UpToDate of string
-    | Outdated of string * string * string
-    
-let private summarizeExercise options (parseCanonicalData':string -> CanonicalData) (exercise:Exercise)  =
-
-    match exercise with
-    | Exercise.Custom custom ->                 SummaryTypes.Custom custom.Name
-    | Exercise.Unimplemented unimplemented ->   SummaryTypes.Unimplemented unimplemented.Name
-    | Exercise.MissingData missingData ->       SummaryTypes.MissingData missingData.Name
-    | Exercise.Deprecated deprecated ->         SummaryTypes.Deprecated deprecated.Name
-    | Exercise.Generator generator ->
-        let cData = parseCanonicalData' generator.Name
-        
-        match generator.ReadVersion (), cData.Version with
-        | a,b when a.Equals b ->  UpToDate generator.Name
-        | a,b -> Outdated (generator.Name,a,b)
-                             
-let private listExercises options =
-    Log.Information(sprintf "Listing exercises with status %s..." (options.Status.Value.ToString()))
-    
-    let parseCanonicalData' = parseCanonicalData options
-    
-    let allExercises = createExercises options
-    
-    let longestNameLength = allExercises |> List.map exerciseName |> List.map (fun e -> e.Length) |> List.max
-    let indentAfter (name:string) = String.replicate (longestNameLength+2-name.Length) " "
-    
-    let exerciseGroups = allExercises
-                            |> List.filter (filterByStatus options parseCanonicalData')
-                            |> List.map (summarizeExercise options parseCanonicalData')
-                            |> List.groupBy (fun x -> x.GetType())
-    
-    exerciseGroups |> List.iter (fun (groupType,group) ->
-        let description = match group.Head with
-                          | SummaryTypes.Custom _ -> "have customized tests"
-                          | SummaryTypes.Unimplemented _ -> "are missing test generator"
-                          | SummaryTypes.MissingData _ -> "are missing canonical data"
-                          | SummaryTypes.Deprecated _ -> "are deprecated"
-                          | SummaryTypes.UpToDate _ -> "are up to date"
-                          | SummaryTypes.Outdated _ -> "are outdated"
-                          
-        Log.Information("{num} exercises {description}", group.Length, description)
-        
-        group |> List.iter (fun exercise -> 
-            match exercise with
-            | SummaryTypes.Custom name ->                   Log.Information(" {name}",name)
-            | SummaryTypes.Unimplemented name ->            Log.Information(" {name}",name)
-            | SummaryTypes.MissingData name ->              Log.Information(" {name}",name)
-            | SummaryTypes.Deprecated name ->               Log.Information(" {name}",name)
-            | SummaryTypes.UpToDate name ->                 Log.Information(" {name}",name)
-            | SummaryTypes.Outdated (name,oldVer,newVer) -> Log.Information(" {name}{indent}({oldVer} -> {newVer})", name, indentAfter name, oldVer, newVer)
-        )
-            
-        printfn ""
-        
-    )
-    
-    
+                      
 
 [<EntryPoint>]
 let main argv = 
@@ -134,7 +55,7 @@ let main argv =
         Log.Error("Can't have both -s and -e.")
         1
     | Ok(options) when options.Status.IsSome -> 
-        listExercises options
+        Reporting.listExercises options
         0
     | Ok(options) -> 
         regenerateTestClasses options

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -75,9 +75,11 @@ let private summarizeExercise options (parseCanonicalData':string -> CanonicalDa
         "are deprecated", deprecated.Name
     | Exercise.Generator generator ->
         let cData = parseCanonicalData' generator.Name
+        
+        let indent = String.replicate (30-generator.Name.Length) " "
         match generator.ReadVersion (), cData.Version with
         | a,b when a.Equals b -> "are up to date",generator.Name
-        | a,b -> "are outdated",sprintf "%s (%s -> %s)" generator.Name a b
+        | a,b -> "are outdated",sprintf "%s%s(%s -> %s)" generator.Name indent a b
                              
 let private listExercises options =
     Log.Information(sprintf "Listing exercises with status %s..." (options.Status.Value.ToString()))
@@ -90,12 +92,16 @@ let private listExercises options =
                         |> List.groupBy fst
     
     exercises |> List.iter (fun category ->
-        printfn "%d exercises %s:" (snd category).Length (fst category)
-        (snd category) |> List.iter (fun e ->
-            printfn "\t%s" (snd e)
-            ()
-        )
-        ()
+        let exList = snd category
+        Log.Information(sprintf "%d exercises %s:" exList.Length (fst category))
+        if fst category = "are outdated" then
+            exList |> List.iter (fun e -> Log.Information(sprintf " %s" (snd e)))
+        else
+            let s = exList |> List.map snd |> List.reduce (sprintf "%s, %s")
+            Log.Information(s)
+            
+        printfn ""
+        
     )
     
     ()

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -15,7 +15,7 @@ let private isOutdated (exercise: GeneratorExercise) options (parseCanonicalData
     let cData = parseCanonicalData' exercise.Name
     match cData.Version,exercise.ReadVersion() with
     | canonVersion,exerciseVersion when canonVersion.Equals exerciseVersion -> false
-    | canonVersion,exerciseVersion -> true
+    | _,_ -> true
     
 let private filterByStatus options (parseCanonicalData':string -> CanonicalData) (exercise: Exercise) =
     match options.Status, exercise with

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -58,16 +58,19 @@ let private regenerateTestClasses options =
 let private checkOutdated options =
     Log.Information("Checking for outdated test classes...")
     
+    let parseCanonicalData' = parseCanonicalData options
+    
     let e = createExercises options
     e |> List.iter (fun ex ->
         match ex with
         | Generator g -> 
             let what = g.Properties
             printfn "generator test: %s" g.Name
+            let cData = parseCanonicalData' g.Name
+            printfn "cdata version %s" cData.Version
         | _ -> ()
 //        printfn "%s %s" ex.
     )
-    let parseCanonicalData' = parseCanonicalData options
     ()
     
 

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -68,8 +68,9 @@ let private checkOutdated options =
             printfn "generator test: %s" g.Name
             let cData = parseCanonicalData' g.Name
             printfn "cdata version %s" cData.Version
+            let ver = g.ReadVersion ()
+            printfn "exercise version %s" ver
         | _ -> ()
-//        printfn "%s %s" ex.
     )
     ()
     

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -61,7 +61,7 @@ let private regenerateTestClasses options =
             List.iter regenerateTestClass' exercises
             Log.Information("Re-generated test classes.")
             
-let private summarizeExercise options (exercise:Exercise)  =
+let private summarizeExercise options (parseCanonicalData':string -> CanonicalData) (exercise:Exercise)  =
 
     match exercise with
     | Exercise.Custom custom ->
@@ -73,7 +73,12 @@ let private summarizeExercise options (exercise:Exercise)  =
     | Exercise.Deprecated deprecated ->
         Log.Warning("{Exercise}: deprecated", deprecated.Name)
     | Exercise.Generator generator ->
-        Log.Information("{Exercise}: ", generator.Name)
+        let cData = parseCanonicalData' generator.Name
+        let versionSummary = match cData.Version,generator.ReadVersion () with
+                             | a,b when a.Equals b -> "Up to date"
+                             | a,b -> sprintf "%s -> %s" a b
+                             
+        Log.Information("{Exercise}: {versionSummary}", generator.Name, versionSummary)
 
 let private listExercises options =
     Log.Information(sprintf "Listing exercises with status %s..." (options.Status.Value.ToString()))
@@ -85,7 +90,7 @@ let private listExercises options =
     |> function
         | [] -> Log.Warning "No exercises matched given options."
         | exercises ->
-            exercises |> List.iter (summarizeExercise options)
+            exercises |> List.iter (summarizeExercise options parseCanonicalData')
 
 //type ExerciseVersionStatus =
 //        | UpToDate

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -51,7 +51,7 @@ let private regenerateTestClasses options =
     createExercises options
     |> List.filter (shouldBeIncluded options)
     |> function
-        | [] -> Log.Warning"No exercises matched given options."
+        | [] -> Log.Warning "No exercises matched given options."
         | exercises ->
             List.iter regenerateTestClass' exercises
             Log.Information("Re-generated test classes.")
@@ -106,11 +106,10 @@ let main argv =
     Logging.setupLogger()
 
     match parseOptions argv with
-    | Ok(options) when options.CheckOutdated ->
-        checkOutdated options
-        0
     | Ok(options) -> 
         regenerateTestClasses options
+        0
+    | Error(errors) when errors |> Seq.contains "CommandLine.HelpRequestedError" ->
         0
     | Error(errors) -> 
         Log.Error("Error(s) parsing commandline arguments: {Errors}", errors)

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -5,6 +5,7 @@ open Exercise
 open CanonicalData
 open Generators
 open Options
+open Reporting
 
 let private isNotFilteredByName options (exercise: Exercise) =
     match options.Exercise with
@@ -52,10 +53,10 @@ let main argv =
 
     match parseOptions argv with
     | Ok(options) when options.Status.IsSome && options.Exercise.IsSome -> 
-        Log.Error("Can't have both -s and -e.")
+        Log.Error("Can't have both -s/--status and -e/--exercise.")
         1
     | Ok(options) when options.Status.IsSome -> 
-        Reporting.listExercises options
+        listExercises options
         0
     | Ok(options) -> 
         regenerateTestClasses options

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -19,17 +19,17 @@ let private regenerateTestClass options =
     fun (exercise) ->
         match exercise with
         | Exercise.Custom custom ->
-            Log.Information("{Exercise}: has customized tests", custom.Name)
+            Log.Information(" {Exercise}: has customized tests", custom.Name)
         | Exercise.Unimplemented unimplemented ->
-            Log.Error("{Exercise}: missing test generator", unimplemented.Name)
+            Log.Error(" {Exercise}: missing test generator", unimplemented.Name)
         | Exercise.MissingData missingData ->
-            Log.Warning("{Exercise}: missing canonical data", missingData.Name)
+            Log.Warning(" {Exercise}: missing canonical data", missingData.Name)
         | Exercise.Deprecated deprecated ->
-            Log.Warning("{Exercise}: deprecated", deprecated.Name)
+            Log.Warning(" {Exercise}: deprecated", deprecated.Name)
         | Exercise.Generator generator ->
             let canonicalData = parseCanonicalData' generator.Name
             generator.Regenerate(canonicalData)
-            Log.Information("{Exercise}: tests generated", generator.Name)
+            Log.Information(" {Exercise}: tests generated", generator.Name)
 
 let private regenerateTestClasses options =
     Log.Information("Re-generating test classes...")

--- a/generators/Reporting.fs
+++ b/generators/Reporting.fs
@@ -69,7 +69,7 @@ let listExercises options =
                           | SummaryTypes.UpToDate _ -> "are up to date"
                           | SummaryTypes.Outdated _ -> "are outdated"
                           
-        Log.Information("{num} exercises {description}", group.Length, description)
+        Log.Information("{num} exercises {description}:", group.Length, description)
         
         group |> List.iter (fun exercise -> 
             match exercise with

--- a/generators/Reporting.fs
+++ b/generators/Reporting.fs
@@ -55,8 +55,8 @@ let private summarizeExercise options (parseCanonicalData':string -> CanonicalDa
 
 let printExercise indentAfter exercise =
     match exercise with
-    | SummaryTypes.Outdated (name, oldVer, newVer) -> Log.Information("   {name}{indent}({oldVer} -> {newVer})", name, indentAfter name, oldVer, newVer)
-    | _ -> Log.Information("   {name}", nameFromSummaryType exercise)
+    | SummaryTypes.Outdated (name, oldVer, newVer) -> Log.Information(" {name}{indent}({oldVer} -> {newVer})", name, indentAfter name, oldVer, newVer)
+    | _ -> Log.Information(" {name}", nameFromSummaryType exercise)
 
 let printExerciseGroup indentAfter (groupType:System.Type, group:SummaryTypes list)=
     let description =

--- a/generators/Reporting.fs
+++ b/generators/Reporting.fs
@@ -1,0 +1,88 @@
+module Generators.Reporting
+
+open Serilog
+open CanonicalData
+open Exercise
+open Options
+       
+let private isOutdated (exercise: GeneratorExercise) options (parseCanonicalData':string -> CanonicalData) =
+    let cData = parseCanonicalData' exercise.Name
+    match cData.Version,exercise.ReadVersion() with
+    | canonVersion,exerciseVersion when canonVersion.Equals exerciseVersion -> false
+    | _,_ -> true
+    
+let private filterByStatus options (parseCanonicalData':string -> CanonicalData) (exercise: Exercise) =
+    match options.Status, exercise with
+    | None, _ -> true
+    | Some Status.Implemented,   Exercise.Generator _     -> true
+    | Some Status.Unimplemented, Exercise.Unimplemented _ -> true
+    | Some Status.MissingData,   Exercise.MissingData _   -> true
+    | Some Status.Deprecated,    Exercise.Deprecated _    -> true
+    | Some Status.Custom,        Exercise.Custom _        -> true
+    | Some Status.Outdated,      Exercise.Generator exercise when isOutdated exercise options parseCanonicalData' -> true
+    | Some Status.All,           _                        -> true
+    | _ -> false
+    
+type SummaryTypes =
+    | Custom of string
+    | Unimplemented of string
+    | MissingData of string
+    | Deprecated of string
+    | UpToDate of string
+    | Outdated of string * string * string
+    
+let private summarizeExercise options (parseCanonicalData':string -> CanonicalData) (exercise:Exercise)  =
+
+    match exercise with
+    | Exercise.Custom custom ->                 SummaryTypes.Custom custom.Name
+    | Exercise.Unimplemented unimplemented ->   SummaryTypes.Unimplemented unimplemented.Name
+    | Exercise.MissingData missingData ->       SummaryTypes.MissingData missingData.Name
+    | Exercise.Deprecated deprecated ->         SummaryTypes.Deprecated deprecated.Name
+    | Exercise.Generator generator ->
+        let cData = parseCanonicalData' generator.Name
+        
+        match generator.ReadVersion (), cData.Version with
+        | a,b when a.Equals b ->  UpToDate generator.Name
+        | a,b -> Outdated (generator.Name,a,b)
+        
+let listExercises options =
+    Log.Information(sprintf "Listing exercises with status %s..." (options.Status.Value.ToString()))
+    
+    let parseCanonicalData' = CanonicalData.parseCanonicalData options
+    
+    let allExercises = createExercises options
+    
+    let longestNameLength = allExercises |> List.map exerciseName |> List.map (fun e -> e.Length) |> List.max
+    let indentAfter (name:string) = String.replicate (longestNameLength+2-name.Length) " "
+    
+    let exerciseGroups = allExercises
+                            |> List.filter (filterByStatus options parseCanonicalData')
+                            |> List.map (summarizeExercise options parseCanonicalData')
+                            |> List.groupBy (fun x -> x.GetType())
+    
+    exerciseGroups |> List.iter (fun (groupType,group) ->
+        let description = match group.Head with
+                          | SummaryTypes.Custom _ -> "have customized tests"
+                          | SummaryTypes.Unimplemented _ -> "are missing test generator"
+                          | SummaryTypes.MissingData _ -> "are missing canonical data"
+                          | SummaryTypes.Deprecated _ -> "are deprecated"
+                          | SummaryTypes.UpToDate _ -> "are up to date"
+                          | SummaryTypes.Outdated _ -> "are outdated"
+                          
+        Log.Information("{num} exercises {description}", group.Length, description)
+        
+        group |> List.iter (fun exercise -> 
+            match exercise with
+            | SummaryTypes.Custom name ->                   Log.Information(" {name}",name)
+            | SummaryTypes.Unimplemented name ->            Log.Information(" {name}",name)
+            | SummaryTypes.MissingData name ->              Log.Information(" {name}",name)
+            | SummaryTypes.Deprecated name ->               Log.Information(" {name}",name)
+            | SummaryTypes.UpToDate name ->                 Log.Information(" {name}",name)
+            | SummaryTypes.Outdated (name,oldVer,newVer) -> Log.Information(" {name}{indent}({oldVer} -> {newVer})", name, indentAfter name, oldVer, newVer)
+        )
+            
+        printfn ""
+        
+    )
+    
+    

--- a/generators/Reporting.fs
+++ b/generators/Reporting.fs
@@ -31,6 +31,14 @@ type SummaryTypes =
     | UpToDate of string
     | Outdated of string * string * string
     
+let nameFromSummaryType = function
+    | Custom n -> n
+    | Unimplemented  n -> n
+    | MissingData n -> n
+    | Deprecated n -> n
+    | UpToDate n -> n
+    | Outdated (n,_,_) -> n
+    
 let private summarizeExercise options (parseCanonicalData':string -> CanonicalData) (exercise:Exercise)  =
 
     match exercise with
@@ -73,12 +81,8 @@ let listExercises options =
         
         group |> List.iter (fun exercise -> 
             match exercise with
-            | SummaryTypes.Custom name ->                   Log.Information(" {name}",name)
-            | SummaryTypes.Unimplemented name ->            Log.Information(" {name}",name)
-            | SummaryTypes.MissingData name ->              Log.Information(" {name}",name)
-            | SummaryTypes.Deprecated name ->               Log.Information(" {name}",name)
-            | SummaryTypes.UpToDate name ->                 Log.Information(" {name}",name)
             | SummaryTypes.Outdated (name,oldVer,newVer) -> Log.Information(" {name}{indent}({oldVer} -> {newVer})", name, indentAfter name, oldVer, newVer)
+            | _ -> Log.Information(" {name}", nameFromSummaryType exercise)
         )
             
         printfn ""


### PR DESCRIPTION
I took a crack at https://github.com/exercism/fsharp/issues/581 .


**Generation** (`-e`) should work as before, except that now it can't be combined with `-s`.

**Status** (`-s`) now works by itself, listing exercises of the specified status. Here's how it looks with `-s outdated`:
```
[23:38:48 INF] Listing exercises with status Outdated...
[23:38:48 INF] Updating repository to latest version...
[23:38:48 INF] Updated repository to latest version.
[23:38:49 INF] 20 exercises are outdated:
[23:38:49 INF]  allergies                  (1.1.0 -> 1.2.0)
[23:38:49 INF]  alphametics                (1.2.0 -> 1.3.0)
[23:38:49 INF]  anagram                    (1.3.0 -> 1.4.0)
[23:38:49 INF]  atbash-cipher              (1.1.0 -> 1.2.0)
[23:38:49 INF]  book-store                 (1.3.0 -> 1.4.0)
[23:38:49 INF]  bracket-push               (1.3.0 -> 1.4.0)
(...)
```

`-s all` will list all exercises, grouped by category.

**--help** will no longer throw an error,  and there's now some usage information:

```
USAGE:
Generate all exercises:
dotnet run
Generate the exercise named 'foobar':
dotnet run --exercise foobar
List outdated exercises:
dotnet run --status outdated
```

