### PR TITLE
Add generator for exercise: pythagorean-triplet

### DIFF
--- a/exercises/pythagorean-triplet/Example.fs
+++ b/exercises/pythagorean-triplet/Example.fs
@@ -14,10 +14,10 @@ let triplet x y z =
 
 let isPythagorean triplet = square triplet.x + square triplet.y = square triplet.z
 
-let pythagoreanTriplets min max = 
-    [for x in min .. (max - 2) do
-        for y in x .. (max - 1) do
-            let target = square x + square y
-            let z = squareRoot target
-            if z <= max && square z = target then
-                yield triplet x y z]
+let tripletsWithSum sum = 
+    [for x in 1 .. (sum - 1) do
+        for y in (x + 1) .. (sum - 1 - x) do
+            let target = sum - (x + y)
+            let triplet = triplet x y target
+            if isPythagorean triplet then
+                    yield triplet] |> List.distinct

--- a/exercises/pythagorean-triplet/Example.fs
+++ b/exercises/pythagorean-triplet/Example.fs
@@ -2,22 +2,14 @@ module PythagoreanTriplet
 
 open System
 
-type Triplet = { x: int; y: int; z: int }
-
 let private square x = x * x
-let private squareRoot x = Math.Sqrt(x |> float) |> Math.Floor |> int
 
-let triplet x y z =     
-    match [x; y; z] |> List.sort with
-    | x'::y'::z'::_ -> { x = x' ; y = y'; z = z' }
-    | _ -> failwith "Should never get here"
-
-let isPythagorean triplet = square triplet.x + square triplet.y = square triplet.z
+let private isPythagorean (x, y, z) = square x + square y = square z
 
 let tripletsWithSum sum = 
     [for x in 1 .. (sum - 1) do
         for y in (x + 1) .. (sum - 1 - x) do
             let target = sum - (x + y)
-            let triplet = triplet x y target
+            let triplet = (x, y, target)
             if isPythagorean triplet then
                     yield triplet] |> List.distinct

--- a/exercises/pythagorean-triplet/PythagoreanTriplet.fs
+++ b/exercises/pythagorean-triplet/PythagoreanTriplet.fs
@@ -1,7 +1,3 @@
 module PythagoreanTriplet
 
-let triplet x y z = failwith "You need to implement this function."
-
-let isPythagorean triplet = failwith "You need to implement this function."
-
 let tripletsWithSum sum = failwith "You need to implement this function."

--- a/exercises/pythagorean-triplet/PythagoreanTriplet.fs
+++ b/exercises/pythagorean-triplet/PythagoreanTriplet.fs
@@ -4,4 +4,4 @@ let triplet x y z = failwith "You need to implement this function."
 
 let isPythagorean triplet = failwith "You need to implement this function."
 
-let pythagoreanTriplets min max = failwith "You need to implement this function."
+let tripletsWithSum sum = failwith "You need to implement this function."

--- a/exercises/pythagorean-triplet/PythagoreanTripletTest.fs
+++ b/exercises/pythagorean-triplet/PythagoreanTripletTest.fs
@@ -9,15 +9,15 @@ open PythagoreanTriplet
 
 [<Fact>]
 let ``Triplets whose sum is 12`` () =
-    tripletsWithSum 12 |> should equal [triplet 3 4 5]
+    tripletsWithSum 12 |> should equal [(3, 4, 5)]
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Triplets whose sum is 108`` () =
-    tripletsWithSum 108 |> should equal [triplet 27 36 45]
+    tripletsWithSum 108 |> should equal [(27, 36, 45)]
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Triplets whose sum is 1000`` () =
-    tripletsWithSum 1000 |> should equal [triplet 200 375 425]
+    tripletsWithSum 1000 |> should equal [(200, 375, 425)]
 
 [<Fact(Skip = "Remove to run test")>]
 let ``No matching triplets for 1001`` () =
@@ -25,13 +25,13 @@ let ``No matching triplets for 1001`` () =
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Returns all matching triplets`` () =
-    tripletsWithSum 90 |> should equal [triplet 9 40 41; triplet 15 36 39]
+    tripletsWithSum 90 |> should equal [(9, 40, 41); (15, 36, 39)]
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Several matching triplets`` () =
-    tripletsWithSum 840 |> should equal [triplet 40 399 401; triplet 56 390 394; triplet 105 360 375; triplet 120 350 370; triplet 140 336 364; triplet 168 315 357; triplet 210 280 350; triplet 240 252 348]
+    tripletsWithSum 840 |> should equal [(40, 399, 401); (56, 390, 394); (105, 360, 375); (120, 350, 370); (140, 336, 364); (168, 315, 357); (210, 280, 350); (240, 252, 348)]
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Triplets for large number`` () =
-    tripletsWithSum 30000 |> should equal [triplet 1200 14375 14425; triplet 1875 14000 14125; triplet 5000 12000 13000; triplet 6000 11250 12750; triplet 7500 10000 12500]
+    tripletsWithSum 30000 |> should equal [(1200, 14375, 14425); (1875, 14000, 14125); (5000, 12000, 13000); (6000, 11250, 12750); (7500, 10000, 12500)]
 

