### PR TITLE
fix type mismatch in exercise:grade-school starting code

### DIFF
--- a/exercises/grade-school/GradeSchool.fs
+++ b/exercises/grade-school/GradeSchool.fs
@@ -6,6 +6,6 @@ let empty: School = failwith "You need to implement this function."
 
 let add (student: string) (grade: int) (school: School): School = failwith "You need to implement this function."
 
-let roster (school: School): (int * string list) list = failwith "You need to implement this function."
+let roster (school: School): string list = failwith "You need to implement this function."
 
 let grade (number: int) (school: School): string list = failwith "You need to implement this function."


### PR DESCRIPTION
The tests (and the original canonical data for the grade-school exercise) expect `roster` to return a list of strings, such as `["Blair"; "James"; "Paul"]`. However, the starting code in GradeSchool.fs specified the return type as a list of tuples, which means implementing the function as specified will never pass the test.

This commit just changes the function signature in the starting file to match what is expected by the tests.