### PR TITLE
Simplify generator logging

### DIFF
--- a/generators/Common.fs
+++ b/generators/Common.fs
@@ -33,5 +33,6 @@ module Logging =
 
     let setupLogger() =
         Log.Logger <- LoggerConfiguration()
-            .WriteTo.LiterateConsole()
+            .WriteTo
+            .Console(outputTemplate = "{Message:lj}{NewLine}{Exception}")
             .CreateLogger()

--- a/generators/Generators.fsproj
+++ b/generators/Generators.fsproj
@@ -24,8 +24,8 @@
     <PackageReference Include="Humanizer" Version="2.5.1" />
     <PackageReference Include="LibGit2Sharp.Portable" Version="0.24.10" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="serilog" Version="2.7.1" />
-    <PackageReference Include="serilog.sinks.literate" Version="3.0.0" />
+    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Based on [discussion](https://github.com/exercism/fsharp/pull/629#discussion_r223410027) from #629, this PR:

- Customizes the format to remove first column (timestamp and severity)
- Switches from the [deprecated](https://github.com/serilog/serilog-sinks-literate#this-package-is-being-retired) _Serilog.Sinks.Literate_ sink to the recommended replacement _Serilog.Sinks.Console_.