### PR TITLE
Add new exercise script

### DIFF
--- a/add-new-exercise.ps1
+++ b/add-new-exercise.ps1
@@ -1,6 +1,6 @@
 param (
     [Parameter(Mandatory=$true)][string]$exercise,
-    [Parameter()][string[]]$topics,
+    [Parameter()][string]$topics,
     [Parameter()][bool]$core,
     [Parameter()][int32]$difficulty,
     [Parameter()][string]$unlocked_by
@@ -11,10 +11,10 @@ class Exercise {
     [guid]$uuid = [Guid]::Empty
     [Boolean]$core = $false
     [int32]$difficulty = 1
-    [string[]]$topics
+    [string]$topics
     [string]$unlocked_by = $null
 
-    Exercise ([String]$slug, [String[]]$topics, [Boolean]$core,[int32]$difficulty,[string]$unlocked_by)
+    Exercise ([String]$slug, [String]$topics, [Boolean]$core,[int32]$difficulty,[string]$unlocked_by)
     {
         $this.slug = $slug
         $this.topics = $topics

--- a/add-new-exercise.ps1
+++ b/add-new-exercise.ps1
@@ -1,0 +1,54 @@
+param (
+    [Parameter(Mandatory=$true)][string]$exercise,
+    [Parameter()][string[]]$topics,
+    [Parameter()][bool]$core,
+    [Parameter()][int32]$difficulty,
+    [Parameter()][string]$unlocked_by
+ )
+
+class Exercise {
+    [String]$slug = ""
+    [guid]$uuid = [Guid]::Empty
+    [Boolean]$core = $false
+    [int32]$difficulty = 1
+    [string[]]$topics
+    [string]$unlocked_by = $null
+
+    Exercise ([String]$slug, [String[]]$topics, [Boolean]$core,[int32]$difficulty,[string]$unlocked_by)
+    {
+        $this.slug = $slug
+        $this.topics = $topics
+        $this.uuid = [Guid]::NewGuid()
+        $this.core = $core
+        $this.difficulty = $difficulty
+        $this.unlocked_by = $unlocked_by
+    }
+}
+# create new folder and update config
+$projectName = (Get-Culture).TextInfo.ToTitleCase($exercise).Replace("-", "")
+New-Item -Path "exercises\$exercise" -ItemType Directory
+$config =  ConvertFrom-JSON -InputObject ([IO.File]::ReadAllText("./config.json"))
+$exercises = $config.exercises
+$newExercise = New-Object -Typename Exercise -ArgumentList $exercise, $topics, $core, $difficulty, $unlocked_by
+$exercises += $newExercise
+$config.exercises = $exercises;
+$newContent = ConvertTo-Json -InputObject $config
+[IO.File]::WriteAllText("./config.json",$newContent)
+
+$fsProj = "exercises/$exercise/$projectName.fsproj"
+dotnet new classlib -lang F# -o "exercises/$exercise" -n $projectName
+dotnet sln "exercises/Exercises.sln" add $fsProj
+dotnet add "exercises/$exercise/$projectName.fsproj" package "Microsoft.NET.Test.Sdk"
+dotnet add "exercises/$exercise/$projectName.fsproj" package "xunit"
+dotnet add "exercises/$exercise/$projectName.fsproj" package "FsUnit.xUnit"
+dotnet add "exercises/$exercise/$projectName.fsproj" package "xunit.runner.visualstudio"
+New-Item -Path "exercises/$exercise/$projectName.fs" -ItemType File
+New-Item -Path ("exercises/$exercise/$projectName" + "Test.fs") -ItemType File
+New-Item -Path "exercises/$exercise/Example.fs" -ItemType File
+[xml]$proj = Get-Content $fsProj
+
+$proj.Project.ItemGroup[0].Compile.Include = "$projectName.fs"
+$exFileTest = $proj.CreateElement("Compile")
+$exFileTest.SetAttribute("Include","$projectName" + "Test.fs")
+$proj.Project.ItemGroup[0].AppendChild($exFileTest)
+$proj.Save($fsProj)

--- a/add-new-exercise.ps1
+++ b/add-new-exercise.ps1
@@ -1,54 +1,51 @@
 param (
-    [Parameter(Mandatory=$true)][string]$exercise,
-    [Parameter()][string]$topics,
-    [Parameter()][bool]$core,
-    [Parameter()][int32]$difficulty,
-    [Parameter()][string]$unlocked_by
+    [Parameter(Mandatory=$true)][string]$Exercise,
+    [Parameter()][string[]]$Topics = $null,
+    [Parameter()][bool]$Core,
+    [Parameter()][int32]$Difficulty = 1,
+    [Parameter()][String]$UnlockedBy = $null
  )
 
 class Exercise {
     [String]$slug = ""
     [guid]$uuid = [Guid]::Empty
     [Boolean]$core = $false
-    [int32]$difficulty = 1
-    [string]$topics
     [string]$unlocked_by = $null
+    [int32]$difficulty = 1
+    [string[]]$topics = $null
 
-    Exercise ([String]$slug, [String]$topics, [Boolean]$core,[int32]$difficulty,[string]$unlocked_by)
+    Exercise ([String]$slug, [String[]]$Topics, [Boolean]$Core,[int32]$Difficulty,[String]$UnlockedBy)
     {
         $this.slug = $slug
-        $this.topics = $topics
+        $this.Topics = $Topics
         $this.uuid = [Guid]::NewGuid()
-        $this.core = $core
-        $this.difficulty = $difficulty
-        $this.unlocked_by = $unlocked_by
+        $this.core = $Core
+        $this.difficulty = $Difficulty
+        $this.unlocked_by = $UnlockedBy
     }
 }
-# create new folder and update config
-$projectName = (Get-Culture).TextInfo.ToTitleCase($exercise).Replace("-", "")
-New-Item -Path "exercises\$exercise" -ItemType Directory
+
+$projectName = (Get-Culture).TextInfo.ToTitleCase($Exercise).Replace("-", "")
+New-Item -Path "Exercises\$Exercise" -ItemType Directory
 $config =  ConvertFrom-JSON -InputObject ([IO.File]::ReadAllText("./config.json"))
-$exercises = $config.exercises
-$newExercise = New-Object -Typename Exercise -ArgumentList $exercise, $topics, $core, $difficulty, $unlocked_by
-$exercises += $newExercise
-$config.exercises = $exercises;
-$newContent = ConvertTo-Json -InputObject $config
+$Exercises = $config.Exercises
+$newExercise = New-Object -Typename Exercise -ArgumentList $Exercise, $Topics, $Core, $Difficulty, $UnlockedBy
+$Exercises += $newExercise
+$config.Exercises = $Exercises;
+$newContent = ConvertTo-Json -InputObject $config -Depth 10
 [IO.File]::WriteAllText("./config.json",$newContent)
 
-$fsProj = "exercises/$exercise/$projectName.fsproj"
-dotnet new classlib -lang F# -o "exercises/$exercise" -n $projectName
-dotnet sln "exercises/Exercises.sln" add $fsProj
-dotnet add "exercises/$exercise/$projectName.fsproj" package "Microsoft.NET.Test.Sdk"
-dotnet add "exercises/$exercise/$projectName.fsproj" package "xunit"
-dotnet add "exercises/$exercise/$projectName.fsproj" package "FsUnit.xUnit"
-dotnet add "exercises/$exercise/$projectName.fsproj" package "xunit.runner.visualstudio"
-New-Item -Path "exercises/$exercise/$projectName.fs" -ItemType File
-New-Item -Path ("exercises/$exercise/$projectName" + "Test.fs") -ItemType File
-New-Item -Path "exercises/$exercise/Example.fs" -ItemType File
+$fsProj = "Exercises/$Exercise/$projectName.fsproj"
+dotnet new xunit -lang F# -o "Exercises/$Exercise" -n $projectName
+dotnet sln "Exercises/Exercises.sln" add $fsProj
+Remove-Item -Path "Exercises/$Exercise/Program.fs" 
+Remove-Item -Path "Exercises/$Exercise/Tests.fs"
+
+New-Item -Path "Exercises/$Exercise/$projectName.fs" -ItemType File
+New-Item -Path ("Exercises/$Exercise/${projectName}Test.fs") -ItemType File
+New-Item -Path "Exercises/$Exercise/Example.fs" -ItemType File
 [xml]$proj = Get-Content $fsProj
 
-$proj.Project.ItemGroup[0].Compile.Include = "$projectName.fs"
-$exFileTest = $proj.CreateElement("Compile")
-$exFileTest.SetAttribute("Include","$projectName" + "Test.fs")
-$proj.Project.ItemGroup[0].AppendChild($exFileTest)
+$proj.Project.ItemGroup[0].Compile[0].Include = "$projectName.fs"
+$proj.Project.ItemGroup[0].Compile[1].Include = "${projectName}Test.fs"
 $proj.Save($fsProj)


### PR DESCRIPTION
Add a script to automate the setup for a new exercise. The script creates the folder and the project with the empty files:

- [exercise].fs
- [exercise]Test.fs
- Example.fs

and adds a new entry in the config.json file.

The script requires the exercise name to run but accept other parameters in order to write the exercise info in the config.json file.

*Minimal parameters*
`.\add-new-exercise.ps1 -exercise affine-cipher`

*All parameters*
`add-new-exercise.ps1 -exercise affine-cipher -topics "a b c" -core 1 -difficulty 3 -unlocked_by "other-exercise"`


Close #697 

