### PR TITLE
Ensure PowerShell errors are propagated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ paket-files
 .idea/
 .vs/
 .vscode/
+.ionide/
 .dotnet
 *.fsproj.user

--- a/add-new-exercise.ps1
+++ b/add-new-exercise.ps1
@@ -63,3 +63,5 @@ New-Item -Path "Exercises/$Exercise/Example.fs" -ItemType File
 $proj.Project.ItemGroup[0].Compile[0].Include = "$projectName.fs"
 $proj.Project.ItemGroup[0].Compile[1].Include = "${projectName}Test.fs"
 $proj.Save($fsProj)
+
+exit $LastExitCode

--- a/build.ps1
+++ b/build.ps1
@@ -1,2 +1,4 @@
 dotnet tool install -g Cake.Tool --version 0.33.0
 dotnet cake build.cake $args
+
+exit $LastExitCode

--- a/exercises/Exercises.sln
+++ b/exercises/Exercises.sln
@@ -31,8 +31,6 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "BookStore", "book-store\Boo
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Bowling", "bowling\Bowling.fsproj", "{9CC473BB-F839-486B-9C7F-B2A8ADF51877}"
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "BracketPush", "bracket-push\BracketPush.fsproj", "{2EDEE4FD-96AF-4150-AED3-4D9EF61C09E1}"
-EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Change", "change\Change.fsproj", "{11C9FBD6-8261-4171-A3E0-FF3E06F220CB}"
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "CircularBuffer", "circular-buffer\CircularBuffer.fsproj", "{6DC8D401-73A7-41CF-B2CD-B1E6134E2340}"
@@ -100,6 +98,8 @@ EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Luhn", "luhn\Luhn.fsproj", "{627C4E77-1833-49B4-955E-62D2734EBDF4}"
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Markdown", "markdown\Markdown.fsproj", "{BE4BEAE0-39EF-47E8-B50F-F0185F4F67E0}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "MatchingBrackets", "matching-brackets\MatchingBrackets.fsproj", "{2EDEE4FD-96AF-4150-AED3-4D9EF61C09E1}"
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Matrix", "matrix\Matrix.fsproj", "{38635346-7531-40A8-AEDC-08EF4C59F516}"
 EndProject

--- a/exercises/acronym/Example.fs
+++ b/exercises/acronym/Example.fs
@@ -5,6 +5,6 @@ open System.Text.RegularExpressions
 
 let abbreviate (phrase:string) =  
     let acronymChar = Char.ToUpperInvariant << Seq.head
-    let words = Regex.Matches(phrase, "[A-Z]+[a-z]*|[a-z]+")
-    let chars = [|for word in words do yield word.Value |> acronymChar|]        
-    new String(chars)
+    let words = Regex.Matches(phrase, "[A-Z]+[a-z']*|[a-z']+")
+    let chars = [|for word in words do yield word.Value |> acronymChar|]
+    String chars

--- a/exercises/allergies/AllergiesTest.fs
+++ b/exercises/allergies/AllergiesTest.fs
@@ -8,198 +8,198 @@ open Xunit
 open Allergies
 
 [<Fact>]
-let ``Not allergic to anything`` () =
+let ``Testing for eggs allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Eggs |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic only to eggs`` () =
+let ``Testing for eggs allergy - allergic only to eggs`` () =
     allergicTo 1 Allergen.Eggs |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to eggs and something else`` () =
+let ``Testing for eggs allergy - allergic to eggs and something else`` () =
     allergicTo 3 Allergen.Eggs |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to something, but not eggs`` () =
+let ``Testing for eggs allergy - allergic to something, but not eggs`` () =
     allergicTo 2 Allergen.Eggs |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to everything`` () =
+let ``Testing for eggs allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Eggs |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Not allergic to anything`` () =
+let ``Testing for peanuts allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Peanuts |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic only to peanuts`` () =
+let ``Testing for peanuts allergy - allergic only to peanuts`` () =
     allergicTo 2 Allergen.Peanuts |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to peanuts and something else`` () =
+let ``Testing for peanuts allergy - allergic to peanuts and something else`` () =
     allergicTo 7 Allergen.Peanuts |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to something, but not peanuts`` () =
+let ``Testing for peanuts allergy - allergic to something, but not peanuts`` () =
     allergicTo 5 Allergen.Peanuts |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to everything`` () =
+let ``Testing for peanuts allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Peanuts |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Not allergic to anything`` () =
+let ``Testing for shellfish allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Shellfish |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic only to shellfish`` () =
+let ``Testing for shellfish allergy - allergic only to shellfish`` () =
     allergicTo 4 Allergen.Shellfish |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to shellfish and something else`` () =
