### PR TITLE
Add test that will fail for non-tail-recursive implementations

### DIFF
--- a/exercises/accumulate/AccumulateTest.fs
+++ b/exercises/accumulate/AccumulateTest.fs
@@ -35,3 +35,8 @@ let ``Accumulate reversed strings`` () =
 let ``Accumulate within accumulate`` () =
     accumulate (fun (x:string) -> String.concat " " (accumulate (fun y -> x + y) ["1"; "2"; "3"])) ["a"; "b"; "c"]
     |> should equal ["a1 a2 a3"; "b1 b2 b3"; "c1 c2 c3"]
+
+[<Fact(Skip = "Remove to run test")>]
+let ``Accumulate large data set without stack overflow`` () =
+    accumulate id [1..100000]
+    |> should equal [1..100000]

--- a/exercises/accumulate/AccumulateTest.fs
+++ b/exercises/accumulate/AccumulateTest.fs
@@ -1,4 +1,4 @@
-// This file was created manually and its version is 1.0.0
+// This file was created manually and its version is 2.0.0
 
 module AccumulateTest
 


### PR DESCRIPTION
It's a bit hard to know if an implementation is tail-recursive [without looking at the MSIL](https://devblogs.microsoft.com/fsharpteam/tail-calls-in-f/).

This test should cause a `StackOverflowException` to be thrown when `accumulate` has a non-tail recursive implementation.
![image](https://user-images.githubusercontent.com/10026538/68087721-2c903d80-fe50-11e9-9c45-f7eccf73b151.png)
Which unfortunately takes down the test host but I guess that's not the end of the world.

When `accumulate` has a tail-recursive implementation then the test passes
![image](https://user-images.githubusercontent.com/10026538/68088093-77f81b00-fe53-11e9-82aa-b93a87884f61.png)

And the test run time is similar without this new test (thinking that the new test might be slow)
![image](https://user-images.githubusercontent.com/10026538/68088050-1d5ebf00-fe53-11e9-9f1d-81f2445ffb49.png)