### PR TITLE
Adjust core track to help ease bottlenecks

### DIFF
--- a/config.json
+++ b/config.json
@@ -44,18 +44,6 @@
       ]
     },
     {
-      "slug": "sum-of-multiples",
-      "uuid": "e702b75e-4c9e-40ef-bcb1-674a87222c23",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "lists",
-        "math",
-        "transforming"
-      ]
-    },
-    {
       "slug": "two-fer",
       "uuid": "2ee3cc7a-db3f-4668-9983-ed6d0fea95d1",
       "core": true,
@@ -108,31 +96,6 @@
       "topics": [
         "maps",
         "sorting"
-      ]
-    },
-    {
-      "slug": "collatz-conjecture",
-      "uuid": "8b66e691-508f-40d9-8cee-1d6aec27366e",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 2,
-      "topics": [
-        "algorithms",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "math"
-      ]
-    },
-    {
-      "slug": "armstrong-numbers",
-      "uuid": "e7f74f6c-16ea-40d8-94f7-7034bc6ee938",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 2,
-      "topics": [
-        "integers",
-        "math"
       ]
     },
     {
@@ -224,6 +187,54 @@
       ]
     },
     {
+      "slug": "pig-latin",
+      "uuid": "a002e3db-8e9c-4cbf-b00f-f2090bae5d5a",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 6,
+      "topics": [
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "e702b75e-4c9e-40ef-bcb1-674a87222c23",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "lists",
+        "math",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "8b66e691-508f-40d9-8cee-1d6aec27366e",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 2,
+      "topics": [
+        "algorithms",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "math"
+      ]
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "e7f74f6c-16ea-40d8-94f7-7034bc6ee938",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 2,
+      "topics": [
+        "integers",
+        "math"
+      ]
+    },
+    {
       "slug": "binary-search-tree",
       "uuid": "4e786e56-2658-445f-ac91-64dd9c38dbb3",
       "core": false,
@@ -233,17 +244,6 @@
         "optional_values",
         "searching",
         "trees"
-      ]
-    },
-    {
-      "slug": "pig-latin",
-      "uuid": "a002e3db-8e9c-4cbf-b00f-f2090bae5d5a",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 6,
-      "topics": [
-        "strings",
-        "transforming"
       ]
     },
     {

--- a/config.json
+++ b/config.json
@@ -46,7 +46,7 @@
     {
       "slug": "sum-of-multiples",
       "uuid": "e702b75e-4c9e-40ef-bcb1-674a87222c23",
-      "core": true,
+      "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
@@ -114,7 +114,7 @@
       "slug": "collatz-conjecture",
       "uuid": "8b66e691-508f-40d9-8cee-1d6aec27366e",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": "space-age",
       "difficulty": 2,
       "topics": [
         "algorithms",
@@ -128,7 +128,7 @@
       "slug": "armstrong-numbers",
       "uuid": "e7f74f6c-16ea-40d8-94f7-7034bc6ee938",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": "space-age",
       "difficulty": 2,
       "topics": [
         "integers",
@@ -421,7 +421,7 @@
       "slug": "protein-translation",
       "uuid": "612395a5-238e-4be0-8ce0-4ac66f57056e",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": "space-age",
       "difficulty": 3,
       "topics": [
         "lists",
@@ -489,7 +489,7 @@
       "slug": "binary-search",
       "uuid": "c5b38251-14ba-4d98-a420-7a930f06167f",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": "space-age",
       "difficulty": 3,
       "topics": [
         "lists",
@@ -567,7 +567,7 @@
       "slug": "simple-linked-list",
       "uuid": "e86e88a0-802c-41f4-b2a1-c7a81b8e87de",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": "space-age",
       "difficulty": 4,
       "topics": [
         "lists"
@@ -647,7 +647,7 @@
       "slug": "saddle-points",
       "uuid": "526fc5b4-e96b-419a-8987-9b78e9bddc19",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": "space-age",
       "difficulty": 4,
       "topics": [
         "lists",
@@ -735,7 +735,7 @@
       "slug": "linked-list",
       "uuid": "253f040d-35c2-4e1c-8651-d7a7410d7d0d",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": "space-age",
       "difficulty": 5,
       "topics": [
         "lists"

--- a/config.json
+++ b/config.json
@@ -22,28 +22,6 @@
       ]
     },
     {
-      "slug": "leap",
-      "uuid": "66d974b5-18fc-4993-b5f2-7beda4f4afa3",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_if_else_statements",
-        "integers"
-      ]
-    },
-    {
-      "slug": "bob",
-      "uuid": "b3c4d578-10c8-47bc-b0ae-149ed8da530a",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_if_else_statements",
-        "strings"
-      ]
-    },
-    {
       "slug": "two-fer",
       "uuid": "2ee3cc7a-db3f-4668-9983-ed6d0fea95d1",
       "core": true,
@@ -55,25 +33,14 @@
       ]
     },
     {
-      "slug": "space-age",
-      "uuid": "277d05db-0ba0-4de6-b5f8-090c251afffc",
+      "slug": "leap",
+      "uuid": "66d974b5-18fc-4993-b5f2-7beda4f4afa3",
       "core": true,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "discriminated_unions",
-        "floating_point_numbers"
-      ]
-    },
-    {
-      "slug": "raindrops",
-      "uuid": "0c953a84-e726-4b9f-a964-1950ac2f95f2",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "filtering",
-        "text_formatting"
+        "control_flow_if_else_statements",
+        "integers"
       ]
     },
     {
@@ -88,6 +55,38 @@
       ]
     },
     {
+      "slug": "raindrops",
+      "uuid": "0c953a84-e726-4b9f-a964-1950ac2f95f2",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "filtering",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "space-age",
+      "uuid": "277d05db-0ba0-4de6-b5f8-090c251afffc",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "discriminated_unions",
+        "floating_point_numbers"
+      ]
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "528a0023-8687-4524-8318-516d1e432d0d",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "tuples"
+      ]
+    },
+    {
       "slug": "grade-school",
       "uuid": "cf058dc8-db6f-4034-ac5b-22f1d8d0decc",
       "core": true,
@@ -96,6 +95,28 @@
       "topics": [
         "maps",
         "sorting"
+      ]
+    },
+    {
+      "slug": "clock",
+      "uuid": "30c3a38e-1e44-4711-887e-fca301c26c1b",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "structural_equality",
+        "time"
+      ]
+    },
+    {
+      "slug": "bob",
+      "uuid": "b3c4d578-10c8-47bc-b0ae-149ed8da530a",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "control_flow_if_else_statements",
+        "strings"
       ]
     },
     {
@@ -110,16 +131,6 @@
       ]
     },
     {
-      "slug": "queen-attack",
-      "uuid": "528a0023-8687-4524-8318-516d1e432d0d",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "tuples"
-      ]
-    },
-    {
       "slug": "kindergarten-garden",
       "uuid": "cf64cddf-63e2-4c71-ac15-0af617f82856",
       "core": true,
@@ -128,17 +139,6 @@
       "topics": [
         "enumerations",
         "parsing"
-      ]
-    },
-    {
-      "slug": "clock",
-      "uuid": "30c3a38e-1e44-4711-887e-fca301c26c1b",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "structural_equality",
-        "time"
       ]
     },
     {
@@ -176,17 +176,6 @@
       ]
     },
     {
-      "slug": "tree-building",
-      "uuid": "a53fa908-f983-4da5-b1c1-3989bd2ea2f9",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 5,
-      "topics": [
-        "refactoring",
-        "trees"
-      ]
-    },
-    {
       "slug": "pig-latin",
       "uuid": "a002e3db-8e9c-4cbf-b00f-f2090bae5d5a",
       "core": true,
@@ -195,6 +184,17 @@
       "topics": [
         "strings",
         "transforming"
+      ]
+    },
+    {
+      "slug": "tree-building",
+      "uuid": "a53fa908-f983-4da5-b1c1-3989bd2ea2f9",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 5,
+      "topics": [
+        "refactoring",
+        "trees"
       ]
     },
     {

--- a/config.json
+++ b/config.json
@@ -44,14 +44,13 @@
       ]
     },
     {
-      "slug": "accumulate",
-      "uuid": "e7085050-1611-4773-9032-0e0ffb56c20e",
+      "slug": "queen-attack",
+      "uuid": "528a0023-8687-4524-8318-516d1e432d0d",
       "core": true,
       "unlocked_by": null,
-      "difficulty": 2,
+      "difficulty": 3,
       "topics": [
-        "recursion",
-        "transforming"
+        "tuples"
       ]
     },
     {
@@ -66,6 +65,17 @@
       ]
     },
     {
+      "slug": "accumulate",
+      "uuid": "e7085050-1611-4773-9032-0e0ffb56c20e",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "recursion",
+        "transforming"
+      ]
+    },
+    {
       "slug": "space-age",
       "uuid": "277d05db-0ba0-4de6-b5f8-090c251afffc",
       "core": true,
@@ -74,16 +84,6 @@
       "topics": [
         "discriminated_unions",
         "floating_point_numbers"
-      ]
-    },
-    {
-      "slug": "queen-attack",
-      "uuid": "528a0023-8687-4524-8318-516d1e432d0d",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "tuples"
       ]
     },
     {

--- a/config.json
+++ b/config.json
@@ -1346,7 +1346,10 @@
       "core": false,
       "unlocked_by": "clock",
       "difficulty": 5,
-      "topics": [ "json", "parsing" ]
+      "topics": [
+        "json",
+        "parsing"
+      ]
     },
     {
       "slug": "dnd-character",
@@ -1354,7 +1357,9 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["randomness"]
+      "topics": [
+        "randomness"
+      ]
     }
   ]
 }