+let ``Testing for shellfish allergy - allergic to shellfish and something else`` () =
     allergicTo 14 Allergen.Shellfish |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to something, but not shellfish`` () =
+let ``Testing for shellfish allergy - allergic to something, but not shellfish`` () =
     allergicTo 10 Allergen.Shellfish |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to everything`` () =
+let ``Testing for shellfish allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Shellfish |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Not allergic to anything`` () =
+let ``Testing for strawberries allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Strawberries |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic only to strawberries`` () =
+let ``Testing for strawberries allergy - allergic only to strawberries`` () =
     allergicTo 8 Allergen.Strawberries |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to strawberries and something else`` () =
+let ``Testing for strawberries allergy - allergic to strawberries and something else`` () =
     allergicTo 28 Allergen.Strawberries |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to something, but not strawberries`` () =
+let ``Testing for strawberries allergy - allergic to something, but not strawberries`` () =
     allergicTo 20 Allergen.Strawberries |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to everything`` () =
+let ``Testing for strawberries allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Strawberries |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Not allergic to anything`` () =
+let ``Testing for tomatoes allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Tomatoes |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic only to tomatoes`` () =
+let ``Testing for tomatoes allergy - allergic only to tomatoes`` () =
     allergicTo 16 Allergen.Tomatoes |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to tomatoes and something else`` () =
+let ``Testing for tomatoes allergy - allergic to tomatoes and something else`` () =
     allergicTo 56 Allergen.Tomatoes |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to something, but not tomatoes`` () =
+let ``Testing for tomatoes allergy - allergic to something, but not tomatoes`` () =
     allergicTo 40 Allergen.Tomatoes |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to everything`` () =
+let ``Testing for tomatoes allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Tomatoes |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Not allergic to anything`` () =
+let ``Testing for chocolate allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Chocolate |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic only to chocolate`` () =
+let ``Testing for chocolate allergy - allergic only to chocolate`` () =
     allergicTo 32 Allergen.Chocolate |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to chocolate and something else`` () =
+let ``Testing for chocolate allergy - allergic to chocolate and something else`` () =
     allergicTo 112 Allergen.Chocolate |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to something, but not chocolate`` () =
+let ``Testing for chocolate allergy - allergic to something, but not chocolate`` () =
     allergicTo 80 Allergen.Chocolate |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to everything`` () =
+let ``Testing for chocolate allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Chocolate |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Not allergic to anything`` () =
+let ``Testing for pollen allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Pollen |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic only to pollen`` () =
+let ``Testing for pollen allergy - allergic only to pollen`` () =
     allergicTo 64 Allergen.Pollen |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to pollen and something else`` () =
+let ``Testing for pollen allergy - allergic to pollen and something else`` () =
     allergicTo 224 Allergen.Pollen |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to something, but not pollen`` () =
+let ``Testing for pollen allergy - allergic to something, but not pollen`` () =
     allergicTo 160 Allergen.Pollen |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to everything`` () =
+let ``Testing for pollen allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Pollen |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Not allergic to anything`` () =
+let ``Testing for cats allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Cats |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic only to cats`` () =
+let ``Testing for cats allergy - allergic only to cats`` () =
     allergicTo 128 Allergen.Cats |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to cats and something else`` () =
+let ``Testing for cats allergy - allergic to cats and something else`` () =
     allergicTo 192 Allergen.Cats |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to something, but not cats`` () =
+let ``Testing for cats allergy - allergic to something, but not cats`` () =
     allergicTo 64 Allergen.Cats |> should equal false
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Allergic to everything`` () =
+let ``Testing for cats allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Cats |> should equal true
 
 [<Fact(Skip = "Remove to run test")>]
-let ``No allergies`` () =
+let ``List - no allergies`` () =
     list 0 |> should be Empty
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Just eggs`` () =
+let ``List - just eggs`` () =
     list 1 |> should equal [Allergen.Eggs]
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Just peanuts`` () =
+let ``List - just peanuts`` () =
     list 2 |> should equal [Allergen.Peanuts]
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Just strawberries`` () =
+let ``List - just strawberries`` () =
     list 8 |> should equal [Allergen.Strawberries]
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Eggs and peanuts`` () =
+let ``List - eggs and peanuts`` () =
     list 3 |> should equal [Allergen.Eggs; Allergen.Peanuts]
 
 [<Fact(Skip = "Remove to run test")>]
-let ``More than eggs but not peanuts`` () =
+let ``List - more than eggs but not peanuts`` () =
     list 5 |> should equal [Allergen.Eggs; Allergen.Shellfish]
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Lots of stuff`` () =
+let ``List - lots of stuff`` () =
     list 248 |> should equal [Allergen.Strawberries; Allergen.Tomatoes; Allergen.Chocolate; Allergen.Pollen; Allergen.Cats]
 
 [<Fact(Skip = "Remove to run test")>]
