### PR TITLE
Added grade-school generator / altered example

### DIFF
--- a/exercises/grade-school/Example.fs
+++ b/exercises/grade-school/Example.fs
@@ -11,8 +11,8 @@ let add student grade school =
 let roster school =
     school
     |> Map.toList
-    |> List.sortBy (fun (a, _) -> a)
-    |> List.map (fun (_, b) -> b)
+    |> List.sortBy fst
+    |> List.map snd
     |> List.fold (fun finalList listItem -> finalList @ (List.sort listItem)) []
 
 let grade number school = 

--- a/exercises/grade-school/Example.fs
+++ b/exercises/grade-school/Example.fs
@@ -1,5 +1,6 @@
 ﻿module GradeSchool
 
+type School = Map<int, string list>
 let empty = Map.empty<int, string list>
 
 let add student grade school = 
@@ -7,7 +8,12 @@ let add student grade school =
     | Some existing -> Map.add grade (student :: existing |> List.sort) school
     | None -> Map.add grade [student] school
 
-let roster school = Map.toList school
+let roster school =
+    school
+    |> Map.toList
+    |> List.sortBy (fun (a, _) -> a)
+    |> List.map (fun (_, b) -> b)
+    |> List.fold (fun finalList listItem -> finalList @ (List.sort listItem)) []
 
 let grade number school = 
     match Map.tryFind number school with

--- a/exercises/grade-school/GradeSchoolTest.fs
+++ b/exercises/grade-school/GradeSchoolTest.fs
@@ -14,17 +14,17 @@ let studentsToSchool (students: List<string*int>):School =
 
 [<Fact>]
 let ``Adding a student adds them to the sorted roster`` () =
-    let school = studentsToSchool [("Aimee",2)]
+    let school = studentsToSchool [("Aimee", 2)]
     roster school |> should equal ["Aimee"]
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Adding more student adds them to the sorted roster`` () =
-    let school = studentsToSchool [("Blair",2);("James",2);("Paul",2)]
+    let school = studentsToSchool [("Blair", 2); ("James", 2); ("Paul", 2)]
     roster school |> should equal ["Blair"; "James"; "Paul"]
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Adding students to different grades adds them to the same sorted roster`` () =
-    let school = studentsToSchool [("Chelsea",3);("Logan",7)]
+    let school = studentsToSchool [("Chelsea", 3); ("Logan", 7)]
     roster school |> should equal ["Chelsea"; "Logan"]
 
 [<Fact(Skip = "Remove to run test")>]
@@ -34,12 +34,12 @@ let ``Roster returns an empty list if there are no students enrolled`` () =
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Student names with grades are displayed in the same sorted roster`` () =
-    let school = studentsToSchool [("Peter",2);("Anna",1);("Barb",1);("Zoe",2);("Alex",2);("Jim",3);("Charlie",1)]
+    let school = studentsToSchool [("Peter", 2); ("Anna", 1); ("Barb", 1); ("Zoe", 2); ("Alex", 2); ("Jim", 3); ("Charlie", 1)]
     roster school |> should equal ["Anna"; "Barb"; "Charlie"; "Alex"; "Peter"; "Zoe"; "Jim"]
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Grade returns the students in that grade in alphabetical order`` () =
-    let school = studentsToSchool [("Franklin",5);("Bradley",5);("Jeff",1)]
+    let school = studentsToSchool [("Franklin", 5); ("Bradley", 5); ("Jeff", 1)]
     grade 5 school |> should equal ["Bradley"; "Franklin"]
 
 [<Fact(Skip = "Remove to run test")>]

--- a/exercises/grade-school/GradeSchoolTest.fs
+++ b/exercises/grade-school/GradeSchoolTest.fs
@@ -1,69 +1,49 @@
-// This file was created manually and its version is 1.0.0.
+// This file was auto-generated based on version 1.0.0 of the canonical data.
 
 module GradeSchoolTest
 
-open Xunit
 open FsUnit.Xunit
+open Xunit
+
 open GradeSchool
 
+let studentsToSchool (students: List<string*int>):School =
+    let schoolFolder school (name,grade) =
+        add name grade school
+    List.fold schoolFolder empty students
+
 [<Fact>]
-let ``Empty school has an empty roster`` () =
-    let school = empty
+let ``Adding a student adds them to the sorted roster`` () =
+    let school = studentsToSchool [("Aimee",2)]
+    roster school |> should equal ["Aimee"]
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Adding more student adds them to the sorted roster`` () =
+    let school = studentsToSchool [("Blair",2);("James",2);("Paul",2)]
+    roster school |> should equal ["Blair"; "James"; "Paul"]
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Adding students to different grades adds them to the same sorted roster`` () =
+    let school = studentsToSchool [("Chelsea",3);("Logan",7)]
+    roster school |> should equal ["Chelsea"; "Logan"]
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Roster returns an empty list if there are no students enrolled`` () =
+    let school = studentsToSchool []
     roster school |> should be Empty
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Adding a student adds them to the roster for the given grade`` () =
-    let school = empty |> add "Aimee" 2
-    let expected = ["Aimee"]
-    grade 2 school |> should equal expected
-
-[<Fact(Skip = "Remove to run test")>]
-let ``Adding more students to the same grade adds them to the roster`` () =
-    let school = 
-        empty
-        |> add "Blair" 2
-        |> add "James" 2
-        |> add "Paul" 2
-    let expected = ["Blair"; "James"; "Paul"]
-    grade 2 school |> should equal expected
-
-[<Fact(Skip = "Remove to run test")>]
-let ``Adding students to different grades adds them to the roster`` () =
-    let school = 
-        empty
-        |> add "Chelsea" 3
-        |> add "Logan" 7
-    grade 3 school |> should equal ["Chelsea"]
-    grade 7 school |> should equal ["Logan"]
+let ``Student names with grades are displayed in the same sorted roster`` () =
+    let school = studentsToSchool [("Peter",2);("Anna",1);("Barb",1);("Zoe",2);("Alex",2);("Jim",3);("Charlie",1)]
+    roster school |> should equal ["Anna"; "Barb"; "Charlie"; "Alex"; "Peter"; "Zoe"; "Jim"]
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Grade returns the students in that grade in alphabetical order`` () =
-    let school = 
-        empty
-        |> add "Franklin" 5
-        |> add "Bradley" 5
-        |> add "Jeff" 1
-    let expected = ["Bradley"; "Franklin"]
-    grade 5 school |> should equal expected
+    let school = studentsToSchool [("Franklin",5);("Bradley",5);("Jeff",1)]
+    grade 5 school |> should equal ["Bradley"; "Franklin"]
 
 [<Fact(Skip = "Remove to run test")>]
 let ``Grade returns an empty list if there are no students in that grade`` () =