### PR DESCRIPTION
I wrote a script that takes some data points into account to move certain core exercises to be optional side exercises, and which reorders the remaining exercises.

This is not meant to be the "be all end all" of perfection :-)
This is an attempt to make some simple changes in the short term. In the longer term, over the next 12 months, the product team will be doing a bunch of work to dig into what makes great Exercism exercises, and how to structure tracks to provide a better experience for both learners and mentors.

**Once this goes live** we will continue to monitor the continuation rate, the median wait time, and a few other stats as well, to help decide whether or not we need to take any other immediate steps. That said, if you see anything weird or worrying once the change is out, please ping us on Slack (or here) so we can discuss a fix posthaste!

**The most helpful thing you can do in reviewing this** is to look at the results and tell me whether anything is obviously terrible or suspiciously weird. I know very little about the F# track (or the language, for that matter), so I could easily have missed something.

I'd also appreciate it if you posted this to the mentors as a heads up, and also because mentors tend to have a great gut sense about the core exercises.

## Bottleneck detection and fixes
### Removal from core:

TL;DR: only `sum-of-multiples` was moved out of core.

This is a list of exercises that typically are unappealing to students and not very interesting to mentor. They tend to be math problems or implementations of CS algorithms and the like.

In this track the only core exercises that were slated for removal were `sum-of-multiples` and `accumulate`. I discussed with @ErikSchierboom and he mentioned that `accumulate` is useful for learning about tail recursion. In the longer term we should probably replace accumulate with a more compelling exercise aimed at tail recursion, but in the meanwhile `accumulate` should stay in core.