-let ``Everything`` () =
+let ``List - everything`` () =
     list 255 |> should equal [Allergen.Eggs; Allergen.Peanuts; Allergen.Shellfish; Allergen.Strawberries; Allergen.Tomatoes; Allergen.Chocolate; Allergen.Pollen; Allergen.Cats]
 
 [<Fact(Skip = "Remove to run test")>]
-let ``No allergen score parts`` () =
+let ``List - no allergen score parts`` () =
     list 509 |> should equal [Allergen.Eggs; Allergen.Shellfish; Allergen.Strawberries; Allergen.Tomatoes; Allergen.Chocolate; Allergen.Pollen; Allergen.Cats]
 

--- a/exercises/high-scores/Example.fs
+++ b/exercises/high-scores/Example.fs
@@ -4,14 +4,6 @@ let scores (values: int list): int list = values
 
 let latest (values: int list): int = List.last values
 
-let highest (values: int list): int = List.max values
+let personalBest (values: int list): int = List.max values
 
-let top  (values: int list): int list = values |> List.sortDescending |> List.truncate 3
-
-let report (values: int list): string =
-    let latest' = latest values
-    let highest' = highest values
-    let difference = highest' - latest'
-    let comparedDifference = if difference = 0 then "" else sprintf "%d short of " difference
-
-    sprintf "Your latest score was %d. That's %syour personal best!" latest' comparedDifference
+let personalTopThree  (values: int list): int list = values |> List.sortDescending |> List.truncate 3

--- a/exercises/high-scores/HighScores.fs
+++ b/exercises/high-scores/HighScores.fs
@@ -4,8 +4,6 @@ let scores (values: int list): int list = failwith "You need to implement this f
 
 let latest (values: int list): int = failwith "You need to implement this function."
 
-let highest (values: int list): int = failwith "You need to implement this function."
+let personalBest (values: int list): int = failwith "You need to implement this function."
 
-let top  (values: int list): int list = failwith "You need to implement this function."
-
-let report (values: int list): string = failwith "You need to implement this function."
+let personalTopThree (values: int list): int list = failwith "You need to implement this function."

--- a/exercises/markdown/Markdown.fs
+++ b/exercises/markdown/Markdown.fs
@@ -66,7 +66,11 @@ let rec parse (markdown: string) =
                html <- html + "<h2>" + lines.[i].[3..] + "</h2>"
            else
                html <- html + "<h1>" + lines.[i].[2..] + "</h1>"
-       else 
+       else
+           if isList then  
+               html <- html + "</ul>"
+               isList <- false
+           
            let mutable line = lines.[i]            
            let mutable __pos = line.IndexOf "__"
 

--- a/exercises/matrix/Example.fs
+++ b/exercises/matrix/Example.fs
@@ -13,9 +13,9 @@ let private parseRows (matrix: string) =
 let row index matrix = 
     matrix
     |> parseRows
-    |> List.item index
+    |> List.item (index - 1)
 
 let column index matrix =
     matrix
     |> parseRows
-    |> List.map (List.item index)
+    |> List.map (List.item (index - 1))

--- a/exercises/phone-number/Example.fs
+++ b/exercises/phone-number/Example.fs
@@ -17,7 +17,7 @@ let private checkNumberLength (input:string): Result<string, string> =
 
 let private checkNoneNumericChars (input:string): Result<string, string> =
     match input with
-    | i when Seq.exists Char.IsLetter i -> Error "alphanumerics not permitted"
+    | i when Seq.exists Char.IsLetter i -> Error "letters not permitted"
     | i when Seq.exists Char.IsPunctuation i -> Error "punctuations not permitted"
     | i when Seq.forall Char.IsNumber i -> Ok input
     | _ -> Error "some char is not a number"

--- a/exercises/saddle-points/Example.fs
+++ b/exercises/saddle-points/Example.fs
@@ -22,6 +22,6 @@ let saddlePoints (matrix: int list list) =
         let isSaddlePoint x y = element x y = rowMax x && element x y = colMin y
 
         [for x in 0 .. (rows - 1) do
-            for y in 0 .. (cols - 1) do            
+            for y in 0 .. (cols - 1) do
                 if isSaddlePoint x y then
-                    yield (x, y)]
+                    yield (x + 1, y + 1)]

--- a/exercises/sgf-parsing/Example.fs
+++ b/exercises/sgf-parsing/Example.fs
@@ -7,11 +7,6 @@ type Tree = Node of Data * Tree list
 
 let mkTree node children = Node (node, children)
 
-let propertyToData = 
-    function 
-    | Some (prop, values) -> Map.ofList [(prop, values)]
-    | None -> Map.empty
-
 let rec nodesToTree (nodes, trees) = 
     match nodes with
     | [] -> failwith "Can only create tree from non-empty nodes list"
