### PR TITLE
Reordered parameters to match tests.

### DIFF
--- a/exercises/grep/Grep.fs
+++ b/exercises/grep/Grep.fs
@@ -1,3 +1,3 @@
 ﻿module Grep
 
-let grep pattern flagArguments files = failwith "You need to implement this function."      
+let grep files flagArguments pattern = failwith "You need to implement this function."      


### PR DESCRIPTION
For this exercise, the tests use the ordering file, flags, pattern, but the template uses the ordering pattern, flags, file. This PR fixes it to prevent confusion.