### Reordering:

The data that I based the reordering on was taken from the production database, and is based on the last 6 months.

I reordered by taking the original order, and then giving "penalty points" for two different things

- low continuation rates (percentage)
- long wait times in the mentor queue (median wait time in minutes)

"Continuation" is when someone completes an exercise, but then does not submit the following exercise. We have other interesting numbers that we may use to adjust things in the future, but this one seemed like our best bet for now for the bottlenecks. I somewhat arbitrarily chose 70% as the cutoff for whether or not to give penalty points, i.e. continuation rate < 70% gets penalized. The only exercise I did not penalize based on this rate was the exercise directly following `hello-world`, since `hello-world` is basically just a taste test, and it is natural to assume that many people will decide that Exercism is not really for them.

<details>
 <summary>Continuation rates</summary>

_Note that exercises with continuation rates above 100 were previously moved from side exercises to core track._

```
- hello-world (100%)
- leap (77%)
- bob (49%)
- sum-of-multiples (66%)
- two-fer (81%)
- space-age (81%)
- raindrops (87%)
- accumulate (83%)
- grade-school (90%)
- beer-song (88%)
- queen-attack (76%)
- kindergarten-garden (90%)
- clock (92%)
- robot-simulator (88%)
- allergies (105%)
- ocr-numbers (73%)
- tree-building (88%)
- pig-latin (64%)
```

</details>

Long wait times in the mentor queue is an indication that mentors don't enjoy mentoring the exercise, or put it off. This could be for a number of reasons, which we have not explicitly identified, but we've observed that sometimes the exercise is simply too difficult in the current position, which means that mentors have to go back and forth a whole bunch with students to get something right, and the discussions can be quite frustrating. Also sometimes the exercise is just not very interesting to mentor. Or if the exercise is too early in the track sometimes people will submit lots of really complicated solutions rather than a small handful of mostly reasonable solutions, also making it harder to mentor.

So this pushes exercises with long wait times further back in the core track. We may decide that we need to remove some exercises from core altogether, if wait times continue to be bad.

<details>
 <summary>Wait times</summary>

```
- hello-world (0 min)
- leap (3560 min)
- bob (2511 min)
- sum-of-multiples (307 min)
- two-fer (463 min)
- space-age (2387 min)
- raindrops (1278 min)
- accumulate (235 min)
- grade-school (2583 min)
- beer-song (3753 min)
- queen-attack (138 min)
- kindergarten-garden (3848 min)
- clock (841 min)
- robot-simulator (3022 min)
- allergies (10227 min)
- ocr-numbers (13997 min)
- tree-building (112681 min)
- pig-latin (15732 min)
```
</details>

### Outcome

#### Before
```
- hello-world
- leap
- bob
- sum-of-multiples
- two-fer
- space-age
- raindrops
- accumulate
- grade-school
- beer-song
- queen-attack
- kindergarten-garden
- clock
- robot-simulator
- allergies
- ocr-numbers
- tree-building
- pig-latin
```

#### After
```
- hello-world
- two-fer (-3)
- leap (+1)
- accumulate (-4)
- raindrops (-2)
- space-age
- queen-attack (-4)
- grade-school (-1)
- clock (-4)
- bob (+7)
- beer-song (+1)
- kindergarten-garden
- robot-simulator (-1)
- allergies (-1)
- ocr-numbers (-1)
- pig-latin (-2)
- tree-building
```