@@ -28,7 +23,7 @@ let cValueType = manyChars (normalChar <|> escapedChar)
 let propValue = between (pchar '[') (pchar ']') cValueType
 let propIdent = asciiUpper
 let property = (propIdent |>> string) .>>. many1 propValue
-let node = (pchar ';') >>. opt property |>> propertyToData
+let node = (pchar ';') >>. many property |>> Map.ofList
 let gameTree = (pchar '(') >>. (many1 node) .>>. (many expr) .>> (pchar ')') |>> nodesToTree
 
 exprImpl := gameTree

--- a/exercises/wordy/Example.fs
+++ b/exercises/wordy/Example.fs
@@ -2,47 +2,27 @@ module Wordy
 
 open System.Text.RegularExpressions
 
-type Operation = int -> int
-type Equation = int * (Operation list)
+let private equationRegex = Regex(@"^What is (?<left>-?\d+)(?<operations> (?<operand>plus|minus|multiplied by|divided by) (?<right>-?\d+))*\?$", RegexOptions.Compiled)
 
-let equationRegex = Regex(@"(?<left>-?\d+) (?<operation>-?plus|minus|divided by|multiplied by) (?=(?<right>-?\d+))", RegexOptions.Compiled)
+let private applyOperand left operand right =
+    match operand with
+    | "plus" -> left + right
+    | "minus" -> left - right
+    | "multiplied by" -> left * right
+    | "divided by" -> left / right
+    | _ -> failwith "Unknown operand"
 
-let regexGroupStr (group: string) (m: Match) = m.Groups.[group].Value
-let regexGroupNumber (group: string) (m: Match) = regexGroupStr group m |> int
+let private solve (parsedQuestion: Match): int =
+    let initial = int parsedQuestion.Groups.["left"].Value
+    [0 .. parsedQuestion.Groups.["operations"].Captures.Count - 1]
+    |> List.fold (fun acc i -> applyOperand acc (parsedQuestion.Groups.["operand"].Captures.[i].Value) (int parsedQuestion.Groups.["right"].Captures.[i].Value)) initial 
 
-let calculate (left, operations) = List.fold (fun acc item -> item acc) left operations
-
-let parseRight (m: Match) = regexGroupNumber "right" m
-
-let parseOperand (m: Match) = 
-    match regexGroupStr "operation" m with
-    | "plus"          -> (+)
-    | "minus"         -> (-)
-    | "multiplied by" -> (*)
-    | "divided by"    -> (/)
-    | _ -> failwith "Unknown operation"
-
-let parseOperation (m: Match) =
-    fun x -> (parseOperand m) x (parseRight m)
-
-let parseOperations (matches: MatchCollection) =
-    matches 
-    |> Seq.cast<Match> 
-    |> Seq.map parseOperation
-    |> Seq.toList
-
-let parseLeft (matches: MatchCollection) = 
-    matches 
-    |> Seq.cast 
-    |> Seq.head 
-    |> regexGroupNumber "left" 
-
-let parse (question: string): Equation option =
-    match equationRegex.Matches question with
-    | m when m.Count = 0 -> None
-    | m -> Some (parseLeft m, parseOperations m)
+let private parse (question: string): Match option =
+    match equationRegex.Match question with
+    | m when m.Success -> Some m
+    | _ -> None
 
 let answer (question: string): int option =  
     question 
     |> parse 
-    |> Option.map calculate
+    |> Option.map solve

--- a/generators/Generators.fs
+++ b/generators/Generators.fs
@@ -48,6 +48,12 @@ type Allergies() =
         | "list" -> List.mapRender renderAllergenEnum canonicalDataCase.Expected
         | _ -> base.RenderExpected (canonicalDataCase, key, value)
 
+    override __.UseFullMethodName _ = true
+
+    override __.TestMethodName canonicalDataCase =
+        let testMethodName = base.TestMethodName canonicalDataCase
+        testMethodName.Replace(" when:", "")
+
 type Alphametics() =
     inherit GeneratorExercise()
 

--- a/update-docs.ps1
+++ b/update-docs.ps1
@@ -6,3 +6,5 @@ git submodule update --remote
 
 .\bin\fetch-configlet
 .\bin\configlet generate . -p problem-specifications $args
+
+exit $LastExitCode


### PR DESCRIPTION
When issue https://github.com/exercism/csharp/issues/1299 was created, I found out that there was something wrong with our build pipeline. The [CI run](https://travis-ci.org/exercism/csharp/builds/554366818?utm_source=github_status&utm_medium=notification) had an error, but Travis still thought that it was a succesful build. Apparently, one has to be explicit about returning the error code of called scripts, which is what this PR adds.