### PR TITLE
add local dotnet tools

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {}
+}

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,5 +1,12 @@
 {
   "version": 1,
   "isRoot": true,
-  "tools": {}
+  "tools": {
+    "dotnet-fsharplint": {
+      "version": "0.12.3",
+      "commands": [
+        "dotnet-fsharplint"
+      ]
+    }
+  }
 }

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "dotnet-fsharplint"
       ]
+    },
+    "fantomas-tool": {
+      "version": "2.9.2",
+      "commands": [
+        "fantomas"
+      ]
     }
   }
 }

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-fsharplint": {
-      "version": "0.12.3",
+      "version": "0.12.5",
       "commands": [
         "dotnet-fsharplint"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,6 +13,12 @@
       "commands": [
         "fantomas"
       ]
+    },
+    "powershell": {
+      "version": "6.2.3",
+      "commands": [
+        "pwsh"
+      ]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please see the [contributing guide](https://github.com/exercism/docs/tree/master
 
 ## Local Tools
 
-[PowerShell](https://github.com/PowerShell/PowerShell), [Fantomas](https://github.com/fsprojects/fantomas), and [FSharpLint](https://github.com/fsprojects/FSharpLint) are are available in this repo as [local tools](https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0#local-tools). Example usage:
+[PowerShell](https://github.com/PowerShell/PowerShell), [Fantomas](https://github.com/fsprojects/fantomas), and [FSharpLint](https://github.com/fsprojects/FSharpLint) are are available in this repo as [local tools](https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0#local-tools). (This requires [.NET Core](https://dotnet.microsoft.com/download) >=3.0) Example usage:
 
 ```
 > dotnet tool restore

--- a/README.md
+++ b/README.md
@@ -13,6 +13,33 @@ We have a [gitter channel](https://gitter.im/exercism/xfsharp) where you can get
 
 Please see the [contributing guide](https://github.com/exercism/docs/tree/master/contributing-to-language-tracks)
 
+## Local Tools
+
+[PowerShell](https://github.com/PowerShell/PowerShell), [Fantomas](https://github.com/fsprojects/fantomas), and [FSharpLint](https://github.com/fsprojects/FSharpLint) are are available in this repo as [local tools](https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0#local-tools). Example usage:
+
+```
+> dotnet tool restore
+Tool 'dotnet-fsharplint' (version '0.12.3') was restored. Available commands: dotnet-fsharplint
+Tool 'fantomas-tool' (version '2.9.2') was restored. Available commands: fantomas
+Tool 'powershell' (version '6.2.3') was restored. Available commands: pwsh
+
+Restore was successful.
+
+> dotnet fsharplint -sf generators/Track.fs
+========== Linting generators/Track.fs ==========
+========== Finished: 0 warnings ==========
+========== Summary: 0 warnings ==========
+
+> dotnet fantomas generators/Track.fs
+generators/Track.fs has been written.
+
+> dotnet pwsh ./test.ps1
+Linting config.json
+-> An implementation for 'bracket-push' was found, but config.json does not reference this exercise.
+-> The implementation for 'bracket-push' is missing a README.
+-> The implementation for 'bracket-push' is missing an example solution.
+-> The implementation for 'bracket-push' is missing a test suite.
+```
 
 ### F# icon
 The F# Software Foundation logo for F# is an asset of the F# Software Foundation. We have adapted it with permission.


### PR DESCRIPTION
This PR adds fsharplint, fantomas, and powershell, which can be invoked like:

```
jrr@jrrmbp ~/r/e/fsharp (feature/dotnet-tools)> dotnet tool restore
Tool 'dotnet-fsharplint' (version '0.12.3') was restored. Available commands: dotnet-fsharplint
Tool 'fantomas-tool' (version '2.9.2') was restored. Available commands: fantomas
Tool 'powershell' (version '6.2.3') was restored. Available commands: pwsh

Restore was successful.
jrr@jrrmbp ~/r/e/fsharp (feature/dotnet-tools)> dotnet fsharplint -sf generators/Track.fs
========== Linting generators/Track.fs ==========
========== Finished: 0 warnings ==========
========== Summary: 0 warnings ==========
jrr@jrrmbp ~/r/e/fsharp (feature/dotnet-tools)> dotnet fantomas generators/Track.fs
generators/Track.fs has been written.
jrr@jrrmbp ~/r/e/fsharp (feature/dotnet-tools)> dotnet pwsh ./test.ps1
Linting config.json
-> An implementation for 'bracket-push' was found, but config.json does not reference this exercise.
-> The implementation for 'bracket-push' is missing a README.
-> The implementation for 'bracket-push' is missing an example solution.
-> The implementation for 'bracket-push' is missing a test suite.
jrr@jrrmbp ~/r/e/fsharp (feature/dotnet-tools) [1]>
```

These seem like tools that contributors on this repo would want around, and providing them takes small steps toward https://github.com/exercism/fsharp/issues/306 and https://github.com/exercism/fsharp/issues/668 .