-    let school = empty
+    let school = studentsToSchool []
     grade 1 school |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
-let ``Student names and grades in roster are sorted`` () =
-    let school =
-        empty        
-        |> add "Jennifer" 4
-        |> add "Kareem" 6
-        |> add "Christopher" 4
-        |> add "Kyle" 3
-        |> add "Zoe" 4
-
-    let expected = 
-        [(3, ["Kyle"]);
-         (4, ["Christopher"; "Jennifer"; "Zoe"]);
-         (6, ["Kareem"])]
-
-    roster school |> should equal expected

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -621,6 +621,48 @@ type GoCounting() =
                     None            
         | _ -> None
 
+type GradeSchool() =
+    inherit GeneratorExercise()
+
+    member private this.RenderPropertyValue canonicalDataCase propertyName =
+        this.RenderInput(canonicalDataCase, propertyName, Map.find propertyName canonicalDataCase.Input)
+
+    member private __.RenderStudent (student: JToken) =
+        let values = student.Values<JToken>()
+        sprintf "(\"%s\",%s)" (student.First|>string) (student.Last|>string)
+
+    member private this.RenderArrangeList canonicalDataCase = 
+        canonicalDataCase.Input.["students"]
+        |> Seq.toList
+        |> List.map this.RenderStudent
+        |> String.concat ";"
+        |> sprintf "[%s]"
+
+    override __.RenderSetup _ =
+        [
+            "let studentsToSchool (students: List<string*int>):School =";
+            "    let schoolFolder school (name,grade) =";
+            "        add name grade school";
+            "    List.fold schoolFolder empty students"
+        ]
+        |> String.concat "\n"
+
+    override this.RenderArrange canonicalDataCase =
+        match canonicalDataCase.Property with
+        | "roster" | "grade" -> 
+            [sprintf "let school = studentsToSchool %s" (this.RenderArrangeList canonicalDataCase)]
+        | _ -> 
+            base.RenderArrange canonicalDataCase
+    
+    override this.RenderSut canonicalDataCase =
+        match canonicalDataCase.Property with
+        | "roster" -> 
+            sprintf "roster school"
+        | "grade" ->
+            let grade  = this.RenderPropertyValue canonicalDataCase "desiredGrade"
+            sprintf "grade %s school" grade
+        | _ -> base.RenderSut canonicalDataCase
+        
 type Grains() =
     inherit GeneratorExercise()
 

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -628,15 +628,10 @@ type GradeSchool() =
         this.RenderInput(canonicalDataCase, propertyName, Map.find propertyName canonicalDataCase.Input)
 
     member private __.RenderStudent (student: JToken) =
-        let values = student.Values<JToken>()
-        sprintf "(\"%s\",%s)" (student.First|>string) (student.Last|>string)
+        Obj.render (string student.First ,int student.Last)
 
-    member private this.RenderArrangeList canonicalDataCase = 
-        canonicalDataCase.Input.["students"]
-        |> Seq.toList
-        |> List.map this.RenderStudent
-        |> String.concat ";"
-        |> sprintf "[%s]"
+    member private this.RenderStudentList canonicalDataCase = 
+        List.mapRender this.RenderStudent canonicalDataCase.Input.["students"]
 
     override __.RenderSetup _ =
         [
@@ -650,7 +645,7 @@ type GradeSchool() =
     override this.RenderArrange canonicalDataCase =
         match canonicalDataCase.Property with
         | "roster" | "grade" -> 
-            [sprintf "let school = studentsToSchool %s" (this.RenderArrangeList canonicalDataCase)]
+            [sprintf "let school = studentsToSchool %s" (this.RenderStudentList canonicalDataCase)]
         | _ -> 
             base.RenderArrange canonicalDataCase
     


### PR DESCRIPTION
Example.fs
- now has a School type
- roster also sorts the list according to canonical data

GradeSchoolTest.fs
- test getting generated 
- no endless pipelining when adding more than one student

Generators.fs
- new generator for this exercise

Things to mention:
- the docs for generator building was not so helpful I spend most time trial and error-ing it out
- I don't like the canonical data to this exercise:
    - ~~Add has to be implemented but it's not explicitly tested.~~
    - Sorting by grade and name and putting this all into one list without grade distinction is somewhat strange because you only recognize the grade cohorts when the first name of the next grade cohort is before the last name of the current cohort in alphabetical order. 