### PR TITLE
Add Fantomas to exercises

### DIFF
--- a/add-new-exercise.ps1
+++ b/add-new-exercise.ps1
@@ -46,6 +46,8 @@ function Add-Project {
     $fsProj = "$exerciseDir/$exerciseName.fsproj"
 
     Run-Command "dotnet new xunit -lang ""F#"" -o $exerciseDir -n $exerciseName"
+    Run-Command "dotnet new tool-manifest -o $exerciseDir"
+    Run-Command "dotnet tool install --tool-manifest $exerciseDir/.config/dotnet-tools.json fantomas-tool"
     Run-Command "dotnet sln ""$exercisesDir/Exercises.sln"" add $fsProj"
     
     Remove-Item -Path "$exerciseDir/Program.fs" 

--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -8,6 +8,12 @@
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/accumulate/.config/dotnet-tools.json
+++ b/exercises/accumulate/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -35,6 +35,12 @@ For this exercise the following F# feature comes in handy:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/acronym/.config/dotnet-tools.json
+++ b/exercises/acronym/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -11,6 +11,12 @@ like Portable Network Graphics to its acronym (PNG).
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/affine-cipher/.config/dotnet-tools.json
+++ b/exercises/affine-cipher/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/affine-cipher/README.md
+++ b/exercises/affine-cipher/README.md
@@ -2,43 +2,43 @@
 
 Create an implementation of the affine cipher,
 an ancient encryption system created in the Middle East.
- 
+
 The affine cipher is a type of monoalphabetic substitution cipher.
 Each character is mapped to its numeric equivalent, encrypted with
 a mathematical function and then converted to the letter relating to
 its new numeric value. Although all monoalphabetic ciphers are weak,
 the affine cypher is much stronger than the atbash cipher,
 because it has many more keys.
- 
+
 the encryption function is:
- 
+
   `E(x) = (ax + b) mod m`
   -  where `x` is the letter's index from 0 - length of alphabet - 1
   -  `m` is the length of the alphabet. For the roman alphabet `m == 26`.
   -  and `a` and `b` make the key
- 
+
 the decryption function is:
- 
+
   `D(y) = a^-1(y - b) mod m`
   -  where `y` is the numeric value of an encrypted letter, ie. `y = E(x)`
   -  it is important to note that `a^-1` is the modular multiplicative inverse
      of `a mod m`
   -  the modular multiplicative inverse of `a` only exists if `a` and `m` are
      coprime.
- 
+
 To find the MMI of `a`:
 
   `an mod m = 1`
   -  where `n` is the modular multiplicative inverse of `a mod m`
 
 More information regarding how to find a Modular Multiplicative Inverse
-and what it means can be found [here.](https://en.wikipedia.org/wiki/Modular_multiplicative_inverse) 
+and what it means can be found [here.](https://en.wikipedia.org/wiki/Modular_multiplicative_inverse)
 
 Because automatic decryption fails if `a` is not coprime to `m` your
 program should return status 1 and `"Error: a and m must be coprime."`
 if they are not.  Otherwise it should encode or decode with the
 provided key.
- 
+
 The Caesar (shift) cipher is a simple affine cipher where `a` is 1 and
 `b` as the magnitude results in a static displacement of the letters.
 This is much less secure than a full implementation of the affine cipher.
@@ -48,7 +48,7 @@ size being 5 letters, and punctuation is excluded. This is to make it
 harder to guess things based on word boundaries.
 
 ## Examples
- 
+
  - Encoding `test` gives `ybty` with the key a=5 b=7
  - Decoding `ybty` gives `test` with the key a=5 b=7
  - Decoding `ybty` gives `lqul` with the wrong key a=11 b=7
@@ -72,6 +72,12 @@ harder to guess things based on word boundaries.
 ## Running the tests
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
+
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
 
 ## Further information
 

--- a/exercises/all-your-base/.config/dotnet-tools.json
+++ b/exercises/all-your-base/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -35,6 +35,12 @@ I think you got the idea!
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/allergies/.config/dotnet-tools.json
+++ b/exercises/allergies/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -33,6 +33,12 @@ score is 257, your program should only report the eggs (1) allergy.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/alphametics/.config/dotnet-tools.json
+++ b/exercises/alphametics/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -41,6 +41,12 @@ Try to find a more sophisticated solution. Hint: You could try the column-wise a
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/anagram/.config/dotnet-tools.json
+++ b/exercises/anagram/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -1,6 +1,7 @@
 # Anagram
 
-Given a word and a list of possible anagrams, select the correct sublist.
+An anagram is a rearrangement of letters to form a new word.
+Given a word and a list of candidates, select the sublist of anagrams of the given word.
 
 Given `"listen"` and a list of candidates like `"enlists" "google"
 "inlets" "banana"` the program should return a list containing
@@ -9,6 +10,12 @@ Given `"listen"` and a list of candidates like `"enlists" "google"
 ## Running the tests
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
+
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
 
 ## Further information
 

--- a/exercises/armstrong-numbers/.config/dotnet-tools.json
+++ b/exercises/armstrong-numbers/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -15,6 +15,12 @@ Write some code to determine whether a number is an Armstrong number.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/atbash-cipher/.config/dotnet-tools.json
+++ b/exercises/atbash-cipher/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -32,6 +32,12 @@ things based on word boundaries.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/bank-account/.config/dotnet-tools.json
+++ b/exercises/bank-account/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/bank-account/README.md
+++ b/exercises/bank-account/README.md
@@ -30,6 +30,12 @@ Have fun!
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/beer-song/.config/dotnet-tools.json
+++ b/exercises/beer-song/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -328,6 +328,12 @@ experiment make the code better? Worse? Did you learn anything from it?
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/binary-search-tree/.config/dotnet-tools.json
+++ b/exercises/binary-search-tree/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/binary-search-tree/README.md
+++ b/exercises/binary-search-tree/README.md
@@ -57,6 +57,12 @@ And if we then added 1, 5, and 7, it would look like this
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/binary-search/.config/dotnet-tools.json
+++ b/exercises/binary-search/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -38,6 +38,12 @@ A binary search is a dichotomic divide and conquer search algorithm.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/binary/.config/dotnet-tools.json
+++ b/exercises/binary/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -34,6 +34,12 @@ So: `101 => 1*2^2 + 0*2^1 + 1*2^0 => 1*4 + 0*2 + 1*1 => 4 + 1 => 5 base 10`.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/bob/.config/dotnet-tools.json
+++ b/exercises/bob/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -2,9 +2,9 @@
 
 Bob is a lackadaisical teenager. In conversation, his responses are very limited.
 
-Bob answers 'Sure.' if you ask him a question.
+Bob answers 'Sure.' if you ask him a question, such as "How are you?".
 
-He answers 'Whoa, chill out!' if you yell at him.
+He answers 'Whoa, chill out!' if you YELL AT HIM (in all capitals).
 
 He answers 'Calm down, I know what I'm doing!' if you yell a question at him.
 
@@ -18,6 +18,12 @@ Bob's conversational partner is a purist when it comes to written communication 
 ## Running the tests
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
+
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
 
 ## Further information
 

--- a/exercises/book-store/.config/dotnet-tools.json
+++ b/exercises/book-store/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/book-store/README.md
+++ b/exercises/book-store/README.md
@@ -71,6 +71,12 @@ And $51.20 is the price with the biggest discount.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/bowling/.config/dotnet-tools.json
+++ b/exercises/bowling/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -64,6 +64,12 @@ support two operations:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/change/.config/dotnet-tools.json
+++ b/exercises/change/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -20,6 +20,12 @@ that the sum of the coins' value would equal the correct amount of change.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/circular-buffer/.config/dotnet-tools.json
+++ b/exercises/circular-buffer/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -54,6 +54,12 @@ the buffer is once again full.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/clock/.config/dotnet-tools.json
+++ b/exercises/clock/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -10,6 +10,12 @@ Two clocks that represent the same time should be equal to each other.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/collatz-conjecture/.config/dotnet-tools.json
+++ b/exercises/collatz-conjecture/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -30,6 +30,12 @@ Resulting in 9 steps. So for input n = 12, the return value would be 9.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/complex-numbers/.config/dotnet-tools.json
+++ b/exercises/complex-numbers/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/complex-numbers/README.md
+++ b/exercises/complex-numbers/README.md
@@ -32,6 +32,12 @@ Assume the programming language you are using does not have an implementation of
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/connect/.config/dotnet-tools.json
+++ b/exercises/connect/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -5,18 +5,18 @@ Compute the result for a game of Hex / Polygon.
 The abstract boardgame known as
 [Hex](https://en.wikipedia.org/wiki/Hex_%28board_game%29) / Polygon /
 CON-TAC-TIX is quite simple in rules, though complex in practice. Two players
-place stones on a rhombus with hexagonal fields. The player to connect his/her
-stones to the opposite side first wins. The four sides of the rhombus are
+place stones on a parallelogram with hexagonal fields. The player to connect his/her
+stones to the opposite side first wins. The four sides of the parallelogram are
 divided between the two players (i.e. one player gets assigned a side and the
 side directly opposite it and the other player gets assigned the two other
 sides).
 
 Your goal is to build a program that given a simple representation of a board
 computes the winner (or lack thereof). Note that all games need not be "fair".
-(For example, players may have mismatched piece counts.)
+(For example, players may have mismatched piece counts or the game's board might
+have a different width and height.)
 
-The boards look like this (with spaces added for readability, which won't be in
-the representation passed to your code):
+The boards look like this:
 
 ```text
 . O . X .
@@ -33,6 +33,12 @@ won since `O` didn't connect top and bottom.
 ## Running the tests
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
+
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
 
 ## Further information
 

--- a/exercises/crypto-square/.config/dotnet-tools.json
+++ b/exercises/crypto-square/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -76,6 +76,12 @@ ciphertext back in to the original message:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/custom-set/.config/dotnet-tools.json
+++ b/exercises/custom-set/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -11,6 +11,12 @@ unique elements.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/darts/.config/dotnet-tools.json
+++ b/exercises/darts/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/darts/README.md
+++ b/exercises/darts/README.md
@@ -19,6 +19,12 @@ Write a function that given a point in the target (defined by its `real` cartesi
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if
@@ -26,5 +32,5 @@ you're having trouble, please visit the exercism.io [F# language page](http://ex
 
 ## Source
 
-Inspired by an excersie created by a professor Della Paolera in Argentina
+Inspired by an exercise created by a professor Della Paolera in Argentina
 

--- a/exercises/diamond/.config/dotnet-tools.json
+++ b/exercises/diamond/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -59,6 +59,12 @@ E·······E
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/difference-of-squares/.config/dotnet-tools.json
+++ b/exercises/difference-of-squares/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -26,6 +26,12 @@ For this exercise the following F# features come in handy:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/diffie-hellman/.config/dotnet-tools.json
+++ b/exercises/diffie-hellman/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -46,6 +46,12 @@ For this exercise the following F# feature comes in handy:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/dnd-character/.config/dotnet-tools.json
+++ b/exercises/dnd-character/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/dnd-character/README.md
+++ b/exercises/dnd-character/README.md
@@ -36,6 +36,12 @@ programming languages are designed to roll dice. One such language is [Troll].
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/dominoes/.config/dotnet-tools.json
+++ b/exercises/dominoes/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -18,6 +18,12 @@ Some test cases may use duplicate stones in a chain solution, assume that multip
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/dot-dsl/.config/dotnet-tools.json
+++ b/exercises/dot-dsl/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/dot-dsl/README.md
+++ b/exercises/dot-dsl/README.md
@@ -1,10 +1,12 @@
 # DOT DSL
 
-Write a Domain Specific Language similar to the Graphviz dot language.
-
 A [Domain Specific Language
 (DSL)](https://en.wikipedia.org/wiki/Domain-specific_language) is a
-small language optimized for a specific domain.
+small language optimized for a specific domain. Since a DSL is
+targeted, it can greatly impact productivity/understanding by allowing the
+writer to declare *what* they want rather than *how*.
+
+One problem area where they are applied are complex customizations/configurations.
 
 For example the [DOT language](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) allows
 you to write a textual description of a graph which is then transformed into a picture by one of
@@ -21,14 +23,31 @@ Putting this in a file `example.dot` and running `dot example.dot -T png
 -o example.png` creates an image `example.png` with red and blue circle
 connected by a green line on a yellow background.
 
-Create a DSL similar to the dot language.
+Write a Domain Specific Language similar to the Graphviz dot language.
+
+Our DSL is similar to the Graphviz dot language in that our DSL will be used
+to create graph data structures. However, unlike the DOT Language, our DSL will
+be an internal DSL for use only in our language.
+
+More information about the difference between internal and external DSLs can be
+found [here](https://martinfowler.com/bliki/DomainSpecificLanguage.html).
 
 ## Running the tests
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if
 you're having trouble, please visit the exercism.io [F# language page](http://exercism.io/languages/fsharp/resources).
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/DOT_(graph_description_language)](https://en.wikipedia.org/wiki/DOT_(graph_description_language))
 

--- a/exercises/error-handling/.config/dotnet-tools.json
+++ b/exercises/error-handling/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/error-handling/README.md
+++ b/exercises/error-handling/README.md
@@ -13,6 +13,12 @@ for your track to see what's exactly required.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/etl/.config/dotnet-tools.json
+++ b/exercises/etl/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -13,7 +13,7 @@ moaning about how stupid we could possibly be.)
 
 ### The goal
 
-We're going to extract some scrabble scores from a legacy system.
+We're going to extract some Scrabble scores from a legacy system.
 
 The old system stored a list of letters per score:
 
@@ -25,7 +25,7 @@ The old system stored a list of letters per score:
 - 8 points: "J", "X",
 - 10 points: "Q", "Z",
 
-The shiny new scrabble system instead stores the score per letter, which
+The shiny new Scrabble system instead stores the score per letter, which
 makes it much faster and easier to calculate the score for a word. It
 also stores the letters in lower-case regardless of the case of the
 input letters:
@@ -49,6 +49,12 @@ game while being scored at 4 in the Hawaiian-language version.
 ## Running the tests
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
+
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
 
 ## Further information
 

--- a/exercises/food-chain/.config/dotnet-tools.json
+++ b/exercises/food-chain/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/food-chain/README.md
+++ b/exercises/food-chain/README.md
@@ -71,6 +71,12 @@ She's dead, of course!
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/forth/.config/dotnet-tools.json
+++ b/exercises/forth/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -29,6 +29,12 @@ Words are case-insensitive.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/gigasecond/.config/dotnet-tools.json
+++ b/exercises/gigasecond/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -9,6 +9,12 @@ A gigasecond is 10^9 (1,000,000,000) seconds.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/go-counting/.config/dotnet-tools.json
+++ b/exercises/go-counting/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/go-counting/README.md
+++ b/exercises/go-counting/README.md
@@ -39,6 +39,12 @@ Library](http://senseis.xmp.net/).
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/grade-school/.config/dotnet-tools.json
+++ b/exercises/grade-school/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -15,8 +15,11 @@ In the end, you should be able to:
   as 1, 2, 3, etc., and students within a grade should be sorted
   alphabetically by name.
   - "Who all is enrolled in school right now?"
-  - "Grade 1: Anna, Barb, and Charlie. Grade 2: Alex, Peter, and Zoe.
-    Grade 3…"
+  - "Let me think. We have
+  Anna, Barb, and Charlie in grade 1,
+  Alex, Peter, and Zoe in grade 2
+  and Jim in grade 5.
+  So the answer is: Anna, Barb, Charlie, Alex, Peter, Zoe and Jim"
 
 Note that all our students only have one name.  (It's a small town, what
 do you want?)
@@ -43,6 +46,12 @@ For this exercise the following F# feature comes in handy:
 ## Running the tests
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
+
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
 
 ## Further information
 

--- a/exercises/grains/.config/dotnet-tools.json
+++ b/exercises/grains/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -35,6 +35,12 @@ For this exercise the following F# features come in handy:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/grep/.config/dotnet-tools.json
+++ b/exercises/grep/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -68,6 +68,12 @@ print the names of files that do not contain the string "hello".
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/hamming/.config/dotnet-tools.json
+++ b/exercises/hamming/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -27,6 +27,12 @@ exception vs returning a special value) may differ between languages.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/hangman/.config/dotnet-tools.json
+++ b/exercises/hangman/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/hangman/README.md
+++ b/exercises/hangman/README.md
@@ -21,6 +21,12 @@ be described in the language/track specific files of the exercise.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/hello-world/.config/dotnet-tools.json
+++ b/exercises/hello-world/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -18,6 +18,12 @@ If everything goes well, you will be ready to fetch your first real exercise.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/hexadecimal/.config/dotnet-tools.json
+++ b/exercises/hexadecimal/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -11,6 +11,12 @@ The program should handle invalid hexadecimal strings.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/high-scores/.config/dotnet-tools.json
+++ b/exercises/high-scores/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/high-scores/README.md
+++ b/exercises/high-scores/README.md
@@ -8,6 +8,12 @@ Your task is to build a high-score component of the classic Frogger game, one of
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/house/.config/dotnet-tools.json
+++ b/exercises/house/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/house/README.md
+++ b/exercises/house/README.md
@@ -113,6 +113,12 @@ that lay in the house that Jack built.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/isbn-verifier/.config/dotnet-tools.json
+++ b/exercises/isbn-verifier/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -40,9 +40,16 @@ Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (represen
 * Generate a valid ISBN-13 from the input ISBN-10 (and maybe verify it again with a derived verifier).
 
 * Generate valid ISBN, maybe even from a given starting ISBN.
+
 ## Running the tests
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
+
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
 
 ## Further information
 

--- a/exercises/isogram/.config/dotnet-tools.json
+++ b/exercises/isogram/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -17,6 +17,12 @@ The word *isograms*, however, is not an isogram, because the s repeats.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/kindergarten-garden/.config/dotnet-tools.json
+++ b/exercises/kindergarten-garden/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/kindergarten-garden/README.md
+++ b/exercises/kindergarten-garden/README.md
@@ -63,6 +63,12 @@ While asking for Bob's plants would yield:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/largest-series-product/.config/dotnet-tools.json
+++ b/exercises/largest-series-product/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -17,6 +17,12 @@ the largest product for a series of 6 digits is 23520.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/leap/.config/dotnet-tools.json
+++ b/exercises/leap/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -32,6 +32,12 @@ which you should pretend doesn't exist for the purposes of implementing this exe
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/ledger/.config/dotnet-tools.json
+++ b/exercises/ledger/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/ledger/README.md
+++ b/exercises/ledger/README.md
@@ -18,6 +18,12 @@ containing that log, this will help reviewers.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/lens-person/.config/dotnet-tools.json
+++ b/exercises/lens-person/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/lens-person/README.md
+++ b/exercises/lens-person/README.md
@@ -15,6 +15,12 @@ different approaches.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/linked-list/.config/dotnet-tools.json
+++ b/exercises/linked-list/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -47,6 +47,12 @@ x <- "new value"
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/list-ops/.config/dotnet-tools.json
+++ b/exercises/list-ops/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -6,7 +6,7 @@ In functional languages list operations like `length`, `map`, and
 `reduce` are very common. Implement a series of basic list operations,
 without using existing functions.
 
-The precise number and names of the operations to be implemented will be 
+The precise number and names of the operations to be implemented will be
 track dependent to avoid conflicts with existing names, but the general
 operations you will implement include:
 
@@ -22,6 +22,12 @@ operations you will implement include:
 ## Running the tests
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
+
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
 
 ## Further information
 

--- a/exercises/luhn/.config/dotnet-tools.json
+++ b/exercises/luhn/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -68,6 +68,12 @@ Sum the digits
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/markdown/.config/dotnet-tools.json
+++ b/exercises/markdown/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/markdown/README.md
+++ b/exercises/markdown/README.md
@@ -18,6 +18,12 @@ important thing is to make the code better!
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/matching-brackets/.config/dotnet-tools.json
+++ b/exercises/matching-brackets/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/matching-brackets/README.md
+++ b/exercises/matching-brackets/README.md
@@ -8,6 +8,12 @@ and nested correctly.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/matrix/.config/dotnet-tools.json
+++ b/exercises/matrix/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/matrix/README.md
+++ b/exercises/matrix/README.md
@@ -44,6 +44,12 @@ And its columns:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/meetup/.config/dotnet-tools.json
+++ b/exercises/meetup/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -30,6 +30,12 @@ descriptor calculate the date of the actual meetup.  For example, if given
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/minesweeper/.config/dotnet-tools.json
+++ b/exercises/minesweeper/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -1,34 +1,50 @@
 # Minesweeper
 
-Add the numbers to a minesweeper board.
+Add the mine counts to a completed Minesweeper board.
 
 Minesweeper is a popular game where the user has to find the mines using
 numeric hints that indicate how many mines are directly adjacent
 (horizontally, vertically, diagonally) to a square.
 
 In this exercise you have to create some code that counts the number of
-mines adjacent to a square and transforms boards like this (where `*`
-indicates a mine):
+mines adjacent to a given empty square and replaces that square with the
+count.
 
-    +-----+
-    | * * |
-    |  *  |
-    |  *  |
-    |     |
-    +-----+
+The board is a rectangle composed of blank space (' ') characters. A mine
+is represented by an asterisk ('\*') character.
 
-into this:
+If a given space has no adjacent mines at all, leave that square blank.
 
-    +-----+
-    |1*3*1|
-    |13*31|
-    | 2*2 |
-    | 111 |
-    +-----+
+## Examples
+
+For example you may receive a 5 x 4 board like this (empty spaces are
+represented here with the '·' character for display on screen):
+
+```
+·*·*·
+··*··
+··*··
+·····
+```
+
+And your code will transform it into this:
+
+```
+1*3*1
+13*31
+·2*2·
+·111·
+```
 
 ## Running the tests
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
+
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
 
 ## Further information
 

--- a/exercises/nth-prime/.config/dotnet-tools.json
+++ b/exercises/nth-prime/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -18,6 +18,12 @@ Note: to help speedup calculation, you should not check numbers which you know b
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/nucleotide-count/.config/dotnet-tools.json
+++ b/exercises/nucleotide-count/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -16,6 +16,12 @@ Here is an analogy:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/ocr-numbers/.config/dotnet-tools.json
+++ b/exercises/ocr-numbers/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -82,6 +82,12 @@ Is converted to "123,456,789"
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/octal/.config/dotnet-tools.json
+++ b/exercises/octal/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/octal/README.md
+++ b/exercises/octal/README.md
@@ -50,6 +50,12 @@ So:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/palindrome-products/.config/dotnet-tools.json
+++ b/exercises/palindrome-products/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -40,6 +40,12 @@ The largest palindrome product is `9009`. Its factors are `(91, 99)`.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/pangram/.config/dotnet-tools.json
+++ b/exercises/pangram/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -12,6 +12,12 @@ insensitive. Input will not contain non-ASCII symbols.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/parallel-letter-frequency/.config/dotnet-tools.json
+++ b/exercises/parallel-letter-frequency/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -15,6 +15,12 @@ For this exercise the following F# feature comes in handy:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/pascals-triangle/.config/dotnet-tools.json
+++ b/exercises/pascals-triangle/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -18,6 +18,12 @@ the right and left of the current position in the previous row.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/perfect-numbers/.config/dotnet-tools.json
+++ b/exercises/perfect-numbers/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -21,6 +21,12 @@ Implement a way to determine whether a given number is **perfect**. Depending on
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/phone-number/.config/dotnet-tools.json
+++ b/exercises/phone-number/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -32,6 +32,12 @@ should all produce the output
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/pig-latin/.config/dotnet-tools.json
+++ b/exercises/pig-latin/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -21,6 +21,12 @@ See <http://en.wikipedia.org/wiki/Pig_latin> for more details.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/poker/.config/dotnet-tools.json
+++ b/exercises/poker/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/poker/README.md
+++ b/exercises/poker/README.md
@@ -12,6 +12,12 @@ overview of poker hands.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/pov/.config/dotnet-tools.json
+++ b/exercises/pov/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/pov/README.md
+++ b/exercises/pov/README.md
@@ -41,6 +41,12 @@ of view of one of the nodes.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/prime-factors/.config/dotnet-tools.json
+++ b/exercises/prime-factors/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -33,6 +33,12 @@ You can check this yourself:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/protein-translation/.config/dotnet-tools.json
+++ b/exercises/protein-translation/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -45,6 +45,12 @@ Learn more about [protein translation on Wikipedia](http://en.wikipedia.org/wiki
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/proverb/.config/dotnet-tools.json
+++ b/exercises/proverb/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -24,6 +24,12 @@ Note that the list of inputs may vary; your solution should be able to handle li
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/pythagorean-triplet/.config/dotnet-tools.json
+++ b/exercises/pythagorean-triplet/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -27,6 +27,12 @@ For example, with N = 1000, there is exactly one Pythagorean triplet for which `
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/queen-attack/.config/dotnet-tools.json
+++ b/exercises/queen-attack/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -30,6 +30,12 @@ share a diagonal.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/rail-fence-cipher/.config/dotnet-tools.json
+++ b/exercises/rail-fence-cipher/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/rail-fence-cipher/README.md
+++ b/exercises/rail-fence-cipher/README.md
@@ -62,6 +62,12 @@ If you now read along the zig-zag shape you can read the original message.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/raindrops/.config/dotnet-tools.json
+++ b/exercises/raindrops/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -1,21 +1,19 @@
 # Raindrops
 
-Convert a number to a string, the contents of which depend on the number's factors.
+Your task is to convert a number into a string that contains raindrop sounds corresponding to certain potential factors. A factor is a number that evenly divides into another number, leaving no remainder. The simplest way to test if a one number is a factor of another is to use the [modulo operation](https://en.wikipedia.org/wiki/Modulo_operation).
 
-- If the number has 3 as a factor, output 'Pling'.
-- If the number has 5 as a factor, output 'Plang'.
-- If the number has 7 as a factor, output 'Plong'.
-- If the number does not have 3, 5, or 7 as a factor,
-  just pass the number's digits straight through.
+The rules of `raindrops` are that if a given number:
+
+- has 3 as a factor, add 'Pling' to the result.
+- has 5 as a factor, add 'Plang' to the result.
+- has 7 as a factor, add 'Plong' to the result.
+- _does not_ have any of 3, 5, or 7 as a factor, the result should be the digits of the number.
 
 ## Examples
 
-- 28's factors are 1, 2, 4, **7**, 14, 28.
-  - In raindrop-speak, this would be a simple "Plong".
-- 30's factors are 1, 2, **3**, **5**, 6, 10, 15, 30.
-  - In raindrop-speak, this would be a "PlingPlang".
-- 34 has four factors: 1, 2, 17, and 34.
-  - In raindrop-speak, this would be "34".
+- 28 has 7 as a factor, but not 3 or 5, so the result would be "Plong".
+- 30 has both 3 and 5 as factors, but not 7, so the result would be "PlingPlang".
+- 34 is not factored by 3, 5, or 7, so the result would be "34".
 
 ## Hints
 - Think of this in a generic way. If you're familiar with the (fizz buzz)[https://en.wikipedia.org/wiki/Fizz_buzz] problem this is similar except there are three conditions instead of two. How would you implement this knowing that one day we might want to extend to four, five, or even ten types of raindrops?
@@ -24,6 +22,12 @@ Convert a number to a string, the contents of which depend on the number's facto
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if
@@ -31,5 +35,5 @@ you're having trouble, please visit the exercism.io [F# language page](http://ex
 
 ## Source
 
-A variation on a famous interview question intended to weed out potential candidates. [http://jumpstartlab.com](http://jumpstartlab.com)
+A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division. [https://en.wikipedia.org/wiki/Fizz_buzz](https://en.wikipedia.org/wiki/Fizz_buzz)
 

--- a/exercises/rational-numbers/.config/dotnet-tools.json
+++ b/exercises/rational-numbers/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/rational-numbers/README.md
+++ b/exercises/rational-numbers/README.md
@@ -32,6 +32,12 @@ Assume that the programming language you are using does not have an implementati
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/react/.config/dotnet-tools.json
+++ b/exercises/react/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/react/README.md
+++ b/exercises/react/README.md
@@ -19,6 +19,12 @@ state has changed from the previous stable state.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/rectangles/.config/dotnet-tools.json
+++ b/exercises/rectangles/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/rectangles/README.md
+++ b/exercises/rectangles/README.md
@@ -67,6 +67,12 @@ every line equals the length of the first line).
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/rest-api/.config/dotnet-tools.json
+++ b/exercises/rest-api/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/rest-api/README.md
+++ b/exercises/rest-api/README.md
@@ -42,6 +42,12 @@ Your task is to implement a simple [RESTful API](https://en.wikipedia.org/wiki/R
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/reverse-string/.config/dotnet-tools.json
+++ b/exercises/reverse-string/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -10,6 +10,12 @@ output: "looc"
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/rna-transcription/.config/dotnet-tools.json
+++ b/exercises/rna-transcription/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -26,6 +26,12 @@ For this exercise the following F# feature comes in handy:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/robot-name/.config/dotnet-tools.json
+++ b/exercises/robot-name/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -2,22 +2,28 @@
 
 Manage robot factory settings.
 
-When robots come off the factory floor, they have no name.
+When a robot comes off the factory floor, it has no name.
 
-The first time you boot them up, a random name is generated in the format
+The first time you turn on a robot, a random name is generated in the format
 of two uppercase letters followed by three digits, such as RX837 or BC811.
 
 Every once in a while we need to reset a robot to its factory settings,
-which means that their name gets wiped. The next time you ask, it will
+which means that its name gets wiped. The next time you ask, that robot will
 respond with a new random name.
 
 The names must be random: they should not follow a predictable sequence.
-Random names means a risk of collisions. Your solution must ensure that
+Using random names means a risk of collisions. Your solution must ensure that
 every existing robot has a unique name.
 
 ## Running the tests
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
+
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
 
 ## Further information
 

--- a/exercises/robot-simulator/.config/dotnet-tools.json
+++ b/exercises/robot-simulator/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -31,6 +31,12 @@ direction it is pointing.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/roman-numerals/.config/dotnet-tools.json
+++ b/exercises/roman-numerals/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -46,6 +46,12 @@ See also: http://www.novaroma.org/via_romana/numbers.html
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/rotational-cipher/.config/dotnet-tools.json
+++ b/exercises/rotational-cipher/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -34,6 +34,12 @@ Ciphertext is written out in the same formatting as the input including spaces a
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/run-length-encoding/.config/dotnet-tools.json
+++ b/exercises/run-length-encoding/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -27,6 +27,12 @@ be decoded always represent the count for the following character.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/saddle-points/.config/dotnet-tools.json
+++ b/exercises/saddle-points/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -32,6 +32,12 @@ but the tests for this exercise follow the above unambiguous definition.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/say/.config/dotnet-tools.json
+++ b/exercises/say/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -66,6 +66,12 @@ Use _and_ (correctly) when spelling out the number in English:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/scale-generator/.config/dotnet-tools.json
+++ b/exercises/scale-generator/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/scale-generator/README.md
+++ b/exercises/scale-generator/README.md
@@ -52,6 +52,12 @@ figure into this exercise.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/scrabble-score/.config/dotnet-tools.json
+++ b/exercises/scrabble-score/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -1,6 +1,6 @@
 # Scrabble Score
 
-Given a word, compute the scrabble score for that word.
+Given a word, compute the Scrabble score for that word.
 
 ## Letter Values
 
@@ -42,6 +42,12 @@ And to total:
 ## Running the tests
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
+
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
 
 ## Further information
 

--- a/exercises/secret-handshake/.config/dotnet-tools.json
+++ b/exercises/secret-handshake/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/secret-handshake/README.md
+++ b/exercises/secret-handshake/README.md
@@ -32,6 +32,12 @@ has caused the array to be reversed.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/series/.config/dotnet-tools.json
+++ b/exercises/series/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -24,6 +24,12 @@ in the input; the digits need not be *numerically consecutive*.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/sgf-parsing/.config/dotnet-tools.json
+++ b/exercises/sgf-parsing/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/sgf-parsing/README.md
+++ b/exercises/sgf-parsing/README.md
@@ -69,6 +69,12 @@ data types of properties, just use the rules for the
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/sieve/.config/dotnet-tools.json
+++ b/exercises/sieve/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -33,6 +33,12 @@ language).
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/simple-cipher/.config/dotnet-tools.json
+++ b/exercises/simple-cipher/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -82,6 +82,12 @@ on Wikipedia][dh] for one of the first implementations of this scheme.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/simple-linked-list/.config/dotnet-tools.json
+++ b/exercises/simple-linked-list/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -25,6 +25,12 @@ implement your own abstract data type.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/space-age/.config/dotnet-tools.json
+++ b/exercises/space-age/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -2,9 +2,9 @@
 
 Given an age in seconds, calculate how old someone would be on:
 
-   - Earth: orbital period 365.25 Earth days, or 31557600 seconds
    - Mercury: orbital period 0.2408467 Earth years
    - Venus: orbital period 0.61519726 Earth years
+   - Earth: orbital period 1.0 Earth years, 365.25 Earth days, or 31557600 seconds
    - Mars: orbital period 1.8808158 Earth years
    - Jupiter: orbital period 11.862615 Earth years
    - Saturn: orbital period 29.447498 Earth years
@@ -24,6 +24,12 @@ youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
 ## Running the tests
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
+
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
 
 ## Further information
 

--- a/exercises/spiral-matrix/.config/dotnet-tools.json
+++ b/exercises/spiral-matrix/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/spiral-matrix/README.md
+++ b/exercises/spiral-matrix/README.md
@@ -27,6 +27,12 @@ like these examples:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/strain/.config/dotnet-tools.json
+++ b/exercises/strain/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -37,6 +37,12 @@ basic tools instead.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/sublist/.config/dotnet-tools.json
+++ b/exercises/sublist/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -21,6 +21,12 @@ Examples:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/sum-of-multiples/.config/dotnet-tools.json
+++ b/exercises/sum-of-multiples/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -12,6 +12,12 @@ The sum of these multiples is 78.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/tournament/.config/dotnet-tools.json
+++ b/exercises/tournament/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -68,6 +68,12 @@ Means that the Devastating Donkeys and Courageous Californians tied.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/transpose/.config/dotnet-tools.json
+++ b/exercises/transpose/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -62,6 +62,12 @@ the corresponding output row should contain the spaces in its right-most column(
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/tree-building/.config/dotnet-tools.json
+++ b/exercises/tree-building/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/tree-building/README.md
+++ b/exercises/tree-building/README.md
@@ -1,21 +1,5 @@
 # Tree Building
 
-This exercise is different from most others in that you already start with
-working code, which needs to be refactored. The existing code is fairly slow and
-very unidiomatic, which means it's not written in a way that F# would typically
-be used in.
-
-In addition to unit tests, this exercise also provides a set of benchmark tests.
-Benchmark tests have a similar purpose to unit tests - they check properties of some
-other code. While unit tests check the correctness of the result, benchmarks
-evaluate the performance of the code under test.
-
-The benchmark tests are run in a similar way as the unit tests (instructions
-provided below). They allow you to check that your code does not just work, but
-is also efficient.
-
-## The task
-
 Refactor a tree building algorithm.
 
 Some web-forums have a tree layout, so posts are presented as a tree. However
@@ -46,29 +30,11 @@ root (ID: 0, parent ID: 0)
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
-## Running the benchmarks
+## Autoformatting the code
 
-The benchmark tests use another library called **BenchmarkDotNet**. This is
-already referenced in the exercise project, and no additional steps need to be
-taken to use it.
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
 
-To run the benchmarks, run the command `dotnet run -c Release` from within the
-exercise directory. You will get a table with two rows of results: `Baseline`
-shows the values for the original version of the code; `Mine` is the performance
-of your current solution.
-
-```text
-|   Method |     Mean | Allocated |
-|--------- |---------:|----------:|
-| Baseline | 12.39 us |  13.87 KB |
-|     Mine | 12.23 us |  13.87 KB |
-```
-
-In addition to identifying the particular version of the code tested, the table
-provides two columns with metrics - `Mean` and `Allocated`.
-
-- The `Mean` column shows the average running time of the respective solution. BenchmarkDotNet runs each solution a number of times and then reports the the average time needed.
-- The `Allocated` column shows the amount of memory that each solution allocates per single benchmark run. This has performance implications, because memory allocated by .NET code is cleaned up by a _Garbage Collector_, and this cleanup process takes time, slowing down the overall execution. For this exercise, reducing the amount of memory allocated should typically also improve overall performance.
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
 
 ## Further information
 

--- a/exercises/triangle/.config/dotnet-tools.json
+++ b/exercises/triangle/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -26,6 +26,12 @@ a single line. Feel free to add your own code/tests to check for degenerate tria
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/trinary/.config/dotnet-tools.json
+++ b/exercises/trinary/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -25,6 +25,12 @@ conversion, pretend it doesn't exist and implement it yourself.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/twelve-days/.config/dotnet-tools.json
+++ b/exercises/twelve-days/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/twelve-days/README.md
+++ b/exercises/twelve-days/README.md
@@ -36,6 +36,12 @@ On the twelfth day of Christmas my true love gave to me: twelve Drummers Drummin
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/two-bucket/.config/dotnet-tools.json
+++ b/exercises/two-bucket/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -33,6 +33,12 @@ Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by Lind
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/two-fer/.config/dotnet-tools.json
+++ b/exercises/two-fer/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -18,16 +18,22 @@ One for you, one for me.
 
 Here are some examples:
 
-|Name    | String to return 
-|:------:|:-----------------: 
-|Alice   | One for Alice, one for me. 
-|Bob     | One for Bob, one for me.
-|        | One for you, one for me.
-|Zaphod  | One for Zaphod, one for me.
+|Name    |String to return
+|:-------|:------------------
+|Alice   |One for Alice, one for me.
+|Bob     |One for Bob, one for me.
+|        |One for you, one for me.
+|Zaphod  |One for Zaphod, one for me.
 
 ## Running the tests
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
+
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
 
 ## Further information
 

--- a/exercises/variable-length-quantity/.config/dotnet-tools.json
+++ b/exercises/variable-length-quantity/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/variable-length-quantity/README.md
+++ b/exercises/variable-length-quantity/README.md
@@ -35,6 +35,12 @@ Here are examples of integers as 32-bit values, and the variable length quantiti
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/word-count/.config/dotnet-tools.json
+++ b/exercises/word-count/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -1,19 +1,44 @@
 # Word Count
 
-Given a phrase, count the occurrences of each word in that phrase.
+Given a phrase, count the occurrences of each _word_ in that phrase.
 
-For example for the input `"olly olly in come free"`
+For the purposes of this exercise you can expect that a _word_ will always be one of:
+
+1. A _number_ composed of one or more ASCII digits (ie "0" or "1234") OR
+2. A _simple word_ composed of one or more ASCII letters (ie "a" or "they") OR
+3. A _contraction_ of two _simple words_ joined by a single apostrophe (ie "it's" or "they're")
+
+When counting words you can assume the following rules:
+
+1. The count is _case insensitive_ (ie "You", "you", and "YOU" are 3 uses of the same word)
+2. The count is _unordered_; the tests will ignore how words and counts are ordered
+3. Other than the apostrophe in a _contraction_ all forms of _punctuation_ are ignored
+4. The words can be separated by _any_ form of whitespace (ie "\t", "\n", " ")
+
+For example, for the phrase `"That's the password: 'PASSWORD 123'!", cried the Special Agent.\nSo I fled.` the count would be:
 
 ```text
-olly: 2
-in: 1
-come: 1
-free: 1
+that's: 1
+the: 2
+password: 2
+123: 1
+cried: 1
+special: 1
+agent: 1
+so: 1
+i: 1
+fled: 1
 ```
 
 ## Running the tests
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
+
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
 
 ## Further information
 

--- a/exercises/word-search/.config/dotnet-tools.json
+++ b/exercises/word-search/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/word-search/README.md
+++ b/exercises/word-search/README.md
@@ -30,6 +30,12 @@ letter of each word.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/wordy/.config/dotnet-tools.json
+++ b/exercises/wordy/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -76,6 +76,12 @@ If you'd like, handle exponentials.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/yacht/.config/dotnet-tools.json
+++ b/exercises/yacht/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/yacht/README.md
+++ b/exercises/yacht/README.md
@@ -40,6 +40,12 @@ inclusively. You should not assume that the dice are ordered.
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/zebra-puzzle/.config/dotnet-tools.json
+++ b/exercises/zebra-puzzle/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/zebra-puzzle/README.md
+++ b/exercises/zebra-puzzle/README.md
@@ -29,6 +29,12 @@ Who owns the zebra?
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/exercises/zipper/.config/dotnet-tools.json
+++ b/exercises/zipper/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "3.2.0",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -31,6 +31,12 @@ list of child nodes) a zipper might support these operations:
 
 To run the tests, run the command `dotnet test` from within the exercise directory.
 
+## Autoformatting the code
+
+F# source code can be formatted with the [Fantomas](https://github.com/fsprojects/fantomas) tool.
+
+After installing it with `dotnet tool restore`, run `dotnet fantomas .` to format code within the current directory.
+
 ## Further information
 
 For more detailed information about the F# track, including how to get help if

--- a/update-exercise-tools.ps1
+++ b/update-exercise-tools.ps1
@@ -1,0 +1,23 @@
+<#
+.SYNOPSIS
+    Add dotnet tools to exercises.
+.DESCRIPTION
+    For each exercise, create a tool manifest and add fantomas.
+.EXAMPLE
+    PS C:\> ./update-exercise-tools.ps1
+#>
+
+# Import shared functionality
+. ./shared.ps1
+
+function Add-Tools {
+    Write-Output "Adding dotnet tools"
+    Get-ChildItem -Directory "exercises" | ForEach-Object {
+        Run-Command "dotnet new tool-manifest -o $_"
+        Run-Command "dotnet tool install --tool-manifest $_/.config/dotnet-tools.json fantomas-tool"
+    }
+}
+
+Add-Tools
+
+exit $LastExitCode


### PR DESCRIPTION
This PR takes a crack at part of #668 :

- Add a Powershell script to add [Fantomas](https://github.com/fsprojects/fantomas) to each exercise
- Update `add-new-exercise.ps1` with the same treatment
- Add a section to the README template describing how to use Fantomas.

☝️ These are in the first commit. Also:

- Run the script to give each project the tool manifest
- Regenerate READMEs