--- a/exercises/pythagorean-triplet/PythagoreanTripletTest.fs
+++ b/exercises/pythagorean-triplet/PythagoreanTripletTest.fs
@@ -1,36 +1,37 @@
-// This file was created manually and its version is 1.0.0.
+// This file was auto-generated based on version 1.0.0 of the canonical data.
 
 module PythagoreanTripletTest
 
-open Xunit
 open FsUnit.Xunit
+open Xunit
 
 open PythagoreanTriplet
-    
-[<Theory(Skip = "Remove to run test")>]
-[<InlineData(3, 4, 5, true)>]
-[<InlineData(3, 5, 4, true)>]
-[<InlineData(4, 3, 5, true)>]
-[<InlineData(4, 5, 3, true)>]
-[<InlineData(5, 3, 4, true)>]
-[<InlineData(5, 4, 3, true)>]
-[<InlineData(3, 3, 3, false)>]
-[<InlineData(5, 6, 7, false)>]
-let ``Can recognize a valid pythagorean`` (x: int) (y: int) (z: int) (expected: bool) =
-    let actual = triplet x y z
-    isPythagorean actual |> should equal expected
-   
-[<Fact(Skip = "Remove to run test")>]
-let ``Can create simple triplets`` () =
-    let actual = pythagoreanTriplets 1 10
-    actual |> should equal [triplet 3 4 5; triplet 6 8 10]
+
+[<Fact>]
+let ``Triplets whose sum is 12`` () =
+    tripletsWithSum 12 |> should equal [triplet 3 4 5]
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Can create more triplets`` () =
-    let actual = pythagoreanTriplets 11 20
-    actual |> should equal [triplet 12 16 20]
+let ``Triplets whose sum is 108`` () =
+    tripletsWithSum 108 |> should equal [triplet 27 36 45]
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Can create complex triplets`` () =
-    let actual = pythagoreanTriplets 56 95
-    actual |> should equal [triplet 57 76 95; triplet 60 63 87]
+let ``Triplets whose sum is 1000`` () =
+    tripletsWithSum 1000 |> should equal [triplet 200 375 425]
+
+[<Fact(Skip = "Remove to run test")>]
+let ``No matching triplets for 1001`` () =
+    tripletsWithSum 1001 |> should be Empty
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Returns all matching triplets`` () =
+    tripletsWithSum 90 |> should equal [triplet 9 40 41; triplet 15 36 39]
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Several matching triplets`` () =
+    tripletsWithSum 840 |> should equal [triplet 40 399 401; triplet 56 390 394; triplet 105 360 375; triplet 120 350 370; triplet 140 336 364; triplet 168 315 357; triplet 210 280 350; triplet 240 252 348]
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Triplets for large number`` () =
+    tripletsWithSum 30000 |> should equal [triplet 1200 14375 14425; triplet 1875 14000 14125; triplet 5000 12000 13000; triplet 6000 11250 12750; triplet 7500 10000 12500]
+

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -976,7 +976,7 @@ type PythagoreanTriplet() =
     inherit GeneratorExercise()
     
     override __.RenderExpected (_, _, value) = 
-        let render value = sprintf "triplet %s" (value |> Seq.map Obj.render |> String.concat " ")
+        let render value = sprintf "(%s)" (value |> Seq.map Obj.render |> String.concat ", ")
         List.mapRender render value
     
 type QueenAttack() =

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -971,6 +971,13 @@ type Proverb() =
         match Seq.isEmpty value with 
         | true  -> Some "string list"
         | false -> None
+
+type PythagoreanTriplet() =
+    inherit GeneratorExercise()
+    
+    override __.RenderExpected (_, _, value) = 
+        let render value = sprintf "triplet %s" (value |> Seq.map Obj.render |> String.concat " ")
+        List.mapRender render value
     
 type QueenAttack() =
     inherit GeneratorExercise()


### PR DESCRIPTION
Fixes #584 

The exercise have changed a little bit: now we need to search for pythagorean triplets whose sum is equal to the given parameter. So I've also changed the example implementation.

One of the test cases is very big (n = 30000) and it takes  ~1.5 min to run the test suite with the current example implementation. So any performance improvements are welcomed :)