### PR TITLE
Use hashes when checking out GH actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ jobs:
   test:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e # v2
+      - uses: actions/setup-dotnet@b7821147f564527086410e8edd122d89b4b9602f # 1.4.0
         with:
           dotnet-version: "3.0.100"
       - run: pwsh ./test.ps1


### PR DESCRIPTION
This is a security feature