### PR TITLE
Improve Skip string

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -8,7 +8,7 @@ dotnet test
 
 ## Solving the exercise
 
-Solving an exercise means making all its tests pass. By default, only one test (the first one) is executed when you run the tests. This is intentional, as it allows you to focus on just making that one test pass. Once it passes, you can enable the next test by removing `Skip = "Remove to run test"` from the test's `[<Fact>]` or `[<Theory>]` attribute. When all tests have been enabled and your implementation makes them all pass, you'll have solved the exercise!
+Solving an exercise means making all its tests pass. By default, only one test (the first one) is executed when you run the tests. This is intentional, as it allows you to focus on just making that one test pass. Once it passes, you can enable the next test by removing `Skip = "Remove this Skip property to run this test"` from the test's `[<Fact>]` or `[<Theory>]` attribute. When all tests have been enabled and your implementation makes them all pass, you'll have solved the exercise!
 
 To help you get started, each exercise comes with a stub implementation file. You can use this file as a starting point for building your solution. Feel free to remove or change this file if you think it is the right thing to do.
 

--- a/exercises/accumulate/AccumulateTests.fs
+++ b/exercises/accumulate/AccumulateTests.fs
@@ -13,30 +13,30 @@ let reverse (str:string) = new string(str.ToCharArray() |> Array.rev)
 let ``Empty accumulation produces empty accumulation`` () =
     accumulate (fun x -> x + 1) List.empty |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Identity accumulation returns unmodified list`` () =
     accumulate id [1; 2; 3] |> should equal [1; 2; 3]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Accumulate squares`` () =
     accumulate (fun x -> x * x) [1; 2; 3] |> should equal [1; 4; 9]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Accumulate upcases`` () =
     accumulate (fun (x:string) -> x.ToUpper()) ["hello"; "world"]
     |> should equal ["HELLO"; "WORLD"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Accumulate reversed strings`` () =
     accumulate reverse (List.ofArray ("the quick brown fox etc".Split(' ')))
     |> should equal (List.ofArray("eht kciuq nworb xof cte".Split(' ')))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Accumulate within accumulate`` () =
     accumulate (fun (x:string) -> String.concat " " (accumulate (fun y -> x + y) ["1"; "2"; "3"])) ["a"; "b"; "c"]
     |> should equal ["a1 a2 a3"; "b1 b2 b3"; "c1 c2 c3"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Accumulate large data set without stack overflow`` () =
     accumulate id [1..100000]
     |> should equal [1..100000]

--- a/exercises/acronym/AcronymTests.fs
+++ b/exercises/acronym/AcronymTests.fs
@@ -11,35 +11,35 @@ open Acronym
 let ``Basic`` () =
     abbreviate "Portable Network Graphics" |> should equal "PNG"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Lowercase words`` () =
     abbreviate "Ruby on Rails" |> should equal "ROR"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Punctuation`` () =
     abbreviate "First In, First Out" |> should equal "FIFO"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``All caps word`` () =
     abbreviate "GNU Image Manipulation Program" |> should equal "GIMP"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Punctuation without whitespace`` () =
     abbreviate "Complementary metal-oxide semiconductor" |> should equal "CMOS"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Very long abbreviation`` () =
     abbreviate "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me" |> should equal "ROTFLSHTMDCOALM"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Consecutive delimiters`` () =
     abbreviate "Something - I made up from thin air" |> should equal "SIMUFTA"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Apostrophes`` () =
     abbreviate "Halley's Comet" |> should equal "HC"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Underscore emphasis`` () =
     abbreviate "The Road _Not_ Taken" |> should equal "TRNT"
 

--- a/exercises/affine-cipher/AffineCipherTests.fs
+++ b/exercises/affine-cipher/AffineCipherTests.fs
@@ -11,63 +11,63 @@ open AffineCipher
 let ``Encode yes`` () =
     encode 5 7 "yes" |> should equal "xbt"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode no`` () =
     encode 15 18 "no" |> should equal "fu"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode OMG`` () =
     encode 21 3 "OMG" |> should equal "lvz"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode O M G`` () =
     encode 25 47 "O M G" |> should equal "hjp"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode mindblowingly`` () =
     encode 11 15 "mindblowingly" |> should equal "rzcwa gnxzc dgt"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode numbers`` () =
     encode 3 4 "Testing,1 2 3, testing." |> should equal "jqgjc rw123 jqgjc rw"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode deep thought`` () =
     encode 5 17 "Truth is fiction." |> should equal "iynia fdqfb ifje"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode all the letters`` () =
     encode 17 33 "The quick brown fox jumps over the lazy dog." |> should equal "swxtj npvyk lruol iejdc blaxk swxmh qzglf"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode with a not coprime to m`` () =
     (fun () -> encode 6 17 "This is a test." |> ignore) |> should throw typeof<System.ArgumentException>
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode exercism`` () =
     decode 3 7 "tytgn fjr" |> should equal "exercism"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode a sentence`` () =
     decode 19 16 "qdwju nqcro muwhn odqun oppmd aunwd o" |> should equal "anobstacleisoftenasteppingstone"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode numbers`` () =
     decode 25 7 "odpoz ub123 odpoz ub" |> should equal "testing123testing"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode all the letters`` () =
     decode 17 33 "swxtj npvyk lruol iejdc blaxk swxmh qzglf" |> should equal "thequickbrownfoxjumpsoverthelazydog"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode with no spaces in input`` () =
     decode 17 33 "swxtjnpvyklruoliejdcblaxkswxmhqzglf" |> should equal "thequickbrownfoxjumpsoverthelazydog"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode with too many spaces`` () =
     decode 15 16 "vszzm    cly   yd cg    qdp" |> should equal "jollygreengiant"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode with a not coprime to m`` () =
     (fun () -> decode 13 5 "Test" |> ignore) |> should throw typeof<System.ArgumentException>
 

--- a/exercises/all-your-base/AllYourBaseTests.fs
+++ b/exercises/all-your-base/AllYourBaseTests.fs
@@ -15,7 +15,7 @@ let ``Single bit one to decimal`` () =
     let expected = Some [1]
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Binary to single decimal`` () =
     let digits = [1; 0; 1]
     let inputBase = 2
@@ -23,7 +23,7 @@ let ``Binary to single decimal`` () =
     let expected = Some [5]
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Single decimal to binary`` () =
     let digits = [5]
     let inputBase = 10
@@ -31,7 +31,7 @@ let ``Single decimal to binary`` () =
     let expected = Some [1; 0; 1]
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Binary to multiple decimal`` () =
     let digits = [1; 0; 1; 0; 1; 0]
     let inputBase = 2
@@ -39,7 +39,7 @@ let ``Binary to multiple decimal`` () =
     let expected = Some [4; 2]
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decimal to binary`` () =
     let digits = [4; 2]
     let inputBase = 10
@@ -47,7 +47,7 @@ let ``Decimal to binary`` () =
     let expected = Some [1; 0; 1; 0; 1; 0]
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Trinary to hexadecimal`` () =
     let digits = [1; 1; 2; 0]
     let inputBase = 3
@@ -55,7 +55,7 @@ let ``Trinary to hexadecimal`` () =
     let expected = Some [2; 10]
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hexadecimal to trinary`` () =
     let digits = [2; 10]
     let inputBase = 16
@@ -63,7 +63,7 @@ let ``Hexadecimal to trinary`` () =
     let expected = Some [1; 1; 2; 0]
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``15-bit integer`` () =
     let digits = [3; 46; 60]
     let inputBase = 97
@@ -71,7 +71,7 @@ let ``15-bit integer`` () =
     let expected = Some [6; 10; 45]
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Empty list`` () =
     let digits = []
     let inputBase = 2
@@ -79,7 +79,7 @@ let ``Empty list`` () =
     let expected = Some [0]
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Single zero`` () =
     let digits = [0]
     let inputBase = 10
@@ -87,7 +87,7 @@ let ``Single zero`` () =
     let expected = Some [0]
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple zeros`` () =
     let digits = [0; 0; 0]
     let inputBase = 10
@@ -95,7 +95,7 @@ let ``Multiple zeros`` () =
     let expected = Some [0]
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Leading zeros`` () =
     let digits = [0; 6; 0]
     let inputBase = 7
@@ -103,7 +103,7 @@ let ``Leading zeros`` () =
     let expected = Some [4; 2]
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Input base is one`` () =
     let digits = [0]
     let inputBase = 1
@@ -111,7 +111,7 @@ let ``Input base is one`` () =
     let expected = None
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Input base is zero`` () =
     let digits = []
     let inputBase = 0
@@ -119,7 +119,7 @@ let ``Input base is zero`` () =
     let expected = None
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Input base is negative`` () =
     let digits = [1]
     let inputBase = -2
@@ -127,7 +127,7 @@ let ``Input base is negative`` () =
     let expected = None
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Negative digit`` () =
     let digits = [1; -1; 1; 0; 1; 0]
     let inputBase = 2
@@ -135,7 +135,7 @@ let ``Negative digit`` () =
     let expected = None
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid positive digit`` () =
     let digits = [1; 2; 1; 0; 1; 0]
     let inputBase = 2
@@ -143,7 +143,7 @@ let ``Invalid positive digit`` () =
     let expected = None
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Output base is one`` () =
     let digits = [1; 0; 1; 0; 1; 0]
     let inputBase = 2
@@ -151,7 +151,7 @@ let ``Output base is one`` () =
     let expected = None
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Output base is zero`` () =
     let digits = [7]
     let inputBase = 10
@@ -159,7 +159,7 @@ let ``Output base is zero`` () =
     let expected = None
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Output base is negative`` () =
     let digits = [1]
     let inputBase = 2
@@ -167,7 +167,7 @@ let ``Output base is negative`` () =
     let expected = None
     rebase digits inputBase outputBase |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Both bases are negative`` () =
     let digits = [1]
     let inputBase = -2

--- a/exercises/allergies/AllergiesTests.fs
+++ b/exercises/allergies/AllergiesTests.fs
@@ -11,195 +11,195 @@ open Allergies
 let ``Testing for eggs allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Eggs |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for eggs allergy - allergic only to eggs`` () =
     allergicTo 1 Allergen.Eggs |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for eggs allergy - allergic to eggs and something else`` () =
     allergicTo 3 Allergen.Eggs |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for eggs allergy - allergic to something, but not eggs`` () =
     allergicTo 2 Allergen.Eggs |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for eggs allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Eggs |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for peanuts allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Peanuts |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for peanuts allergy - allergic only to peanuts`` () =
     allergicTo 2 Allergen.Peanuts |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for peanuts allergy - allergic to peanuts and something else`` () =
     allergicTo 7 Allergen.Peanuts |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for peanuts allergy - allergic to something, but not peanuts`` () =
     allergicTo 5 Allergen.Peanuts |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for peanuts allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Peanuts |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for shellfish allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Shellfish |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for shellfish allergy - allergic only to shellfish`` () =
     allergicTo 4 Allergen.Shellfish |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for shellfish allergy - allergic to shellfish and something else`` () =
     allergicTo 14 Allergen.Shellfish |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for shellfish allergy - allergic to something, but not shellfish`` () =
     allergicTo 10 Allergen.Shellfish |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for shellfish allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Shellfish |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for strawberries allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Strawberries |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for strawberries allergy - allergic only to strawberries`` () =
     allergicTo 8 Allergen.Strawberries |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for strawberries allergy - allergic to strawberries and something else`` () =
     allergicTo 28 Allergen.Strawberries |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for strawberries allergy - allergic to something, but not strawberries`` () =
     allergicTo 20 Allergen.Strawberries |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for strawberries allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Strawberries |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for tomatoes allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Tomatoes |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for tomatoes allergy - allergic only to tomatoes`` () =
     allergicTo 16 Allergen.Tomatoes |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for tomatoes allergy - allergic to tomatoes and something else`` () =
     allergicTo 56 Allergen.Tomatoes |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for tomatoes allergy - allergic to something, but not tomatoes`` () =
     allergicTo 40 Allergen.Tomatoes |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for tomatoes allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Tomatoes |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for chocolate allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Chocolate |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for chocolate allergy - allergic only to chocolate`` () =
     allergicTo 32 Allergen.Chocolate |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for chocolate allergy - allergic to chocolate and something else`` () =
     allergicTo 112 Allergen.Chocolate |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for chocolate allergy - allergic to something, but not chocolate`` () =
     allergicTo 80 Allergen.Chocolate |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for chocolate allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Chocolate |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for pollen allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Pollen |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for pollen allergy - allergic only to pollen`` () =
     allergicTo 64 Allergen.Pollen |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for pollen allergy - allergic to pollen and something else`` () =
     allergicTo 224 Allergen.Pollen |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for pollen allergy - allergic to something, but not pollen`` () =
     allergicTo 160 Allergen.Pollen |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for pollen allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Pollen |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for cats allergy - not allergic to anything`` () =
     allergicTo 0 Allergen.Cats |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for cats allergy - allergic only to cats`` () =
     allergicTo 128 Allergen.Cats |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for cats allergy - allergic to cats and something else`` () =
     allergicTo 192 Allergen.Cats |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for cats allergy - allergic to something, but not cats`` () =
     allergicTo 64 Allergen.Cats |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Testing for cats allergy - allergic to everything`` () =
     allergicTo 255 Allergen.Cats |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``List - no allergies`` () =
     list 0 |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``List - just eggs`` () =
     list 1 |> should equal [Allergen.Eggs]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``List - just peanuts`` () =
     list 2 |> should equal [Allergen.Peanuts]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``List - just strawberries`` () =
     list 8 |> should equal [Allergen.Strawberries]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``List - eggs and peanuts`` () =
     list 3 |> should equal [Allergen.Eggs; Allergen.Peanuts]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``List - more than eggs but not peanuts`` () =
     list 5 |> should equal [Allergen.Eggs; Allergen.Shellfish]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``List - lots of stuff`` () =
     list 248 |> should equal [Allergen.Strawberries; Allergen.Tomatoes; Allergen.Chocolate; Allergen.Pollen; Allergen.Cats]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``List - everything`` () =
     list 255 |> should equal [Allergen.Eggs; Allergen.Peanuts; Allergen.Shellfish; Allergen.Strawberries; Allergen.Tomatoes; Allergen.Chocolate; Allergen.Pollen; Allergen.Cats]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``List - no allergen score parts`` () =
     list 509 |> should equal [Allergen.Eggs; Allergen.Shellfish; Allergen.Strawberries; Allergen.Tomatoes; Allergen.Chocolate; Allergen.Pollen; Allergen.Cats]
 

--- a/exercises/alphametics/AlphameticsTests.fs
+++ b/exercises/alphametics/AlphameticsTests.fs
@@ -18,19 +18,19 @@ let ``Puzzle with three letters`` () =
         |> Some
     solve puzzle |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Solution must have unique value for each letter`` () =
     let puzzle = "A == B"
     let expected = None
     solve puzzle |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Leading zero solution is invalid`` () =
     let puzzle = "ACA + DD == BD"
     let expected = None
     solve puzzle |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Puzzle with two digits final carry`` () =
     let puzzle = "A + A + A + A + A + A + A + A + A + A + A + B == BCC"
     let expected = 
@@ -41,7 +41,7 @@ let ``Puzzle with two digits final carry`` () =
         |> Some
     solve puzzle |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Puzzle with four letters`` () =
     let puzzle = "AS + A == MOM"
     let expected = 
@@ -53,7 +53,7 @@ let ``Puzzle with four letters`` () =
         |> Some
     solve puzzle |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Puzzle with six letters`` () =
     let puzzle = "NO + NO + TOO == LATE"
     let expected = 
@@ -67,7 +67,7 @@ let ``Puzzle with six letters`` () =
         |> Some
     solve puzzle |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Puzzle with seven letters`` () =
     let puzzle = "HE + SEES + THE == LIGHT"
     let expected = 
@@ -82,7 +82,7 @@ let ``Puzzle with seven letters`` () =
         |> Some
     solve puzzle |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Puzzle with eight letters`` () =
     let puzzle = "SEND + MORE == MONEY"
     let expected = 
@@ -98,7 +98,7 @@ let ``Puzzle with eight letters`` () =
         |> Some
     solve puzzle |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Puzzle with ten letters`` () =
     let puzzle = "AND + A + STRONG + OFFENSE + AS + A + GOOD == DEFENSE"
     let expected = 
@@ -116,7 +116,7 @@ let ``Puzzle with ten letters`` () =
         |> Some
     solve puzzle |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Puzzle with ten letters and 199 addends`` () =
     let puzzle = "THIS + A + FIRE + THEREFORE + FOR + ALL + HISTORIES + I + TELL + A + TALE + THAT + FALSIFIES + ITS + TITLE + TIS + A + LIE + THE + TALE + OF + THE + LAST + FIRE + HORSES + LATE + AFTER + THE + FIRST + FATHERS + FORESEE + THE + HORRORS + THE + LAST + FREE + TROLL + TERRIFIES + THE + HORSES + OF + FIRE + THE + TROLL + RESTS + AT + THE + HOLE + OF + LOSSES + IT + IS + THERE + THAT + SHE + STORES + ROLES + OF + LEATHERS + AFTER + SHE + SATISFIES + HER + HATE + OFF + THOSE + FEARS + A + TASTE + RISES + AS + SHE + HEARS + THE + LEAST + FAR + HORSE + THOSE + FAST + HORSES + THAT + FIRST + HEAR + THE + TROLL + FLEE + OFF + TO + THE + FOREST + THE + HORSES + THAT + ALERTS + RAISE + THE + STARES + OF + THE + OTHERS + AS + THE + TROLL + ASSAILS + AT + THE + TOTAL + SHIFT + HER + TEETH + TEAR + HOOF + OFF + TORSO + AS + THE + LAST + HORSE + FORFEITS + ITS + LIFE + THE + FIRST + FATHERS + HEAR + OF + THE + HORRORS + THEIR + FEARS + THAT + THE + FIRES + FOR + THEIR + FEASTS + ARREST + AS + THE + FIRST + FATHERS + RESETTLE + THE + LAST + OF + THE + FIRE + HORSES + THE + LAST + TROLL + HARASSES + THE + FOREST + HEART + FREE + AT + LAST + OF + THE + LAST + TROLL + ALL + OFFER + THEIR + FIRE + HEAT + TO + THE + ASSISTERS + FAR + OFF + THE + TROLL + FASTS + ITS + LIFE + SHORTER + AS + STARS + RISE + THE + HORSES + REST + SAFE + AFTER + ALL + SHARE + HOT + FISH + AS + THEIR + AFFILIATES + TAILOR + A + ROOFS + FOR + THEIR + SAFE == FORTRESSES"
     let expected = 

--- a/exercises/anagram/AnagramTests.fs
+++ b/exercises/anagram/AnagramTests.fs
@@ -12,67 +12,67 @@ let ``No matches`` () =
     let candidates = ["hello"; "world"; "zombies"; "pants"]
     findAnagrams candidates "diaper" |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Detects two anagrams`` () =
     let candidates = ["stream"; "pigeon"; "maters"]
     findAnagrams candidates "master" |> should equal ["stream"; "maters"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Does not detect anagram subsets`` () =
     let candidates = ["dog"; "goody"]
     findAnagrams candidates "good" |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Detects anagram`` () =
     let candidates = ["enlists"; "google"; "inlets"; "banana"]
     findAnagrams candidates "listen" |> should equal ["inlets"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Detects three anagrams`` () =
     let candidates = ["gallery"; "ballerina"; "regally"; "clergy"; "largely"; "leading"]
     findAnagrams candidates "allergy" |> should equal ["gallery"; "regally"; "largely"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Detects multiple anagrams with different case`` () =
     let candidates = ["Eons"; "ONES"]
     findAnagrams candidates "nose" |> should equal ["Eons"; "ONES"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Does not detect non-anagrams with identical checksum`` () =
     let candidates = ["last"]
     findAnagrams candidates "mass" |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Detects anagrams case-insensitively`` () =
     let candidates = ["cashregister"; "Carthorse"; "radishes"]
     findAnagrams candidates "Orchestra" |> should equal ["Carthorse"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Detects anagrams using case-insensitive subject`` () =
     let candidates = ["cashregister"; "carthorse"; "radishes"]
     findAnagrams candidates "Orchestra" |> should equal ["carthorse"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Detects anagrams using case-insensitive possible matches`` () =
     let candidates = ["cashregister"; "Carthorse"; "radishes"]
     findAnagrams candidates "orchestra" |> should equal ["Carthorse"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Does not detect an anagram if the original word is repeated`` () =
     let candidates = ["go Go GO"]
     findAnagrams candidates "go" |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Anagrams must use all letters exactly once`` () =
     let candidates = ["patter"]
     findAnagrams candidates "tapper" |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Words are not anagrams of themselves (case-insensitive)`` () =
     let candidates = ["BANANA"; "Banana"; "banana"]
     findAnagrams candidates "BANANA" |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Words other than themselves can be anagrams`` () =
     let candidates = ["Listen"; "Silent"; "LISTEN"]
     findAnagrams candidates "LISTEN" |> should equal ["Silent"]

--- a/exercises/armstrong-numbers/ArmstrongNumbersTests.fs
+++ b/exercises/armstrong-numbers/ArmstrongNumbersTests.fs
@@ -11,35 +11,35 @@ open ArmstrongNumbers
 let ``Zero is an Armstrong number`` () =
     isArmstrongNumber 0 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Single digit numbers are Armstrong numbers`` () =
     isArmstrongNumber 5 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``There are no 2 digit Armstrong numbers`` () =
     isArmstrongNumber 10 |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Three digit number that is an Armstrong number`` () =
     isArmstrongNumber 153 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Three digit number that is not an Armstrong number`` () =
     isArmstrongNumber 100 |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Four digit number that is an Armstrong number`` () =
     isArmstrongNumber 9474 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Four digit number that is not an Armstrong number`` () =
     isArmstrongNumber 9475 |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Seven digit number that is an Armstrong number`` () =
     isArmstrongNumber 9926315 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Seven digit number that is not an Armstrong number`` () =
     isArmstrongNumber 9926314 |> should equal false
 

--- a/exercises/atbash-cipher/AtbashCipherTests.fs
+++ b/exercises/atbash-cipher/AtbashCipherTests.fs
@@ -11,55 +11,55 @@ open AtbashCipher
 let ``Encode yes`` () =
     encode "yes" |> should equal "bvh"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode no`` () =
     encode "no" |> should equal "ml"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode OMG`` () =
     encode "OMG" |> should equal "lnt"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode spaces`` () =
     encode "O M G" |> should equal "lnt"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode mindblowingly`` () =
     encode "mindblowingly" |> should equal "nrmwy oldrm tob"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode numbers`` () =
     encode "Testing,1 2 3, testing." |> should equal "gvhgr mt123 gvhgr mt"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode deep thought`` () =
     encode "Truth is fiction." |> should equal "gifgs rhurx grlm"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode all the letters`` () =
     encode "The quick brown fox jumps over the lazy dog." |> should equal "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode exercism`` () =
     decode "vcvix rhn" |> should equal "exercism"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode a sentence`` () =
     decode "zmlyh gzxov rhlug vmzhg vkkrm thglm v" |> should equal "anobstacleisoftenasteppingstone"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode numbers`` () =
     decode "gvhgr mt123 gvhgr mt" |> should equal "testing123testing"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode all the letters`` () =
     decode "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt" |> should equal "thequickbrownfoxjumpsoverthelazydog"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode with too many spaces`` () =
     decode "vc vix    r hn" |> should equal "exercism"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode with no spaces`` () =
     decode "zmlyhgzxovrhlugvmzhgvkkrmthglmv" |> should equal "anobstacleisoftenasteppingstone"
 

--- a/exercises/bank-account/BankAccountTests.fs
+++ b/exercises/bank-account/BankAccountTests.fs
@@ -12,7 +12,7 @@ let ``Returns empty balance after opening`` () =
 
     getBalance account |> should equal (Some 0.0m)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Check basic balance`` () =
     let account = mkBankAccount() |> openAccount
     let openingBalance = account |> getBalance 
@@ -25,7 +25,7 @@ let ``Check basic balance`` () =
     openingBalance |> should equal (Some 0.0m)
     updatedBalance |> should equal (Some 10.0m)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Balance can increment or decrement`` () =    
     let account = mkBankAccount() |> openAccount
     let openingBalance = account |> getBalance 
@@ -44,7 +44,7 @@ let ``Balance can increment or decrement`` () =
     addedBalance |> should equal (Some 10.0m)
     subtractedBalance |> should equal (Some -5.0m)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Account can be closed`` () =
     let account = 
         mkBankAccount()
@@ -54,7 +54,7 @@ let ``Account can be closed`` () =
     getBalance account |> should equal None
     account |> should not' (equal None)
     
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Account can be updated from multiple threads`` () =
     let account = 
         mkBankAccount()

--- a/exercises/beer-song/BeerSongTests.fs
+++ b/exercises/beer-song/BeerSongTests.fs
@@ -14,35 +14,35 @@ let ``First generic verse`` () =
           "Take one down and pass it around, 98 bottles of beer on the wall." ]
     recite 99 1 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last generic verse`` () =
     let expected = 
         [ "3 bottles of beer on the wall, 3 bottles of beer.";
           "Take one down and pass it around, 2 bottles of beer on the wall." ]
     recite 3 1 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Verse with 2 bottles`` () =
     let expected = 
         [ "2 bottles of beer on the wall, 2 bottles of beer.";
           "Take one down and pass it around, 1 bottle of beer on the wall." ]
     recite 2 1 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Verse with 1 bottle`` () =
     let expected = 
         [ "1 bottle of beer on the wall, 1 bottle of beer.";
           "Take it down and pass it around, no more bottles of beer on the wall." ]
     recite 1 1 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Verse with 0 bottles`` () =
     let expected = 
         [ "No more bottles of beer on the wall, no more bottles of beer.";
           "Go to the store and buy some more, 99 bottles of beer on the wall." ]
     recite 0 1 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First two verses`` () =
     let expected = 
         [ "99 bottles of beer on the wall, 99 bottles of beer.";
@@ -52,7 +52,7 @@ let ``First two verses`` () =
           "Take one down and pass it around, 97 bottles of beer on the wall." ]
     recite 99 2 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last three verses`` () =
     let expected = 
         [ "2 bottles of beer on the wall, 2 bottles of beer.";
@@ -65,7 +65,7 @@ let ``Last three verses`` () =
           "Go to the store and buy some more, 99 bottles of beer on the wall." ]
     recite 2 3 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``All verses`` () =
     let expected = 
         [ "99 bottles of beer on the wall, 99 bottles of beer.";

--- a/exercises/binary-search-tree/BinarySearchTreeTests.fs
+++ b/exercises/binary-search-tree/BinarySearchTreeTests.fs
@@ -14,7 +14,7 @@ let ``Data is retained`` () =
     treeData |> left |> should equal None
     treeData |> right |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Smaller number at left node`` () =
     let treeData = create [4; 2]
     treeData |> data |> should equal 4
@@ -23,7 +23,7 @@ let ``Smaller number at left node`` () =
     treeData |> left |> Option.bind right |> should equal None
     treeData |> right |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Same number at left node`` () =
     let treeData = create [4; 4]
     treeData |> data |> should equal 4
@@ -32,7 +32,7 @@ let ``Same number at left node`` () =
     treeData |> left |> Option.bind right |> should equal None
     treeData |> right |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Greater number at right node`` () =
     let treeData = create [4; 5]
     treeData |> data |> should equal 4
@@ -41,7 +41,7 @@ let ``Greater number at right node`` () =
     treeData |> right |> Option.bind left |> should equal None
     treeData |> right |> Option.bind right |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can create complex tree`` () =
     let treeData = create [4; 2; 6; 1; 3; 5; 7]
     treeData |> data |> should equal 4
@@ -60,27 +60,27 @@ let ``Can create complex tree`` () =
     treeData |> right |> Option.bind right |> Option.bind left |> should equal None
     treeData |> right |> Option.bind right |> Option.bind right |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can sort single number`` () =
     let treeData = create [2]
     sortedData treeData |> should equal [2]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can sort if second number is smaller than first`` () =
     let treeData = create [2; 1]
     sortedData treeData |> should equal [1; 2]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can sort if second number is same as first`` () =
     let treeData = create [2; 2]
     sortedData treeData |> should equal [2; 2]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can sort if second number is greater than first`` () =
     let treeData = create [2; 3]
     sortedData treeData |> should equal [2; 3]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can sort complex tree`` () =
     let treeData = create [2; 1; 3; 6; 7; 5]
     sortedData treeData |> should equal [1; 2; 3; 5; 6; 7]

--- a/exercises/binary-search/BinarySearchTests.fs
+++ b/exercises/binary-search/BinarySearchTests.fs
@@ -14,70 +14,70 @@ let ``Finds a value in an array with one element`` () =
     let expected = Some 0
     find array value |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Finds a value in the middle of an array`` () =
     let array = [|1; 3; 4; 6; 8; 9; 11|]
     let value = 6
     let expected = Some 3
     find array value |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Finds a value at the beginning of an array`` () =
     let array = [|1; 3; 4; 6; 8; 9; 11|]
     let value = 1
     let expected = Some 0
     find array value |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Finds a value at the end of an array`` () =
     let array = [|1; 3; 4; 6; 8; 9; 11|]
     let value = 11
     let expected = Some 6
     find array value |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Finds a value in an array of odd length`` () =
     let array = [|1; 3; 5; 8; 13; 21; 34; 55; 89; 144; 233; 377; 634|]
     let value = 144
     let expected = Some 9
     find array value |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Finds a value in an array of even length`` () =
     let array = [|1; 3; 5; 8; 13; 21; 34; 55; 89; 144; 233; 377|]
     let value = 21
     let expected = Some 5
     find array value |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Identifies that a value is not included in the array`` () =
     let array = [|1; 3; 4; 6; 8; 9; 11|]
     let value = 7
     let expected = None
     find array value |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A value smaller than the array's smallest value is not found`` () =
     let array = [|1; 3; 4; 6; 8; 9; 11|]
     let value = 0
     let expected = None
     find array value |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A value larger than the array's largest value is not found`` () =
     let array = [|1; 3; 4; 6; 8; 9; 11|]
     let value = 13
     let expected = None
     find array value |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Nothing is found in an empty array`` () =
     let array = [||]
     let value = 1
     let expected = None
     find array value |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Nothing is found when the left and right bounds cross`` () =
     let array = [|1; 2|]
     let value = 0

--- a/exercises/binary/BinaryTests.fs
+++ b/exercises/binary/BinaryTests.fs
@@ -7,63 +7,63 @@ open Xunit
 
 open Binary
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Binary_0_is_decimal_0`` () =
     toDecimal "0" |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Binary_1_is_decimal_1`` () =
     toDecimal "1" |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Binary_10_is_decimal_2`` () =
     toDecimal "10" |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Binary_11_is_decimal_3`` () =
     toDecimal "11" |> should equal 3
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Binary_100_is_decimal_4`` () =
     toDecimal "100" |> should equal 4
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Binary_1001_is_decimal_9`` () =
     toDecimal "1001" |> should equal 9
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Binary_11010_is_decimal_26`` () =
     toDecimal "11010" |> should equal 26
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Binary_10001101000_is_decimal_1128`` () =
     toDecimal "10001101000" |> should equal 1128
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Binary_ignores_leading_zeros`` () =
     toDecimal "000011111" |> should equal 31
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``2_is_not_a_valid_binary_digit`` () =
     toDecimal "2" |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A_number_containing_a_non_binary_digit_is_invalid`` () =
     toDecimal "01201" |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A_number_with_trailing_non_binary_characters_is_invalid`` () =
     toDecimal "10nope" |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A_number_with_leading_non_binary_characters_is_invalid`` () =
     toDecimal "nope10" |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A_number_with_internal_non_binary_characters_is_invalid`` () =
     toDecimal "10nope10" |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A_number_and_a_word_whitespace_separated_is_invalid`` () =
     toDecimal "001 nope" |> should equal 0
 

--- a/exercises/bob/BobTests.fs
+++ b/exercises/bob/BobTests.fs
@@ -11,99 +11,99 @@ open Bob
 let ``Stating something`` () =
     response "Tom-ay-to, tom-aaaah-to." |> should equal "Whatever."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Shouting`` () =
     response "WATCH OUT!" |> should equal "Whoa, chill out!"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Shouting gibberish`` () =
     response "FCECDFCAAB" |> should equal "Whoa, chill out!"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Asking a question`` () =
     response "Does this cryogenic chamber make me look fat?" |> should equal "Sure."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Asking a numeric question`` () =
     response "You are, what, like 15?" |> should equal "Sure."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Asking gibberish`` () =
     response "fffbbcbeab?" |> should equal "Sure."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Talking forcefully`` () =
     response "Hi there!" |> should equal "Whatever."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Using acronyms in regular speech`` () =
     response "It's OK if you don't want to go work for NASA." |> should equal "Whatever."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Forceful question`` () =
     response "WHAT'S GOING ON?" |> should equal "Calm down, I know what I'm doing!"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Shouting numbers`` () =
     response "1, 2, 3 GO!" |> should equal "Whoa, chill out!"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``No letters`` () =
     response "1, 2, 3" |> should equal "Whatever."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Question with no letters`` () =
     response "4?" |> should equal "Sure."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Shouting with special characters`` () =
     response "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!" |> should equal "Whoa, chill out!"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Shouting with no exclamation mark`` () =
     response "I HATE THE DENTIST" |> should equal "Whoa, chill out!"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Statement containing question mark`` () =
     response "Ending with ? means a question." |> should equal "Whatever."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Non-letters with question`` () =
     response ":) ?" |> should equal "Sure."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Prattling on`` () =
     response "Wait! Hang on. Are you going to be OK?" |> should equal "Sure."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Silence`` () =
     response "" |> should equal "Fine. Be that way!"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Prolonged silence`` () =
     response "          " |> should equal "Fine. Be that way!"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Alternate silence`` () =
     response "\t\t\t\t\t\t\t\t\t\t" |> should equal "Fine. Be that way!"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple line question`` () =
     response "\nDoes this cryogenic chamber make me look fat?\nNo." |> should equal "Whatever."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Starting with whitespace`` () =
     response "         hmmmmmmm..." |> should equal "Whatever."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ending with whitespace`` () =
     response "Okay if like my  spacebar  quite a bit?   " |> should equal "Sure."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Other whitespace`` () =
     response "\n\r \t" |> should equal "Fine. Be that way!"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Non-question ending with whitespace`` () =
     response "This is a statement ending with whitespace      " |> should equal "Whatever."
 

--- a/exercises/book-store/BookStoreTests.fs
+++ b/exercises/book-store/BookStoreTests.fs
@@ -11,59 +11,59 @@ open BookStore
 let ``Only a single book`` () =
     total [1] |> should equal 8.00m
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two of the same book`` () =
     total [2; 2] |> should equal 16.00m
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Empty basket`` () =
     total [] |> should equal 0.00m
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two different books`` () =
     total [1; 2] |> should equal 15.20m
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Three different books`` () =
     total [1; 2; 3] |> should equal 21.60m
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Four different books`` () =
     total [1; 2; 3; 4] |> should equal 25.60m
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Five different books`` () =
     total [1; 2; 3; 4; 5] |> should equal 30.00m
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two groups of four is cheaper than group of five plus group of three`` () =
     total [1; 1; 2; 2; 3; 3; 4; 5] |> should equal 51.20m
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two groups of four is cheaper than groups of five and three`` () =
     total [1; 1; 2; 3; 4; 4; 5; 5] |> should equal 51.20m
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Group of four plus group of two is cheaper than two groups of three`` () =
     total [1; 1; 2; 2; 3; 4] |> should equal 40.80m
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two each of first 4 books and 1 copy each of rest`` () =
     total [1; 1; 2; 2; 3; 3; 4; 4; 5] |> should equal 55.60m
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two copies of each book`` () =
     total [1; 1; 2; 2; 3; 3; 4; 4; 5; 5] |> should equal 60.00m
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Three copies of first book and 2 each of remaining`` () =
     total [1; 1; 2; 2; 3; 3; 4; 4; 5; 5; 1] |> should equal 68.00m
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Three each of first 2 books and 2 each of remaining books`` () =
     total [1; 1; 2; 2; 3; 3; 4; 4; 5; 5; 1; 2] |> should equal 75.20m
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Four groups of four are cheaper than two groups each of five and three`` () =
     total [1; 1; 2; 2; 3; 3; 4; 5; 1; 1; 2; 2; 3; 3; 4; 5] |> should equal 102.40m
 

--- a/exercises/bowling/BowlingTests.fs
+++ b/exercises/bowling/BowlingTests.fs
@@ -15,184 +15,184 @@ let ``Should be able to score a game with all zeros`` () =
     let game = rollMany rolls (newGame())
     score game |> should equal (Some 0)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should be able to score a game with no strikes or spares`` () =
     let rolls = [3; 6; 3; 6; 3; 6; 3; 6; 3; 6; 3; 6; 3; 6; 3; 6; 3; 6; 3; 6]
     let game = rollMany rolls (newGame())
     score game |> should equal (Some 90)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A spare followed by zeros is worth ten points`` () =
     let rolls = [6; 4; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0]
     let game = rollMany rolls (newGame())
     score game |> should equal (Some 10)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Points scored in the roll after a spare are counted twice`` () =
     let rolls = [6; 4; 3; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0]
     let game = rollMany rolls (newGame())
     score game |> should equal (Some 16)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Consecutive spares each get a one roll bonus`` () =
     let rolls = [5; 5; 3; 7; 4; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0]
     let game = rollMany rolls (newGame())
     score game |> should equal (Some 31)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A spare in the last frame gets a one roll bonus that is counted once`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 7; 3; 7]
     let game = rollMany rolls (newGame())
     score game |> should equal (Some 17)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A strike earns ten points in a frame with a single roll`` () =
     let rolls = [10; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0]
     let game = rollMany rolls (newGame())
     score game |> should equal (Some 10)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Points scored in the two rolls after a strike are counted twice as a bonus`` () =
     let rolls = [10; 5; 3; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0]
     let game = rollMany rolls (newGame())
     score game |> should equal (Some 26)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Consecutive strikes each get the two roll bonus`` () =
     let rolls = [10; 10; 10; 5; 3; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0]
     let game = rollMany rolls (newGame())
     score game |> should equal (Some 81)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A strike in the last frame gets a two roll bonus that is counted once`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 10; 7; 1]
     let game = rollMany rolls (newGame())
     score game |> should equal (Some 18)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rolling a spare with the two roll bonus does not get a bonus roll`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 10; 7; 3]
     let game = rollMany rolls (newGame())
     score game |> should equal (Some 20)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Strikes with the two roll bonus do not get bonus rolls`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 10; 10; 10]
     let game = rollMany rolls (newGame())
     score game |> should equal (Some 30)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A strike with the one roll bonus after a spare in the last frame does not get a bonus`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 7; 3; 10]
     let game = rollMany rolls (newGame())
     score game |> should equal (Some 20)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``All strikes is a perfect game`` () =
     let rolls = [10; 10; 10; 10; 10; 10; 10; 10; 10; 10; 10; 10]
     let game = rollMany rolls (newGame())
     score game |> should equal (Some 300)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rolls cannot score negative points`` () =
     let rolls = []
     let startingRolls = rollMany rolls (newGame())
     let game = roll -1 startingRolls
     score game |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A roll cannot score more than 10 points`` () =
     let rolls = []
     let startingRolls = rollMany rolls (newGame())
     let game = roll 11 startingRolls
     score game |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two rolls in a frame cannot score more than 10 points`` () =
     let rolls = [5]
     let startingRolls = rollMany rolls (newGame())
     let game = roll 6 startingRolls
     score game |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Bonus roll after a strike in the last frame cannot score more than 10 points`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 10]
     let startingRolls = rollMany rolls (newGame())
     let game = roll 11 startingRolls
     score game |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two bonus rolls after a strike in the last frame cannot score more than 10 points`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 10; 5]
     let startingRolls = rollMany rolls (newGame())
     let game = roll 6 startingRolls
     score game |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 10; 10; 6]
     let game = rollMany rolls (newGame())
     score game |> should equal (Some 26)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 10; 6]
     let startingRolls = rollMany rolls (newGame())
     let game = roll 10 startingRolls
     score game |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second bonus roll after a strike in the last frame cannot score more than 10 points`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 10; 10]
     let startingRolls = rollMany rolls (newGame())
     let game = roll 11 startingRolls
     score game |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``An unstarted game cannot be scored`` () =
     let rolls = []
     let game = rollMany rolls (newGame())
     score game |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``An incomplete game cannot be scored`` () =
     let rolls = [0; 0]
     let game = rollMany rolls (newGame())
     score game |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Cannot roll if game already has ten frames`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0]
     let startingRolls = rollMany rolls (newGame())
     let game = roll 0 startingRolls
     score game |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Bonus rolls for a strike in the last frame must be rolled before score can be calculated`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 10]
     let game = rollMany rolls (newGame())
     score game |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Both bonus rolls for a strike in the last frame must be rolled before score can be calculated`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 10; 10]
     let game = rollMany rolls (newGame())
     score game |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Bonus roll for a spare in the last frame must be rolled before score can be calculated`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 7; 3]
     let game = rollMany rolls (newGame())
     score game |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Cannot roll after bonus roll for spare`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 7; 3; 2]
     let startingRolls = rollMany rolls (newGame())
     let game = roll 2 startingRolls
     score game |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Cannot roll after bonus rolls for strike`` () =
     let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 10; 3; 2]
     let startingRolls = rollMany rolls (newGame())

--- a/exercises/change/ChangeTests.fs
+++ b/exercises/change/ChangeTests.fs
@@ -14,70 +14,70 @@ let ``Single coin change`` () =
     let expected = Some [25]
     findFewestCoins coins target |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple coin change`` () =
     let coins = [1; 5; 10; 25; 100]
     let target = 15
     let expected = Some [5; 10]
     findFewestCoins coins target |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Change with Lilliputian Coins`` () =
     let coins = [1; 4; 15; 20; 50]
     let target = 23
     let expected = Some [4; 4; 15]
     findFewestCoins coins target |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Change with Lower Elbonia Coins`` () =
     let coins = [1; 5; 10; 21; 25]
     let target = 63
     let expected = Some [21; 21; 21]
     findFewestCoins coins target |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Large target values`` () =
     let coins = [1; 2; 5; 10; 20; 50; 100]
     let target = 999
     let expected = Some [2; 2; 5; 20; 20; 50; 100; 100; 100; 100; 100; 100; 100; 100; 100]
     findFewestCoins coins target |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Possible change without unit coins available`` () =
     let coins = [2; 5; 10; 20; 50]
     let target = 21
     let expected = Some [2; 2; 2; 5; 10]
     findFewestCoins coins target |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Another possible change without unit coins available`` () =
     let coins = [4; 5]
     let target = 27
     let expected = Some [4; 4; 4; 5; 5; 5]
     findFewestCoins coins target |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``No coins make 0 change`` () =
     let coins = [1; 5; 10; 21; 25]
     let target = 0
     let expected: int list option = Some []
     findFewestCoins coins target |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Error testing for change smaller than the smallest of coins`` () =
     let coins = [5; 10]
     let target = 3
     let expected = None
     findFewestCoins coins target |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Error if no combination can add up to target`` () =
     let coins = [5; 10]
     let target = 94
     let expected = None
     findFewestCoins coins target |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Cannot find negative change values`` () =
     let coins = [1; 2; 5]
     let target = -5

--- a/exercises/circular-buffer/CircularBufferTests.fs
+++ b/exercises/circular-buffer/CircularBufferTests.fs
@@ -13,14 +13,14 @@ let ``Reading empty buffer should fail`` () =
     let buffer1 = mkCircularBuffer 1
     (fun () -> read buffer1 |> ignore) |> should throw typeof<Exception>
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can read an item just written`` () =
     let buffer1 = mkCircularBuffer 1
     let buffer2 = write 1 buffer1
     let (val3, _) = read buffer2
     val3 |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Each item may only be read once`` () =
     let buffer1 = mkCircularBuffer 1
     let buffer2 = write 1 buffer1
@@ -28,7 +28,7 @@ let ``Each item may only be read once`` () =
     val3 |> should equal 1
     (fun () -> read buffer3 |> ignore) |> should throw typeof<Exception>
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Items are read in the order they are written`` () =
     let buffer1 = mkCircularBuffer 2
     let buffer2 = write 1 buffer1
@@ -38,13 +38,13 @@ let ``Items are read in the order they are written`` () =
     let (val5, _) = read buffer4
     val5 |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Full buffer can't be written to`` () =
     let buffer1 = mkCircularBuffer 1
     let buffer2 = write 1 buffer1
     (fun () -> write 2 buffer2 |> ignore) |> should throw typeof<Exception>
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A read frees up capacity for another write`` () =
     let buffer1 = mkCircularBuffer 1
     let buffer2 = write 1 buffer1
@@ -54,7 +54,7 @@ let ``A read frees up capacity for another write`` () =
     let (val5, _) = read buffer4
     val5 |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Read position is maintained even across multiple writes`` () =
     let buffer1 = mkCircularBuffer 3
     let buffer2 = write 1 buffer1
@@ -67,14 +67,14 @@ let ``Read position is maintained even across multiple writes`` () =
     let (val7, _) = read buffer6
     val7 |> should equal 3
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Items cleared out of buffer can't be read`` () =
     let buffer1 = mkCircularBuffer 1
     let buffer2 = write 1 buffer1
     let buffer3 = clear buffer2
     (fun () -> read buffer3 |> ignore) |> should throw typeof<Exception>
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clear frees up capacity for another write`` () =
     let buffer1 = mkCircularBuffer 1
     let buffer2 = write 1 buffer1
@@ -83,7 +83,7 @@ let ``Clear frees up capacity for another write`` () =
     let (val5, _) = read buffer4
     val5 |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clear does nothing on empty buffer`` () =
     let buffer1 = mkCircularBuffer 1
     let buffer2 = clear buffer1
@@ -91,7 +91,7 @@ let ``Clear does nothing on empty buffer`` () =
     let (val4, _) = read buffer3
     val4 |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Overwrite acts like write on non-full buffer`` () =
     let buffer1 = mkCircularBuffer 2
     let buffer2 = write 1 buffer1
@@ -101,7 +101,7 @@ let ``Overwrite acts like write on non-full buffer`` () =
     let (val5, _) = read buffer4
     val5 |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Overwrite replaces the oldest item on full buffer`` () =
     let buffer1 = mkCircularBuffer 2
     let buffer2 = write 1 buffer1
@@ -112,7 +112,7 @@ let ``Overwrite replaces the oldest item on full buffer`` () =
     let (val6, _) = read buffer5
     val6 |> should equal 3
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Overwrite replaces the oldest item remaining in buffer following a read`` () =
     let buffer1 = mkCircularBuffer 3
     let buffer2 = write 1 buffer1
@@ -129,7 +129,7 @@ let ``Overwrite replaces the oldest item remaining in buffer following a read`` 
     let (val10, _) = read buffer9
     val10 |> should equal 5
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Initial clear does not affect wrapping around`` () =
     let buffer1 = mkCircularBuffer 2
     let buffer2 = clear buffer1

--- a/exercises/clock/ClockTests.fs
+++ b/exercises/clock/ClockTests.fs
@@ -12,272 +12,272 @@ let ``On the hour`` () =
     let clock = create 8 0
     display clock |> should equal "08:00"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Past the hour`` () =
     let clock = create 11 9
     display clock |> should equal "11:09"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Midnight is zero hours`` () =
     let clock = create 24 0
     display clock |> should equal "00:00"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hour rolls over`` () =
     let clock = create 25 0
     display clock |> should equal "01:00"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hour rolls over continuously`` () =
     let clock = create 100 0
     display clock |> should equal "04:00"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sixty minutes is next hour`` () =
     let clock = create 1 60
     display clock |> should equal "02:00"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Minutes roll over`` () =
     let clock = create 0 160
     display clock |> should equal "02:40"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Minutes roll over continuously`` () =
     let clock = create 0 1723
     display clock |> should equal "04:43"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hour and minutes roll over`` () =
     let clock = create 25 160
     display clock |> should equal "03:40"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hour and minutes roll over continuously`` () =
     let clock = create 201 3001
     display clock |> should equal "11:01"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hour and minutes roll over to exactly midnight`` () =
     let clock = create 72 8640
     display clock |> should equal "00:00"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Negative hour`` () =
     let clock = create -1 15
     display clock |> should equal "23:15"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Negative hour rolls over`` () =
     let clock = create -25 0
     display clock |> should equal "23:00"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Negative hour rolls over continuously`` () =
     let clock = create -91 0
     display clock |> should equal "05:00"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Negative minutes`` () =
     let clock = create 1 -40
     display clock |> should equal "00:20"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Negative minutes roll over`` () =
     let clock = create 1 -160
     display clock |> should equal "22:20"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Negative minutes roll over continuously`` () =
     let clock = create 1 -4820
     display clock |> should equal "16:40"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Negative sixty minutes is previous hour`` () =
     let clock = create 2 -60
     display clock |> should equal "01:00"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Negative hour and minutes both roll over`` () =
     let clock = create -25 -160
     display clock |> should equal "20:20"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Negative hour and minutes both roll over continuously`` () =
     let clock = create -121 -5810
     display clock |> should equal "22:10"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add minutes`` () =
     let clock = create 10 0
     add 3 clock |> display |> should equal "10:03"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add no minutes`` () =
     let clock = create 6 41
     add 0 clock |> display |> should equal "06:41"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add to next hour`` () =
     let clock = create 0 45
     add 40 clock |> display |> should equal "01:25"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add more than one hour`` () =
     let clock = create 10 0
     add 61 clock |> display |> should equal "11:01"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add more than two hours with carry`` () =
     let clock = create 0 45
     add 160 clock |> display |> should equal "03:25"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add across midnight`` () =
     let clock = create 23 59
     add 2 clock |> display |> should equal "00:01"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add more than one day (1500 min = 25 hrs)`` () =
     let clock = create 5 32
     add 1500 clock |> display |> should equal "06:32"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add more than two days`` () =
     let clock = create 1 1
     add 3500 clock |> display |> should equal "11:21"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtract minutes`` () =
     let clock = create 10 3
     subtract 3 clock |> display |> should equal "10:00"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtract to previous hour`` () =
     let clock = create 10 3
     subtract 30 clock |> display |> should equal "09:33"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtract more than an hour`` () =
     let clock = create 10 3
     subtract 70 clock |> display |> should equal "08:53"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtract across midnight`` () =
     let clock = create 0 3
     subtract 4 clock |> display |> should equal "23:59"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtract more than two hours`` () =
     let clock = create 0 0
     subtract 160 clock |> display |> should equal "21:20"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtract more than two hours with borrow`` () =
     let clock = create 6 15
     subtract 160 clock |> display |> should equal "03:35"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtract more than one day (1500 min = 25 hrs)`` () =
     let clock = create 5 32
     subtract 1500 clock |> display |> should equal "04:32"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtract more than two days`` () =
     let clock = create 2 20
     subtract 3000 clock |> display |> should equal "00:20"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clocks with same time`` () =
     let clock1 = create 15 37
     let clock2 = create 15 37
     clock1 = clock2 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clocks a minute apart`` () =
     let clock1 = create 15 36
     let clock2 = create 15 37
     clock1 = clock2 |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clocks an hour apart`` () =
     let clock1 = create 14 37
     let clock2 = create 15 37
     clock1 = clock2 |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clocks with hour overflow`` () =
     let clock1 = create 10 37
     let clock2 = create 34 37
     clock1 = clock2 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clocks with hour overflow by several days`` () =
     let clock1 = create 3 11
     let clock2 = create 99 11
     clock1 = clock2 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clocks with negative hour`` () =
     let clock1 = create 22 40
     let clock2 = create -2 40
     clock1 = clock2 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clocks with negative hour that wraps`` () =
     let clock1 = create 17 3
     let clock2 = create -31 3
     clock1 = clock2 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clocks with negative hour that wraps multiple times`` () =
     let clock1 = create 13 49
     let clock2 = create -83 49
     clock1 = clock2 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clocks with minute overflow`` () =
     let clock1 = create 0 1
     let clock2 = create 0 1441
     clock1 = clock2 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clocks with minute overflow by several days`` () =
     let clock1 = create 2 2
     let clock2 = create 2 4322
     clock1 = clock2 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clocks with negative minute`` () =
     let clock1 = create 2 40
     let clock2 = create 3 -20
     clock1 = clock2 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clocks with negative minute that wraps`` () =
     let clock1 = create 4 10
     let clock2 = create 5 -1490
     clock1 = clock2 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clocks with negative minute that wraps multiple times`` () =
     let clock1 = create 6 15
     let clock2 = create 6 -4305
     clock1 = clock2 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clocks with negative hours and minutes`` () =
     let clock1 = create 7 32
     let clock2 = create -12 -268
     clock1 = clock2 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Clocks with negative hours and minutes that wrap`` () =
     let clock1 = create 18 7
     let clock2 = create -54 -11513
     clock1 = clock2 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Full clock and zeroed clock`` () =
     let clock1 = create 24 0
     let clock2 = create 0 0

--- a/exercises/collatz-conjecture/CollatzConjectureTests.fs
+++ b/exercises/collatz-conjecture/CollatzConjectureTests.fs
@@ -11,23 +11,23 @@ open CollatzConjecture
 let ``Zero steps for one`` () =
     steps 1 |> should equal (Some 0)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Divide if even`` () =
     steps 16 |> should equal (Some 4)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Even and odd steps`` () =
     steps 12 |> should equal (Some 9)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Large number of even and odd steps`` () =
     steps 1000000 |> should equal (Some 152)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Zero is an error`` () =
     steps 0 |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Negative value is an error`` () =
     steps -15 |> should equal None
 

--- a/exercises/complex-numbers/ComplexNumbersTests.fs
+++ b/exercises/complex-numbers/ComplexNumbersTests.fs
@@ -12,161 +12,161 @@ open ComplexNumbers
 let ``Real part of a purely real number`` () =
     real (create 1.0 0.0) |> should equal 1.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Real part of a purely imaginary number`` () =
     real (create 0.0 1.0) |> should equal 0.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Real part of a number with real and imaginary part`` () =
     real (create 1.0 2.0) |> should equal 1.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Imaginary part of a purely real number`` () =
     imaginary (create 1.0 0.0) |> should equal 0.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Imaginary part of a purely imaginary number`` () =
     imaginary (create 0.0 1.0) |> should equal 1.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Imaginary part of a number with real and imaginary part`` () =
     imaginary (create 1.0 2.0) |> should equal 2.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Imaginary unit`` () =
     let sut = mul (create 0.0 1.0) (create 0.0 1.0)
     real sut |> should (equalWithin 0.01) -1.0
     imaginary sut |> should (equalWithin 0.01) 0.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add purely real numbers`` () =
     let sut = add (create 1.0 0.0) (create 2.0 0.0)
     real sut |> should (equalWithin 0.01) 3.0
     imaginary sut |> should (equalWithin 0.01) 0.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add purely imaginary numbers`` () =
     let sut = add (create 0.0 1.0) (create 0.0 2.0)
     real sut |> should (equalWithin 0.01) 0.0
     imaginary sut |> should (equalWithin 0.01) 3.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add numbers with real and imaginary part`` () =
     let sut = add (create 1.0 2.0) (create 3.0 4.0)
     real sut |> should (equalWithin 0.01) 4.0
     imaginary sut |> should (equalWithin 0.01) 6.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtract purely real numbers`` () =
     let sut = sub (create 1.0 0.0) (create 2.0 0.0)
     real sut |> should (equalWithin 0.01) -1.0
     imaginary sut |> should (equalWithin 0.01) 0.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtract purely imaginary numbers`` () =
     let sut = sub (create 0.0 1.0) (create 0.0 2.0)
     real sut |> should (equalWithin 0.01) 0.0
     imaginary sut |> should (equalWithin 0.01) -1.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtract numbers with real and imaginary part`` () =
     let sut = sub (create 1.0 2.0) (create 3.0 4.0)
     real sut |> should (equalWithin 0.01) -2.0
     imaginary sut |> should (equalWithin 0.01) -2.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiply purely real numbers`` () =
     let sut = mul (create 1.0 0.0) (create 2.0 0.0)
     real sut |> should (equalWithin 0.01) 2.0
     imaginary sut |> should (equalWithin 0.01) 0.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiply purely imaginary numbers`` () =
     let sut = mul (create 0.0 1.0) (create 0.0 2.0)
     real sut |> should (equalWithin 0.01) -2.0
     imaginary sut |> should (equalWithin 0.01) 0.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiply numbers with real and imaginary part`` () =
     let sut = mul (create 1.0 2.0) (create 3.0 4.0)
     real sut |> should (equalWithin 0.01) -5.0
     imaginary sut |> should (equalWithin 0.01) 10.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Divide purely real numbers`` () =
     let sut = div (create 1.0 0.0) (create 2.0 0.0)
     real sut |> should (equalWithin 0.01) 0.5
     imaginary sut |> should (equalWithin 0.01) 0.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Divide purely imaginary numbers`` () =
     let sut = div (create 0.0 1.0) (create 0.0 2.0)
     real sut |> should (equalWithin 0.01) 0.5
     imaginary sut |> should (equalWithin 0.01) 0.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Divide numbers with real and imaginary part`` () =
     let sut = div (create 1.0 2.0) (create 3.0 4.0)
     real sut |> should (equalWithin 0.01) 0.44
     imaginary sut |> should (equalWithin 0.01) 0.08
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Absolute value of a positive purely real number`` () =
     abs (create 5.0 0.0) |> should equal 5.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Absolute value of a negative purely real number`` () =
     abs (create -5.0 0.0) |> should equal 5.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Absolute value of a purely imaginary number with positive imaginary part`` () =
     abs (create 0.0 5.0) |> should equal 5.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Absolute value of a purely imaginary number with negative imaginary part`` () =
     abs (create 0.0 -5.0) |> should equal 5.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Absolute value of a number with real and imaginary part`` () =
     abs (create 3.0 4.0) |> should equal 5.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Conjugate a purely real number`` () =
     let sut = conjugate (create 5.0 0.0)
     real sut |> should (equalWithin 0.01) 5.0
     imaginary sut |> should (equalWithin 0.01) 0.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Conjugate a purely imaginary number`` () =
     let sut = conjugate (create 0.0 5.0)
     real sut |> should (equalWithin 0.01) 0.0
     imaginary sut |> should (equalWithin 0.01) -5.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Conjugate a number with real and imaginary part`` () =
     let sut = conjugate (create 1.0 1.0)
     real sut |> should (equalWithin 0.01) 1.0
     imaginary sut |> should (equalWithin 0.01) -1.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Euler's identity/formula`` () =
     let sut = exp (create 0.0 Math.PI)
     real sut |> should (equalWithin 0.01) -1.0
     imaginary sut |> should (equalWithin 0.01) 0.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Exponential of 0`` () =
     let sut = exp (create 0.0 0.0)
     real sut |> should (equalWithin 0.01) 1.0
     imaginary sut |> should (equalWithin 0.01) 0.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Exponential of a purely real number`` () =
     let sut = exp (create 1.0 0.0)
     real sut |> should (equalWithin 0.01) Math.E
     imaginary sut |> should (equalWithin 0.01) 0.0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Exponential of a number with real and imaginary part`` () =
     let sut = exp (create (Math.Log(2.0)) Math.PI)
     real sut |> should (equalWithin 0.01) -2.0

--- a/exercises/connect/ConnectTests.fs
+++ b/exercises/connect/ConnectTests.fs
@@ -17,17 +17,17 @@ let ``An empty board has no winner`` () =
           "    . . . . ." ]
     winner board |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``X can win on a 1x1 board`` () =
     let board = ["X"]
     winner board |> should equal (Some Black)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``O can win on a 1x1 board`` () =
     let board = ["O"]
     winner board |> should equal (Some White)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Only edges does not make a winner`` () =
     let board = 
         [ "O O O X   ";
@@ -36,7 +36,7 @@ let ``Only edges does not make a winner`` () =
           "   X O O O" ]
     winner board |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Illegal diagonal does not make a winner`` () =
     let board = 
         [ "X O . .    ";
@@ -46,7 +46,7 @@ let ``Illegal diagonal does not make a winner`` () =
           "    X X O O" ]
     winner board |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Nobody wins crossing adjacent angles`` () =
     let board = 
         [ "X . . .    ";
@@ -56,7 +56,7 @@ let ``Nobody wins crossing adjacent angles`` () =
           "    . . O ." ]
     winner board |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``X wins crossing from left to right`` () =
     let board = 
         [ ". O . .    ";
@@ -66,7 +66,7 @@ let ``X wins crossing from left to right`` () =
           "    . O X ." ]
     winner board |> should equal (Some Black)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``O wins crossing from top to bottom`` () =
     let board = 
         [ ". O . .    ";
@@ -76,7 +76,7 @@ let ``O wins crossing from top to bottom`` () =
           "    . O X ." ]
     winner board |> should equal (Some White)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``X wins using a convoluted path`` () =
     let board = 
         [ ". X X . .    ";
@@ -86,7 +86,7 @@ let ``X wins using a convoluted path`` () =
           "    O O O O O" ]
     winner board |> should equal (Some Black)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``X wins using a spiral path`` () =
     let board = 
         [ "O X X X X X X X X        ";

--- a/exercises/crypto-square/CryptoSquareTests.fs
+++ b/exercises/crypto-square/CryptoSquareTests.fs
@@ -11,27 +11,27 @@ open CryptoSquare
 let ``Empty plaintext results in an empty ciphertext`` () =
     ciphertext "" |> should equal ""
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Lowercase`` () =
     ciphertext "A" |> should equal "a"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Remove spaces`` () =
     ciphertext "  b " |> should equal "b"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Remove punctuation`` () =
     ciphertext "@1,%!" |> should equal "1"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``9 character plaintext results in 3 chunks of 3 characters`` () =
     ciphertext "This is fun!" |> should equal "tsf hiu isn"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``8 character plaintext results in 3 chunks, the last one with a trailing space`` () =
     ciphertext "Chill out." |> should equal "clu hlt io "
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``54 character plaintext results in 7 chunks, the last two with trailing spaces`` () =
     ciphertext "If man was meant to stay on the ground, god would have given us roots." |> should equal "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "
 

--- a/exercises/custom-set/CustomSetTests.fs
+++ b/exercises/custom-set/CustomSetTests.fs
@@ -12,152 +12,152 @@ let ``Sets with no elements are empty`` () =
     let actual = CustomSet.isEmpty (CustomSet.fromList [])
     actual |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sets with elements are not empty`` () =
     let actual = CustomSet.isEmpty (CustomSet.fromList [1])
     actual |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Nothing is contained in an empty set`` () =
     let setValue = CustomSet.fromList []
     let element = 1
     let actual = CustomSet.contains element setValue
     actual |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``When the element is in the set`` () =
     let setValue = CustomSet.fromList [1; 2; 3]
     let element = 1
     let actual = CustomSet.contains element setValue
     actual |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``When the element is not in the set`` () =
     let setValue = CustomSet.fromList [1; 2; 3]
     let element = 4
     let actual = CustomSet.contains element setValue
     actual |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Empty set is a subset of another empty set`` () =
     let set1 = CustomSet.fromList []
     let set2 = CustomSet.fromList []
     let actual = CustomSet.isSubsetOf set1 set2
     actual |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Empty set is a subset of non-empty set`` () =
     let set1 = CustomSet.fromList []
     let set2 = CustomSet.fromList [1]
     let actual = CustomSet.isSubsetOf set1 set2
     actual |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Non-empty set is not a subset of empty set`` () =
     let set1 = CustomSet.fromList [1]
     let set2 = CustomSet.fromList []
     let actual = CustomSet.isSubsetOf set1 set2
     actual |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Set is a subset of set with exact same elements`` () =
     let set1 = CustomSet.fromList [1; 2; 3]
     let set2 = CustomSet.fromList [1; 2; 3]
     let actual = CustomSet.isSubsetOf set1 set2
     actual |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Set is a subset of larger set with same elements`` () =
     let set1 = CustomSet.fromList [1; 2; 3]
     let set2 = CustomSet.fromList [4; 1; 2; 3]
     let actual = CustomSet.isSubsetOf set1 set2
     actual |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Set is not a subset of set that does not contain its elements`` () =
     let set1 = CustomSet.fromList [1; 2; 3]
     let set2 = CustomSet.fromList [4; 1; 3]
     let actual = CustomSet.isSubsetOf set1 set2
     actual |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The empty set is disjoint with itself`` () =
     let set1 = CustomSet.fromList []
     let set2 = CustomSet.fromList []
     let actual = CustomSet.isDisjointFrom set1 set2
     actual |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Empty set is disjoint with non-empty set`` () =
     let set1 = CustomSet.fromList []
     let set2 = CustomSet.fromList [1]
     let actual = CustomSet.isDisjointFrom set1 set2
     actual |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Non-empty set is disjoint with empty set`` () =
     let set1 = CustomSet.fromList [1]
     let set2 = CustomSet.fromList []
     let actual = CustomSet.isDisjointFrom set1 set2
     actual |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sets are not disjoint if they share an element`` () =
     let set1 = CustomSet.fromList [1; 2]
     let set2 = CustomSet.fromList [2; 3]
     let actual = CustomSet.isDisjointFrom set1 set2
     actual |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sets are disjoint if they share no elements`` () =
     let set1 = CustomSet.fromList [1; 2]
     let set2 = CustomSet.fromList [3; 4]
     let actual = CustomSet.isDisjointFrom set1 set2
     actual |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Empty sets are equal`` () =
     let set1 = CustomSet.fromList []
     let set2 = CustomSet.fromList []
     let actual = CustomSet.isEqualTo set1 set2
     actual |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Empty set is not equal to non-empty set`` () =
     let set1 = CustomSet.fromList []
     let set2 = CustomSet.fromList [1; 2; 3]
     let actual = CustomSet.isEqualTo set1 set2
     actual |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Non-empty set is not equal to empty set`` () =
     let set1 = CustomSet.fromList [1; 2; 3]
     let set2 = CustomSet.fromList []
     let actual = CustomSet.isEqualTo set1 set2
     actual |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sets with the same elements are equal`` () =
     let set1 = CustomSet.fromList [1; 2]
     let set2 = CustomSet.fromList [2; 1]
     let actual = CustomSet.isEqualTo set1 set2
     actual |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sets with different elements are not equal`` () =
     let set1 = CustomSet.fromList [1; 2; 3]
     let set2 = CustomSet.fromList [1; 2; 4]
     let actual = CustomSet.isEqualTo set1 set2
     actual |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Set is not equal to larger set with same elements`` () =
     let set1 = CustomSet.fromList [1; 2; 3]
     let set2 = CustomSet.fromList [1; 2; 3; 4]
     let actual = CustomSet.isEqualTo set1 set2
     actual |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add to empty set`` () =
     let setValue = CustomSet.fromList []
     let element = 3
@@ -166,7 +166,7 @@ let ``Add to empty set`` () =
     let actualBool = CustomSet.isEqualTo actual expectedSet
     actualBool |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add to non-empty set`` () =
     let setValue = CustomSet.fromList [1; 2; 4]
     let element = 3
@@ -175,7 +175,7 @@ let ``Add to non-empty set`` () =
     let actualBool = CustomSet.isEqualTo actual expectedSet
     actualBool |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Adding an existing element does not change the set`` () =
     let setValue = CustomSet.fromList [1; 2; 3]
     let element = 3
@@ -184,7 +184,7 @@ let ``Adding an existing element does not change the set`` () =
     let actualBool = CustomSet.isEqualTo actual expectedSet
     actualBool |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Intersection of two empty sets is an empty set`` () =
     let set1 = CustomSet.fromList []
     let set2 = CustomSet.fromList []
@@ -193,7 +193,7 @@ let ``Intersection of two empty sets is an empty set`` () =
     let actualBool = CustomSet.isEqualTo actual expectedSet
     actualBool |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Intersection of an empty set and non-empty set is an empty set`` () =
     let set1 = CustomSet.fromList []
     let set2 = CustomSet.fromList [3; 2; 5]
@@ -202,7 +202,7 @@ let ``Intersection of an empty set and non-empty set is an empty set`` () =
     let actualBool = CustomSet.isEqualTo actual expectedSet
     actualBool |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Intersection of a non-empty set and an empty set is an empty set`` () =
     let set1 = CustomSet.fromList [1; 2; 3; 4]
     let set2 = CustomSet.fromList []
@@ -211,7 +211,7 @@ let ``Intersection of a non-empty set and an empty set is an empty set`` () =
     let actualBool = CustomSet.isEqualTo actual expectedSet
     actualBool |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Intersection of two sets with no shared elements is an empty set`` () =
     let set1 = CustomSet.fromList [1; 2; 3]
     let set2 = CustomSet.fromList [4; 5; 6]
@@ -220,7 +220,7 @@ let ``Intersection of two sets with no shared elements is an empty set`` () =
     let actualBool = CustomSet.isEqualTo actual expectedSet
     actualBool |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Intersection of two sets with shared elements is a set of the shared elements`` () =
     let set1 = CustomSet.fromList [1; 2; 3; 4]
     let set2 = CustomSet.fromList [3; 2; 5]
@@ -229,7 +229,7 @@ let ``Intersection of two sets with shared elements is a set of the shared eleme
     let actualBool = CustomSet.isEqualTo actual expectedSet
     actualBool |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Difference of two empty sets is an empty set`` () =
     let set1 = CustomSet.fromList []
     let set2 = CustomSet.fromList []
@@ -238,7 +238,7 @@ let ``Difference of two empty sets is an empty set`` () =
     let actualBool = CustomSet.isEqualTo actual expectedSet
     actualBool |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Difference of empty set and non-empty set is an empty set`` () =
     let set1 = CustomSet.fromList []
     let set2 = CustomSet.fromList [3; 2; 5]
@@ -247,7 +247,7 @@ let ``Difference of empty set and non-empty set is an empty set`` () =
     let actualBool = CustomSet.isEqualTo actual expectedSet
     actualBool |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Difference of a non-empty set and an empty set is the non-empty set`` () =
     let set1 = CustomSet.fromList [1; 2; 3; 4]
     let set2 = CustomSet.fromList []
@@ -256,7 +256,7 @@ let ``Difference of a non-empty set and an empty set is the non-empty set`` () =
     let actualBool = CustomSet.isEqualTo actual expectedSet
     actualBool |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Difference of two non-empty sets is a set of elements that are only in the first set`` () =
     let set1 = CustomSet.fromList [3; 2; 1]
     let set2 = CustomSet.fromList [2; 4]
@@ -265,7 +265,7 @@ let ``Difference of two non-empty sets is a set of elements that are only in the
     let actualBool = CustomSet.isEqualTo actual expectedSet
     actualBool |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Union of empty sets is an empty set`` () =
     let set1 = CustomSet.fromList []
     let set2 = CustomSet.fromList []
@@ -274,7 +274,7 @@ let ``Union of empty sets is an empty set`` () =
     let actualBool = CustomSet.isEqualTo actual expectedSet
     actualBool |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Union of an empty set and non-empty set is the non-empty set`` () =
     let set1 = CustomSet.fromList []
     let set2 = CustomSet.fromList [2]
@@ -283,7 +283,7 @@ let ``Union of an empty set and non-empty set is the non-empty set`` () =
     let actualBool = CustomSet.isEqualTo actual expectedSet
     actualBool |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Union of a non-empty set and empty set is the non-empty set`` () =
     let set1 = CustomSet.fromList [1; 3]
     let set2 = CustomSet.fromList []
@@ -292,7 +292,7 @@ let ``Union of a non-empty set and empty set is the non-empty set`` () =
     let actualBool = CustomSet.isEqualTo actual expectedSet
     actualBool |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Union of non-empty sets contains all unique elements`` () =
     let set1 = CustomSet.fromList [1; 3]
     let set2 = CustomSet.fromList [2; 3]

--- a/exercises/darts/DartsTests.fs
+++ b/exercises/darts/DartsTests.fs
@@ -11,51 +11,51 @@ open Darts
 let ``Missed target`` () =
     score -9.0 9.0 |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``On the outer circle`` () =
     score 0.0 10.0 |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``On the middle circle`` () =
     score -5.0 0.0 |> should equal 5
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``On the inner circle`` () =
     score 0.0 -1.0 |> should equal 10
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Exactly on centre`` () =
     score 0.0 0.0 |> should equal 10
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Near the centre`` () =
     score -0.1 -0.1 |> should equal 10
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Just within the inner circle`` () =
     score 0.7 0.7 |> should equal 10
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Just outside the inner circle`` () =
     score 0.8 -0.8 |> should equal 5
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Just within the middle circle`` () =
     score -3.5 3.5 |> should equal 5
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Just outside the middle circle`` () =
     score -3.6 -3.6 |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Just within the outer circle`` () =
     score -7.0 7.0 |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Just outside the outer circle`` () =
     score 7.1 -7.1 |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Asymmetric position between the inner and middle circles`` () =
     score 0.5 -4.0 |> should equal 5
 

--- a/exercises/diamond/DiamondTests.fs
+++ b/exercises/diamond/DiamondTests.fs
@@ -33,7 +33,7 @@ let ``First row contains 'A'`` (letter:char) =
 
     firstRowCharacters |> should equal "A"
 
-[<DiamondProperty(Skip = "Remove to run test")>]
+[<DiamondProperty(Skip = "Remove this Skip property to run this test")>]
 let ``All rows must have symmetric contour`` (letter:char) =
     let actual = make letter
     let rows = actual |> split
@@ -41,7 +41,7 @@ let ``All rows must have symmetric contour`` (letter:char) =
 
     rows |> Array.iter (fun x -> symmetric x |> should equal true)
 
-[<DiamondProperty(Skip = "Remove to run test")>]
+[<DiamondProperty(Skip = "Remove this Skip property to run this test")>]
 let ``Top of figure has letters in correct order`` (letter:char) =
     let actual = make letter
 
@@ -55,7 +55,7 @@ let ``Top of figure has letters in correct order`` (letter:char) =
 
     expected |> should equal firstNonSpaceLetters
 
-[<DiamondProperty(Skip = "Remove to run test")>]
+[<DiamondProperty(Skip = "Remove this Skip property to run this test")>]
 let ``Figure is symmetric around the horizontal axis`` (letter:char) =
     let actual = make letter
 
@@ -73,7 +73,7 @@ let ``Figure is symmetric around the horizontal axis`` (letter:char) =
 
     top |> should equal bottom
 
-[<DiamondProperty(Skip = "Remove to run test")>]
+[<DiamondProperty(Skip = "Remove this Skip property to run this test")>]
 let ``Diamond has square shape`` (letter:char) =
     let actual = make letter
 
@@ -83,7 +83,7 @@ let ``Diamond has square shape`` (letter:char) =
 
     rows |> Array.iter (fun x -> correctWidth x |> should equal true)
 
-[<DiamondProperty(Skip = "Remove to run test")>]
+[<DiamondProperty(Skip = "Remove this Skip property to run this test")>]
 let ``All rows except top and bottom have two identical letters`` (letter:char) =
     let actual = make letter
 
@@ -99,7 +99,7 @@ let ``All rows except top and bottom have two identical letters`` (letter:char) 
 
     rows |> Array.iter (fun x -> twoIdenticalLetters x |> should equal true)
 
-[<DiamondProperty(Skip = "Remove to run test")>]
+[<DiamondProperty(Skip = "Remove this Skip property to run this test")>]
 let ``Bottom left corner spaces are triangle`` (letter:char) =
     let actual = make letter
 

--- a/exercises/difference-of-squares/DifferenceOfSquaresTests.fs
+++ b/exercises/difference-of-squares/DifferenceOfSquaresTests.fs
@@ -11,35 +11,35 @@ open DifferenceOfSquares
 let ``Square of sum 1`` () =
     squareOfSum 1 |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Square of sum 5`` () =
     squareOfSum 5 |> should equal 225
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Square of sum 100`` () =
     squareOfSum 100 |> should equal 25502500
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sum of squares 1`` () =
     sumOfSquares 1 |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sum of squares 5`` () =
     sumOfSquares 5 |> should equal 55
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sum of squares 100`` () =
     sumOfSquares 100 |> should equal 338350
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Difference of squares 1`` () =
     differenceOfSquares 1 |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Difference of squares 5`` () =
     differenceOfSquares 5 |> should equal 170
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Difference of squares 100`` () =
     differenceOfSquares 100 |> should equal 25164150
 

--- a/exercises/diffie-hellman/DiffieHellmanTests.fs
+++ b/exercises/diffie-hellman/DiffieHellmanTests.fs
@@ -14,27 +14,27 @@ let ``Private key is in range 1 .. p`` () =
     privateKeys |> List.iter (fun x -> x |> should be (greaterThan 1I))
     privateKeys |> List.iter (fun x -> x |> should be (lessThan p))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Private key is random`` () =
     let p = 7919I
     let privateKeys = [for _ in 0 .. 10 -> privateKey p]
     List.distinct privateKeys |> List.length |> should equal (List.length privateKeys)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can calculate public key using private key`` () =
     let p = 23I
     let g = 5I
     let privateKey = 6I
     publicKey p g privateKey |> should equal 8I
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can calculate secret using other party's public key`` () =
     let p = 23I
     let theirPublicKey = 19I
     let myPrivateKey = 6I
     secret p theirPublicKey myPrivateKey |> should equal 2I
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Key exchange`` () =
     let p = 23I
     let g = 5I

--- a/exercises/dnd-character/DndCharacterTests.fs
+++ b/exercises/dnd-character/DndCharacterTests.fs
@@ -11,74 +11,74 @@ open DndCharacter
 let ``Ability modifier for score 3 is -4`` () =
     modifier 3 |> should equal -4
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ability modifier for score 4 is -3`` () =
     modifier 4 |> should equal -3
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ability modifier for score 5 is -3`` () =
     modifier 5 |> should equal -3
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ability modifier for score 6 is -2`` () =
     modifier 6 |> should equal -2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ability modifier for score 7 is -2`` () =
     modifier 7 |> should equal -2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ability modifier for score 8 is -1`` () =
     modifier 8 |> should equal -1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ability modifier for score 9 is -1`` () =
     modifier 9 |> should equal -1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ability modifier for score 10 is 0`` () =
     modifier 10 |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ability modifier for score 11 is 0`` () =
     modifier 11 |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ability modifier for score 12 is +1`` () =
     modifier 12 |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ability modifier for score 13 is +1`` () =
     modifier 13 |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ability modifier for score 14 is +2`` () =
     modifier 14 |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ability modifier for score 15 is +2`` () =
     modifier 15 |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ability modifier for score 16 is +3`` () =
     modifier 16 |> should equal 3
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ability modifier for score 17 is +3`` () =
     modifier 17 |> should equal 3
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ability modifier for score 18 is +4`` () =
     modifier 18 |> should equal 4
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Random ability is within range`` () =
     for i in 1 .. 10 do
         let ability = ability()
         ability |> should be (greaterThanOrEqualTo 3)
         ability |> should be (lessThanOrEqualTo  18)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Random character is valid`` () =
     for i in 1 .. 10 do
         let character = createCharacter()
@@ -96,7 +96,7 @@ let ``Random character is valid`` () =
         character.Charisma |> should be (lessThanOrEqualTo  18)
         character.Hitpoints |> should equal (10 + modifier(character.Constitution))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Each ability is only calculated once`` () =
     for i in 1 .. 10 do
         let character = createCharacter()

--- a/exercises/dominoes/DominoesTests.fs
+++ b/exercises/dominoes/DominoesTests.fs
@@ -12,57 +12,57 @@ let ``Empty input = empty output`` () =
     let dominoes = []
     canChain dominoes |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Singleton input = singleton output`` () =
     let dominoes = [(1, 1)]
     canChain dominoes |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Singleton that can't be chained`` () =
     let dominoes = [(1, 2)]
     canChain dominoes |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Three elements`` () =
     let dominoes = [(1, 2); (3, 1); (2, 3)]
     canChain dominoes |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can reverse dominoes`` () =
     let dominoes = [(1, 2); (1, 3); (2, 3)]
     canChain dominoes |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can't be chained`` () =
     let dominoes = [(1, 2); (4, 1); (2, 3)]
     canChain dominoes |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Disconnected - simple`` () =
     let dominoes = [(1, 1); (2, 2)]
     canChain dominoes |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Disconnected - double loop`` () =
     let dominoes = [(1, 2); (2, 1); (3, 4); (4, 3)]
     canChain dominoes |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Disconnected - single isolated`` () =
     let dominoes = [(1, 2); (2, 3); (3, 1); (4, 4)]
     canChain dominoes |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Need backtrack`` () =
     let dominoes = [(1, 2); (2, 3); (3, 1); (2, 4); (2, 4)]
     canChain dominoes |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Separate loops`` () =
     let dominoes = [(1, 2); (2, 3); (3, 1); (1, 1); (2, 2); (3, 3)]
     canChain dominoes |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Nine elements`` () =
     let dominoes = [(1, 2); (5, 3); (3, 1); (1, 2); (2, 4); (1, 6); (2, 3); (3, 4); (5, 6)]
     canChain dominoes |> should equal true

--- a/exercises/dot-dsl/DotDslTests.fs
+++ b/exercises/dot-dsl/DotDslTests.fs
@@ -15,7 +15,7 @@ let ``Empty graph`` () =
     edges g |> should be Empty
     attrs g |> should be Empty
     
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Graph with one node`` () =
     let g = graph [
                 node "a" []
@@ -25,7 +25,7 @@ let ``Graph with one node`` () =
     edges g |> should be Empty
     attrs g |> should be Empty
     
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Graph with one node with keywords`` () =    
     let g = graph [
                 node "a" [("color", "green")]
@@ -35,7 +35,7 @@ let ``Graph with one node with keywords`` () =
     edges g |> should be Empty
     attrs g |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Graph with one edge`` () =    
     let g = graph [
                 edge "a" "b" []
@@ -45,7 +45,7 @@ let ``Graph with one edge`` () =
     edges g |> should equal [edge "a" "b" []]
     attrs g |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Graph with one attribute`` () = 
     let g = graph [
                 attr "foo" "1"
@@ -55,7 +55,7 @@ let ``Graph with one attribute`` () =
     edges g |> should be Empty
     attrs g |> should equal [attr "foo" "1"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Graph with attributes`` () =    
     let g = graph [
                 attr "foo" "1"

--- a/exercises/error-handling/ErrorHandlingTests.fs
+++ b/exercises/error-handling/ErrorHandlingTests.fs
@@ -29,7 +29,7 @@ let ``Throwing exception`` () =
 // Upon failure, None is returned. The caller can then pattern match on the
 // returned value. As Option<'T> is a discriminated union, the user is forced to
 // consider both possible outputs: success and failure.
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Returning Option<'T>`` () =
     let successResult = handleErrorByReturningOption "1"
     successResult |> should equal <| Some 1
@@ -42,7 +42,7 @@ let ``Returning Option<'T>`` () =
 // This discriminated union has two possible cases: Ok and Error, which contain data
 // of type 'TSuccess and 'TError respectively. Note that these types can be different, so
 // you are free to return an integer upon success and a string upon failure.
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Returning Result<'TSuccess, 'TError>`` () =
     let successResult = handleErrorByReturningResult "1"
     (successResult = Ok 1) |> should equal true
@@ -65,7 +65,7 @@ let ``Returning Result<'TSuccess, 'TError>`` () =
 //
 // In this test, your task is to write a function "bind", that allows you to combine
 // two functions that take a 'TSuccess instance and return a Result<'TSuccess, 'TError> instance.
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Using railway-oriented programming`` () =
     let validate1 x = if x > 5 then Ok x else Error "Input less than or equal to five"
     let validate2 x = if x < 10 then Ok x else Error "Input greater than or equal to ten"
@@ -92,7 +92,7 @@ let ``Using railway-oriented programming`` () =
     
 // If you are dealing with code that throws exceptions, you should ensure that any
 // disposable resources that are used are being disposed of
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Cleaning up disposables when throwing exception`` () =    
     let resource = new Resource()
 

--- a/exercises/etl/EtlTests.fs
+++ b/exercises/etl/EtlTests.fs
@@ -13,7 +13,7 @@ let ``Single letter`` () =
     let expected = [('a', 1)] |> Map.ofList
     transform lettersByScore |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Single score with multiple letters`` () =
     let lettersByScore = [(1, ['A'; 'E'; 'I'; 'O'; 'U'])] |> Map.ofList
     let expected = 
@@ -25,7 +25,7 @@ let ``Single score with multiple letters`` () =
         |> Map.ofList
     transform lettersByScore |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple scores with multiple letters`` () =
     let lettersByScore = 
         [ (1, ['A'; 'E']);
@@ -39,7 +39,7 @@ let ``Multiple scores with multiple letters`` () =
         |> Map.ofList
     transform lettersByScore |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple scores with differing numbers of letters`` () =
     let lettersByScore = 
         [ (1, ['A'; 'E'; 'I'; 'O'; 'U'; 'L'; 'N'; 'R'; 'S'; 'T']);

--- a/exercises/food-chain/FoodChainTests.fs
+++ b/exercises/food-chain/FoodChainTests.fs
@@ -14,7 +14,7 @@ let ``Fly`` () =
           "I don't know why she swallowed the fly. Perhaps she'll die." ]
     recite 1 1 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Spider`` () =
     let expected = 
         [ "I know an old lady who swallowed a spider.";
@@ -23,7 +23,7 @@ let ``Spider`` () =
           "I don't know why she swallowed the fly. Perhaps she'll die." ]
     recite 2 2 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Bird`` () =
     let expected = 
         [ "I know an old lady who swallowed a bird.";
@@ -33,7 +33,7 @@ let ``Bird`` () =
           "I don't know why she swallowed the fly. Perhaps she'll die." ]
     recite 3 3 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Cat`` () =
     let expected = 
         [ "I know an old lady who swallowed a cat.";
@@ -44,7 +44,7 @@ let ``Cat`` () =
           "I don't know why she swallowed the fly. Perhaps she'll die." ]
     recite 4 4 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Dog`` () =
     let expected = 
         [ "I know an old lady who swallowed a dog.";
@@ -56,7 +56,7 @@ let ``Dog`` () =
           "I don't know why she swallowed the fly. Perhaps she'll die." ]
     recite 5 5 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Goat`` () =
     let expected = 
         [ "I know an old lady who swallowed a goat.";
@@ -69,7 +69,7 @@ let ``Goat`` () =
           "I don't know why she swallowed the fly. Perhaps she'll die." ]
     recite 6 6 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Cow`` () =
     let expected = 
         [ "I know an old lady who swallowed a cow.";
@@ -83,14 +83,14 @@ let ``Cow`` () =
           "I don't know why she swallowed the fly. Perhaps she'll die." ]
     recite 7 7 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Horse`` () =
     let expected = 
         [ "I know an old lady who swallowed a horse.";
           "She's dead, of course!" ]
     recite 8 8 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple verses`` () =
     let expected = 
         [ "I know an old lady who swallowed a fly.";
@@ -108,7 +108,7 @@ let ``Multiple verses`` () =
           "I don't know why she swallowed the fly. Perhaps she'll die." ]
     recite 1 3 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Full song`` () =
     let expected = 
         [ "I know an old lady who swallowed a fly.";

--- a/exercises/forth/ForthTests.fs
+++ b/exercises/forth/ForthTests.fs
@@ -12,227 +12,227 @@ let ``Parsing and numbers - numbers just get pushed onto the stack`` () =
     let expected = Some [1; 2; 3; 4; 5]
     evaluate ["1 2 3 4 5"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Addition - can add two numbers`` () =
     let expected = Some [3]
     evaluate ["1 2 +"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Addition - errors if there is nothing on the stack`` () =
     let expected = None
     evaluate ["+"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Addition - errors if there is only one value on the stack`` () =
     let expected = None
     evaluate ["1 +"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtraction - can subtract two numbers`` () =
     let expected = Some [-1]
     evaluate ["3 4 -"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtraction - errors if there is nothing on the stack`` () =
     let expected = None
     evaluate ["-"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtraction - errors if there is only one value on the stack`` () =
     let expected = None
     evaluate ["1 -"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiplication - can multiply two numbers`` () =
     let expected = Some [8]
     evaluate ["2 4 *"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiplication - errors if there is nothing on the stack`` () =
     let expected = None
     evaluate ["*"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiplication - errors if there is only one value on the stack`` () =
     let expected = None
     evaluate ["1 *"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Division - can divide two numbers`` () =
     let expected = Some [4]
     evaluate ["12 3 /"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Division - performs integer division`` () =
     let expected = Some [2]
     evaluate ["8 3 /"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Division - errors if dividing by zero`` () =
     let expected = None
     evaluate ["4 0 /"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Division - errors if there is nothing on the stack`` () =
     let expected = None
     evaluate ["/"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Division - errors if there is only one value on the stack`` () =
     let expected = None
     evaluate ["1 /"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Combined arithmetic - addition and subtraction`` () =
     let expected = Some [-1]
     evaluate ["1 2 + 4 -"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Combined arithmetic - multiplication and division`` () =
     let expected = Some [2]
     evaluate ["2 4 * 3 /"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Dup - copies a value on the stack`` () =
     let expected = Some [1; 1]
     evaluate ["1 dup"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Dup - copies the top value on the stack`` () =
     let expected = Some [1; 2; 2]
     evaluate ["1 2 dup"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Dup - errors if there is nothing on the stack`` () =
     let expected = None
     evaluate ["dup"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Drop - removes the top value on the stack if it is the only one`` () =
     let expected: int list option = Some []
     evaluate ["1 drop"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Drop - removes the top value on the stack if it is not the only one`` () =
     let expected = Some [1]
     evaluate ["1 2 drop"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Drop - errors if there is nothing on the stack`` () =
     let expected = None
     evaluate ["drop"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Swap - swaps the top two values on the stack if they are the only ones`` () =
     let expected = Some [2; 1]
     evaluate ["1 2 swap"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Swap - swaps the top two values on the stack if they are not the only ones`` () =
     let expected = Some [1; 3; 2]
     evaluate ["1 2 3 swap"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Swap - errors if there is nothing on the stack`` () =
     let expected = None
     evaluate ["swap"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Swap - errors if there is only one value on the stack`` () =
     let expected = None
     evaluate ["1 swap"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Over - copies the second element if there are only two`` () =
     let expected = Some [1; 2; 1]
     evaluate ["1 2 over"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Over - copies the second element if there are more than two`` () =
     let expected = Some [1; 2; 3; 2]
     evaluate ["1 2 3 over"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Over - errors if there is nothing on the stack`` () =
     let expected = None
     evaluate ["over"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Over - errors if there is only one value on the stack`` () =
     let expected = None
     evaluate ["1 over"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``User-defined words - can consist of built-in words`` () =
     let expected = Some [1; 1; 1]
     evaluate [": dup-twice dup dup ;"; "1 dup-twice"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``User-defined words - execute in the right order`` () =
     let expected = Some [1; 2; 3]
     evaluate [": countup 1 2 3 ;"; "countup"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``User-defined words - can override other user-defined words`` () =
     let expected = Some [1; 1; 1]
     evaluate [": foo dup ;"; ": foo dup dup ;"; "1 foo"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``User-defined words - can override built-in words`` () =
     let expected = Some [1; 1]
     evaluate [": swap dup ;"; "1 swap"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``User-defined words - can override built-in operators`` () =
     let expected = Some [12]
     evaluate [": + * ;"; "3 4 +"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``User-defined words - can use different words with the same name`` () =
     let expected = Some [5; 6]
     evaluate [": foo 5 ;"; ": bar foo ;"; ": foo 6 ;"; "bar foo"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``User-defined words - can define word that uses word with the same name`` () =
     let expected = Some [11]
     evaluate [": foo 10 ;"; ": foo foo 1 + ;"; "foo"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``User-defined words - cannot redefine numbers`` () =
     let expected = None
     evaluate [": 1 2 ;"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``User-defined words - errors if executing a non-existent word`` () =
     let expected = None
     evaluate ["foo"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Case-insensitivity - DUP is case-insensitive`` () =
     let expected = Some [1; 1; 1; 1]
     evaluate ["1 DUP Dup dup"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Case-insensitivity - DROP is case-insensitive`` () =
     let expected = Some [1]
     evaluate ["1 2 3 4 DROP Drop drop"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Case-insensitivity - SWAP is case-insensitive`` () =
     let expected = Some [2; 3; 4; 1]
     evaluate ["1 2 SWAP 3 Swap 4 swap"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Case-insensitivity - OVER is case-insensitive`` () =
     let expected = Some [1; 2; 1; 2; 1]
     evaluate ["1 2 OVER Over over"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Case-insensitivity - user-defined words are case-insensitive`` () =
     let expected = Some [1; 1; 1; 1]
     evaluate [": foo dup ;"; "1 FOO Foo foo"] |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Case-insensitivity - definitions are case-insensitive`` () =
     let expected = Some [1; 1; 1; 1]
     evaluate [": SWAP DUP Dup dup ;"; "1 swap"] |> should equal expected

--- a/exercises/gigasecond/GigasecondTests.fs
+++ b/exercises/gigasecond/GigasecondTests.fs
@@ -12,19 +12,19 @@ open Gigasecond
 let ``Date only specification of time`` () =
     add (DateTime(2011, 4, 25)) |> should equal (DateTime(2043, 1, 1, 1, 46, 40))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second test for date only specification of time`` () =
     add (DateTime(1977, 6, 13)) |> should equal (DateTime(2009, 2, 19, 1, 46, 40))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third test for date only specification of time`` () =
     add (DateTime(1959, 7, 19)) |> should equal (DateTime(1991, 3, 27, 1, 46, 40))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Full time specified`` () =
     add (DateTime(2015, 1, 24, 22, 0, 0)) |> should equal (DateTime(2046, 10, 2, 23, 46, 40))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Full time with day roll-over`` () =
     add (DateTime(2015, 1, 24, 23, 59, 59)) |> should equal (DateTime(2046, 10, 3, 1, 46, 39))
 

--- a/exercises/go-counting/GoCountingTests.fs
+++ b/exercises/go-counting/GoCountingTests.fs
@@ -19,7 +19,7 @@ let ``Black corner territory on 5x5 board`` () =
     let expected = Option.Some (Owner.Black, [(0, 0); (0, 1); (1, 0)])
     territory board position |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``White center territory on 5x5 board`` () =
     let board = 
         [ "  B  ";
@@ -31,7 +31,7 @@ let ``White center territory on 5x5 board`` () =
     let expected = Option.Some (Owner.White, [(2, 3)])
     territory board position |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Open corner territory on 5x5 board`` () =
     let board = 
         [ "  B  ";
@@ -43,7 +43,7 @@ let ``Open corner territory on 5x5 board`` () =
     let expected = Option.Some (Owner.None, [(0, 3); (0, 4); (1, 4)])
     territory board position |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A stone and not a territory on 5x5 board`` () =
     let board = 
         [ "  B  ";
@@ -55,7 +55,7 @@ let ``A stone and not a territory on 5x5 board`` () =
     let expected: (Owner * (int * int) list) option = Option.Some (Owner.None, [])
     territory board position |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid because X is too low for 5x5 board`` () =
     let board = 
         [ "  B  ";
@@ -67,7 +67,7 @@ let ``Invalid because X is too low for 5x5 board`` () =
     let expected = Option.None
     territory board position |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid because X is too high for 5x5 board`` () =
     let board = 
         [ "  B  ";
@@ -79,7 +79,7 @@ let ``Invalid because X is too high for 5x5 board`` () =
     let expected = Option.None
     territory board position |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid because Y is too low for 5x5 board`` () =
     let board = 
         [ "  B  ";
@@ -91,7 +91,7 @@ let ``Invalid because Y is too low for 5x5 board`` () =
     let expected = Option.None
     territory board position |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid because Y is too high for 5x5 board`` () =
     let board = 
         [ "  B  ";
@@ -103,7 +103,7 @@ let ``Invalid because Y is too high for 5x5 board`` () =
     let expected = Option.None
     territory board position |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One territory is the whole board`` () =
     let board = [" "]
     let expected = 
@@ -113,7 +113,7 @@ let ``One territory is the whole board`` () =
         |> Map.ofList
     territories board |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two territory rectangular board`` () =
     let board = 
         [ " BW ";
@@ -125,7 +125,7 @@ let ``Two territory rectangular board`` () =
         |> Map.ofList
     territories board |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two region rectangular board`` () =
     let board = [" B "]
     let expected = 

--- a/exercises/grade-school/GradeSchoolTests.fs
+++ b/exercises/grade-school/GradeSchoolTests.fs
@@ -17,32 +17,32 @@ let ``Adding a student adds them to the sorted roster`` () =
     let school = studentsToSchool [("Aimee", 2)]
     roster school |> should equal ["Aimee"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Adding more student adds them to the sorted roster`` () =
     let school = studentsToSchool [("Blair", 2); ("James", 2); ("Paul", 2)]
     roster school |> should equal ["Blair"; "James"; "Paul"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Adding students to different grades adds them to the same sorted roster`` () =
     let school = studentsToSchool [("Chelsea", 3); ("Logan", 7)]
     roster school |> should equal ["Chelsea"; "Logan"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Roster returns an empty list if there are no students enrolled`` () =
     let school = studentsToSchool []
     roster school |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Student names with grades are displayed in the same sorted roster`` () =
     let school = studentsToSchool [("Peter", 2); ("Anna", 1); ("Barb", 1); ("Zoe", 2); ("Alex", 2); ("Jim", 3); ("Charlie", 1)]
     roster school |> should equal ["Anna"; "Barb"; "Charlie"; "Alex"; "Peter"; "Zoe"; "Jim"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Grade returns the students in that grade in alphabetical order`` () =
     let school = studentsToSchool [("Franklin", 5); ("Bradley", 5); ("Jeff", 1)]
     grade 5 school |> should equal ["Bradley"; "Franklin"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Grade returns an empty list if there are no students in that grade`` () =
     let school = studentsToSchool []
     grade 1 school |> should be Empty

--- a/exercises/grains/GrainsTests.fs
+++ b/exercises/grains/GrainsTests.fs
@@ -12,52 +12,52 @@ let ``1`` () =
     let expected: Result<uint64,string> = Ok 1UL
     square 1 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``2`` () =
     let expected: Result<uint64,string> = Ok 2UL
     square 2 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``3`` () =
     let expected: Result<uint64,string> = Ok 4UL
     square 3 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``4`` () =
     let expected: Result<uint64,string> = Ok 8UL
     square 4 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``16`` () =
     let expected: Result<uint64,string> = Ok 32768UL
     square 16 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``32`` () =
     let expected: Result<uint64,string> = Ok 2147483648UL
     square 32 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``64`` () =
     let expected: Result<uint64,string> = Ok 9223372036854775808UL
     square 64 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Square 0 raises an exception`` () =
     let expected: Result<uint64,string> = Error "square must be between 1 and 64"
     square 0 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Negative square raises an exception`` () =
     let expected: Result<uint64,string> = Error "square must be between 1 and 64"
     square -1 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Square greater than 64 raises an exception`` () =
     let expected: Result<uint64,string> = Error "square must be between 1 and 64"
     square 65 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Returns the total number of grains on the board`` () =
     let expected: Result<uint64,string> = Ok 18446744073709551615UL
     total |> should equal expected

--- a/exercises/grep/GrepTests.fs
+++ b/exercises/grep/GrepTests.fs
@@ -58,7 +58,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``One file, one match, print line numbers flag`` () =
         let files = ["paradise-lost.txt"]
         let flags = ["-n"]
@@ -68,7 +68,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``One file, one match, case-insensitive flag`` () =
         let files = ["paradise-lost.txt"]
         let flags = ["-i"]
@@ -78,7 +78,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``One file, one match, print file names flag`` () =
         let files = ["paradise-lost.txt"]
         let flags = ["-l"]
@@ -88,7 +88,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``One file, one match, match entire lines flag`` () =
         let files = ["paradise-lost.txt"]
         let flags = ["-x"]
@@ -98,7 +98,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``One file, one match, multiple flags`` () =
         let files = ["iliad.txt"]
         let flags = ["-n"; "-i"; "-x"]
@@ -108,7 +108,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``One file, several matches, no flags`` () =
         let files = ["midsummer-night.txt"]
         let flags = []
@@ -121,7 +121,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``One file, several matches, print line numbers flag`` () =
         let files = ["midsummer-night.txt"]
         let flags = ["-n"]
@@ -134,7 +134,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``One file, several matches, match entire lines flag`` () =
         let files = ["midsummer-night.txt"]
         let flags = ["-x"]
@@ -144,7 +144,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``One file, several matches, case-insensitive flag`` () =
         let files = ["iliad.txt"]
         let flags = ["-i"]
@@ -156,7 +156,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``One file, several matches, inverted flag`` () =
         let files = ["paradise-lost.txt"]
         let flags = ["-v"]
@@ -171,7 +171,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``One file, no matches, various flags`` () =
         let files = ["iliad.txt"]
         let flags = ["-n"; "-l"; "-x"; "-i"]
@@ -181,7 +181,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``One file, one match, file flag takes precedence over line flag`` () =
         let files = ["iliad.txt"]
         let flags = ["-n"; "-l"]
@@ -191,7 +191,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``One file, several matches, inverted and match entire lines flags`` () =
         let files = ["iliad.txt"]
         let flags = ["-x"; "-v"]
@@ -209,7 +209,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``Multiple files, one match, no flags`` () =
         let files = ["iliad.txt"; "midsummer-night.txt"; "paradise-lost.txt"]
         let flags = []
@@ -219,7 +219,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``Multiple files, several matches, no flags`` () =
         let files = ["iliad.txt"; "midsummer-night.txt"; "paradise-lost.txt"]
         let flags = []
@@ -232,7 +232,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``Multiple files, several matches, print line numbers flag`` () =
         let files = ["iliad.txt"; "midsummer-night.txt"; "paradise-lost.txt"]
         let flags = ["-n"]
@@ -246,7 +246,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``Multiple files, one match, print file names flag`` () =
         let files = ["iliad.txt"; "midsummer-night.txt"; "paradise-lost.txt"]
         let flags = ["-l"]
@@ -258,7 +258,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``Multiple files, several matches, case-insensitive flag`` () =
         let files = ["iliad.txt"; "midsummer-night.txt"; "paradise-lost.txt"]
         let flags = ["-i"]
@@ -278,7 +278,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``Multiple files, several matches, inverted flag`` () =
         let files = ["iliad.txt"; "midsummer-night.txt"; "paradise-lost.txt"]
         let flags = ["-v"]
@@ -291,7 +291,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``Multiple files, one match, match entire lines flag`` () =
         let files = ["iliad.txt"; "midsummer-night.txt"; "paradise-lost.txt"]
         let flags = ["-x"]
@@ -301,7 +301,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``Multiple files, one match, multiple flags`` () =
         let files = ["iliad.txt"; "midsummer-night.txt"; "paradise-lost.txt"]
         let flags = ["-n"; "-i"; "-x"]
@@ -311,7 +311,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``Multiple files, no matches, various flags`` () =
         let files = ["iliad.txt"; "midsummer-night.txt"; "paradise-lost.txt"]
         let flags = ["-n"; "-l"; "-x"; "-i"]
@@ -321,7 +321,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``Multiple files, several matches, file flag takes precedence over line number flag`` () =
         let files = ["iliad.txt"; "midsummer-night.txt"; "paradise-lost.txt"]
         let flags = ["-n"; "-l"]
@@ -333,7 +333,7 @@ type GrepTests() =
         createFiles() |> ignore
         grep files flags pattern |> should equal expected
 
-    [<Fact(Skip = "Remove to run test")>]
+    [<Fact(Skip = "Remove this Skip property to run this test")>]
     member this.``Multiple files, several matches, inverted and match entire lines flags`` () =
         let files = ["iliad.txt"; "midsummer-night.txt"; "paradise-lost.txt"]
         let flags = ["-x"; "-v"]

--- a/exercises/hamming/HammingTests.fs
+++ b/exercises/hamming/HammingTests.fs
@@ -11,35 +11,35 @@ open Hamming
 let ``Empty strands`` () =
     distance "" "" |> should equal (Some 0)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Single letter identical strands`` () =
     distance "A" "A" |> should equal (Some 0)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Single letter different strands`` () =
     distance "G" "T" |> should equal (Some 1)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Long identical strands`` () =
     distance "GGACTGAAATCTG" "GGACTGAAATCTG" |> should equal (Some 0)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Long different strands`` () =
     distance "GGACGGATTCTG" "AGGACGGATTCT" |> should equal (Some 9)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Disallow first strand longer`` () =
     distance "AATG" "AAA" |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Disallow second strand longer`` () =
     distance "ATA" "AGTG" |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Disallow left empty strand`` () =
     distance "" "G" |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Disallow right empty strand`` () =
     distance "G" "" |> should equal None
 

--- a/exercises/hangman/HangmanTests.fs
+++ b/exercises/hangman/HangmanTests.fs
@@ -19,7 +19,7 @@ let ``Initially 9 failures are allowed`` () =
 
     lastProgress |> should equal <| Busy 9
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Initially no letters are guessed`` () =
     let game = createGame "foo"
     let states = statesObservable game
@@ -31,7 +31,7 @@ let ``Initially no letters are guessed`` () =
 
     lastMaskedWord |> should equal "___"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``After 10 failures the game is over`` () =
     let game = createGame "foo"
     let states = statesObservable game
@@ -45,7 +45,7 @@ let ``After 10 failures the game is over`` () =
 
     lastProgress |> should equal Lose
     
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Feeding a correct letter removes underscores`` () =
     let game = createGame "foobar"
     let states = statesObservable game
@@ -65,7 +65,7 @@ let ``Feeding a correct letter removes underscores`` () =
     lastState.Value.progress |> should equal <| Busy 9
     lastState.Value.maskedWord |> should equal "_oob__"
     
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Feeding a correct letter twice counts as a failure`` () =
     let game = createGame "foobar"
     let states = statesObservable game
@@ -85,7 +85,7 @@ let ``Feeding a correct letter twice counts as a failure`` () =
     lastState.Value.progress |> should equal <| Busy 8
     lastState.Value.maskedWord |> should equal "___b__"
      
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Getting all the letters right makes for a win`` () =
     let game = createGame "hello"
     let states = statesObservable game

--- a/exercises/hexadecimal/HexadecimalTests.fs
+++ b/exercises/hexadecimal/HexadecimalTests.fs
@@ -11,39 +11,39 @@ open Hexadecimal
 let ``Hexadecimal 1 is decimal 1`` () =
     toDecimal "1" |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hexadecimal c is decimal 12`` () =
     toDecimal "c" |> should equal 12
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hexadecimal 10 is decimal 16`` () =
     toDecimal "10" |> should equal 16
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hexadecimal af is decimal 175`` () =
     toDecimal "af" |> should equal 175
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hexadecimal 100 is decimal 256`` () =
     toDecimal "100" |> should equal 256
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hexadecimal 19ace is decimal 105166`` () =
     toDecimal "19ace" |> should equal 105166
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hexadecimal 000000 is decimal 0`` () =
     toDecimal "000000" |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hexadecimal ffffff is decimal 16777215`` () =
     toDecimal "ffffff" |> should equal 16777215
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hexadecimal ffff00 is decimal 16776960`` () =
     toDecimal "ffff00" |> should equal 16776960
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hexadecimal carrot is decimal 0`` () =
     toDecimal "carrot" |> should equal 0
 

--- a/exercises/high-scores/HighScoresTests.fs
+++ b/exercises/high-scores/HighScoresTests.fs
@@ -11,31 +11,31 @@ open HighScores
 let ``List of scores`` () =
     scores [30; 50; 20; 70] |> should equal [30; 50; 20; 70]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Latest score`` () =
     latest [100; 0; 90; 30] |> should equal 30
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Personal best`` () =
     personalBest [40; 100; 70] |> should equal 100
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Personal top three from a list of scores`` () =
     personalTopThree [10; 30; 90; 30; 100; 20; 10; 0; 30; 40; 40; 70; 70] |> should equal [100; 90; 70]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Personal top highest to lowest`` () =
     personalTopThree [20; 10; 30] |> should equal [30; 20; 10]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Personal top when there is a tie`` () =
     personalTopThree [40; 20; 40; 30] |> should equal [40; 40; 30]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Personal top when there are less than 3`` () =
     personalTopThree [30; 70] |> should equal [70; 30]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Personal top when there is only one`` () =
     personalTopThree [40] |> should equal [40]
 

--- a/exercises/house/HouseTests.fs
+++ b/exercises/house/HouseTests.fs
@@ -12,62 +12,62 @@ let ``Verse one - the house that jack built`` () =
     let expected = ["This is the house that Jack built."]
     recite 1 1 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Verse two - the malt that lay`` () =
     let expected = ["This is the malt that lay in the house that Jack built."]
     recite 2 2 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Verse three - the rat that ate`` () =
     let expected = ["This is the rat that ate the malt that lay in the house that Jack built."]
     recite 3 3 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Verse four - the cat that killed`` () =
     let expected = ["This is the cat that killed the rat that ate the malt that lay in the house that Jack built."]
     recite 4 4 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Verse five - the dog that worried`` () =
     let expected = ["This is the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."]
     recite 5 5 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Verse six - the cow with the crumpled horn`` () =
     let expected = ["This is the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."]
     recite 6 6 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Verse seven - the maiden all forlorn`` () =
     let expected = ["This is the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."]
     recite 7 7 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Verse eight - the man all tattered and torn`` () =
     let expected = ["This is the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."]
     recite 8 8 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Verse nine - the priest all shaven and shorn`` () =
     let expected = ["This is the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."]
     recite 9 9 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Verse 10 - the rooster that crowed in the morn`` () =
     let expected = ["This is the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."]
     recite 10 10 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Verse 11 - the farmer sowing his corn`` () =
     let expected = ["This is the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."]
     recite 11 11 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Verse 12 - the horse and the hound and the horn`` () =
     let expected = ["This is the horse and the hound and the horn that belonged to the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."]
     recite 12 12 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple verses`` () =
     let expected = 
         [ "This is the cat that killed the rat that ate the malt that lay in the house that Jack built.";
@@ -77,7 +77,7 @@ let ``Multiple verses`` () =
           "This is the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built." ]
     recite 4 8 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Full rhyme`` () =
     let expected = 
         [ "This is the house that Jack built.";

--- a/exercises/isbn-verifier/IsbnVerifierTests.fs
+++ b/exercises/isbn-verifier/IsbnVerifierTests.fs
@@ -11,67 +11,67 @@ open IsbnVerifier
 let ``Valid isbn number`` () =
     isValid "3-598-21508-8" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid isbn check digit`` () =
     isValid "3-598-21508-9" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Valid isbn number with a check digit of 10`` () =
     isValid "3-598-21507-X" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Check digit is a character other than X`` () =
     isValid "3-598-21507-A" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid character in isbn`` () =
     isValid "3-598-P1581-X" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``X is only valid as a check digit`` () =
     isValid "3-598-2X507-9" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Valid isbn without separating dashes`` () =
     isValid "3598215088" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Isbn without separating dashes and X as check digit`` () =
     isValid "359821507X" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Isbn without check digit and dashes`` () =
     isValid "359821507" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Too long isbn and no dashes`` () =
     isValid "3598215078X" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Too short isbn`` () =
     isValid "00" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Isbn without check digit`` () =
     isValid "3-598-21507" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Check digit of X should not be used for 0`` () =
     isValid "3-598-21515-X" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Empty isbn`` () =
     isValid "" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Input is 9 characters`` () =
     isValid "134456729" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid characters are not ignored`` () =
     isValid "3132P34035" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Input is too long but contains a valid isbn`` () =
     isValid "98245726788" |> should equal false
 

--- a/exercises/isogram/IsogramTests.fs
+++ b/exercises/isogram/IsogramTests.fs
@@ -11,51 +11,51 @@ open Isogram
 let ``Empty string`` () =
     isIsogram "" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Isogram with only lower case characters`` () =
     isIsogram "isogram" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word with one duplicated character`` () =
     isIsogram "eleven" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word with one duplicated character from the end of the alphabet`` () =
     isIsogram "zzyzx" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Longest reported english isogram`` () =
     isIsogram "subdermatoglyphic" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word with duplicated character in mixed case`` () =
     isIsogram "Alphabet" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word with duplicated character in mixed case, lowercase first`` () =
     isIsogram "alphAbet" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hypothetical isogrammic word with hyphen`` () =
     isIsogram "thumbscrew-japingly" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hypothetical word with duplicated character following hyphen`` () =
     isIsogram "thumbscrew-jappingly" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Isogram with duplicated hyphen`` () =
     isIsogram "six-year-old" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Made-up name that is an isogram`` () =
     isIsogram "Emily Jung Schwartzkopf" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Duplicated character in the middle`` () =
     isIsogram "accentor" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Same first and last characters`` () =
     isIsogram "angola" |> should equal false
 

--- a/exercises/kindergarten-garden/KindergartenGardenTests.fs
+++ b/exercises/kindergarten-garden/KindergartenGardenTests.fs
@@ -14,56 +14,56 @@ let ``Partial garden - garden with single student`` () =
     let expected = [Plant.Radishes; Plant.Clover; Plant.Grass; Plant.Grass]
     plants diagram student |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Partial garden - different garden with single student`` () =
     let student = "Alice"
     let diagram = "VC\nRC"
     let expected = [Plant.Violets; Plant.Clover; Plant.Radishes; Plant.Clover]
     plants diagram student |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Partial garden - garden with two students`` () =
     let student = "Bob"
     let diagram = "VVCG\nVVRC"
     let expected = [Plant.Clover; Plant.Grass; Plant.Radishes; Plant.Clover]
     plants diagram student |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Partial garden - multiple students for the same garden with three students - second student's garden`` () =
     let student = "Bob"
     let diagram = "VVCCGG\nVVCCGG"
     let expected = [Plant.Clover; Plant.Clover; Plant.Clover; Plant.Clover]
     plants diagram student |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Partial garden - multiple students for the same garden with three students - third student's garden`` () =
     let student = "Charlie"
     let diagram = "VVCCGG\nVVCCGG"
     let expected = [Plant.Grass; Plant.Grass; Plant.Grass; Plant.Grass]
     plants diagram student |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Full garden - first student's garden`` () =
     let student = "Alice"
     let diagram = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"
     let expected = [Plant.Violets; Plant.Radishes; Plant.Violets; Plant.Radishes]
     plants diagram student |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Full garden - second student's garden`` () =
     let student = "Bob"
     let diagram = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"
     let expected = [Plant.Clover; Plant.Grass; Plant.Clover; Plant.Clover]
     plants diagram student |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Full garden - second to last student's garden`` () =
     let student = "Kincaid"
     let diagram = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"
     let expected = [Plant.Grass; Plant.Clover; Plant.Clover; Plant.Grass]
     plants diagram student |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Full garden - last student's garden`` () =
     let student = "Larry"
     let diagram = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"

--- a/exercises/largest-series-product/LargestSeriesProductTests.fs
+++ b/exercises/largest-series-product/LargestSeriesProductTests.fs
@@ -13,85 +13,85 @@ let ``Finds the largest product if span equals length`` () =
     let span = 2
     largestProduct digits span |> should equal (Some 18)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can find the largest product of 2 with numbers in order`` () =
     let digits = "0123456789"
     let span = 2
     largestProduct digits span |> should equal (Some 72)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can find the largest product of 2`` () =
     let digits = "576802143"
     let span = 2
     largestProduct digits span |> should equal (Some 48)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can find the largest product of 3 with numbers in order`` () =
     let digits = "0123456789"
     let span = 3
     largestProduct digits span |> should equal (Some 504)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can find the largest product of 3`` () =
     let digits = "1027839564"
     let span = 3
     largestProduct digits span |> should equal (Some 270)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can find the largest product of 5 with numbers in order`` () =
     let digits = "0123456789"
     let span = 5
     largestProduct digits span |> should equal (Some 15120)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can get the largest product of a big number`` () =
     let digits = "73167176531330624919225119674426574742355349194934"
     let span = 6
     largestProduct digits span |> should equal (Some 23520)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reports zero if the only digits are zero`` () =
     let digits = "0000"
     let span = 2
     largestProduct digits span |> should equal (Some 0)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reports zero if all spans include zero`` () =
     let digits = "99099"
     let span = 3
     largestProduct digits span |> should equal (Some 0)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rejects span longer than string length`` () =
     let digits = "123"
     let span = 4
     largestProduct digits span |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reports 1 for empty string and empty product (0 span)`` () =
     let digits = ""
     let span = 0
     largestProduct digits span |> should equal (Some 1)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reports 1 for nonempty string and empty product (0 span)`` () =
     let digits = "123"
     let span = 0
     largestProduct digits span |> should equal (Some 1)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rejects empty string and nonzero span`` () =
     let digits = ""
     let span = 1
     largestProduct digits span |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rejects invalid character in digits`` () =
     let digits = "1234a5"
     let span = 2
     largestProduct digits span |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rejects negative span`` () =
     let digits = "12345"
     let span = -1

--- a/exercises/leap/LeapTests.fs
+++ b/exercises/leap/LeapTests.fs
@@ -11,35 +11,35 @@ open Leap
 let ``Year not divisible by 4 in common year`` () =
     leapYear 2015 |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Year divisible by 2, not divisible by 4 in common year`` () =
     leapYear 1970 |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Year divisible by 4, not divisible by 100 in leap year`` () =
     leapYear 1996 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Year divisible by 4 and 5 is still a leap year`` () =
     leapYear 1960 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Year divisible by 100, not divisible by 400 in common year`` () =
     leapYear 2100 |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Year divisible by 100 but not by 3 is still not a leap year`` () =
     leapYear 1900 |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Year divisible by 400 in leap year`` () =
     leapYear 2000 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Year divisible by 400 but not by 125 is still a leap year`` () =
     leapYear 2400 |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Year divisible by 200, not divisible by 400 in common year`` () =
     leapYear 1800 |> should equal false
 

--- a/exercises/lens-person/LensPersonTests.fs
+++ b/exercises/lens-person/LensPersonTests.fs
@@ -30,14 +30,14 @@ let testPerson =
 let ``Set born at street`` () =
     Optic.get bornAtStreet testPerson |> should equal "Longway"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Set current street`` () =
     Optic.set currentStreet "Middleroad" testPerson |> Optic.get currentStreet |> should equal "Middleroad"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Upper case born at street`` () =
     Optic.map bornAtStreet (fun x -> x.ToUpper()) testPerson |> Optic.get bornAtStreet |> should equal "LONGWAY"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Set birth month`` () =
     Optic.set birthMonth 9 testPerson |> Optic.get bornOn |> should equal <| DateTime(1984, 9, 12)

--- a/exercises/linked-list/LinkedListTests.fs
+++ b/exercises/linked-list/LinkedListTests.fs
@@ -18,7 +18,7 @@ let ``Push and pop are first in last out order`` () =
     val1 |> should equal 20
     val2 |> should equal 10
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Push and shift are first in first out order`` () =
     let linkedList = mkLinkedList ()
     linkedList |> push 10
@@ -30,7 +30,7 @@ let ``Push and shift are first in first out order`` () =
     val1 |> should equal 10
     val2 |> should equal 20
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Unshift and shift are last in first out order`` () =
     let linkedList = mkLinkedList ()
     linkedList |> unshift 10
@@ -42,7 +42,7 @@ let ``Unshift and shift are last in first out order`` () =
     val1 |> should equal 20
     val2 |> should equal 10
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Unshift and pop are last in last out order`` () =
     let linkedList = mkLinkedList ()
     linkedList |> unshift 10
@@ -54,7 +54,7 @@ let ``Unshift and pop are last in last out order`` () =
     val1 |> should equal 10
     val2 |> should equal 20
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Push and pop can handle multiple values`` () =
     let linkedList = mkLinkedList ()
     linkedList |> push 10
@@ -69,7 +69,7 @@ let ``Push and pop can handle multiple values`` () =
     val2 |> should equal 20
     val3 |> should equal 10
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Unshift and shift can handle multiple values`` () =
     let linkedList = mkLinkedList ()
     linkedList |> unshift 10
@@ -84,7 +84,7 @@ let ``Unshift and shift can handle multiple values`` () =
     val2 |> should equal 20
     val3 |> should equal 10
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``All methods of manipulating the linkedList can be used together`` () =
     let linkedList = mkLinkedList ()
     linkedList |> push 10

--- a/exercises/list-ops/ListOpsTests.fs
+++ b/exercises/list-ops/ListOpsTests.fs
@@ -11,83 +11,83 @@ open ListOps
 let ``append empty lists`` () =
     append [] [] |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``append list to empty list`` () =
     append [] [1; 2; 3; 4] |> should equal [1; 2; 3; 4]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``append non-empty lists`` () =
     append [1; 2] [2; 3; 4; 5] |> should equal [1; 2; 2; 3; 4; 5]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``concat empty list`` () =
     concat [] |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``concat list of lists`` () =
     concat [[1; 2]; [3]; []; [4; 5; 6]] |> should equal [1; 2; 3; 4; 5; 6]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``concat list of nested lists`` () =
     concat [[[1]; [2]]; [[3]]; [[]]; [[4; 5; 6]]] |> should equal [[1]; [2]; [3]; []; [4; 5; 6]]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``filter empty list`` () =
     filter (fun x -> x % 2 = 1) [] |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``filter non-empty list`` () =
     filter (fun x -> x % 2 = 1) [1; 2; 3; 5] |> should equal [1; 3; 5]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``length empty list`` () =
     length [] |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``length non-empty list`` () =
     length [1; 2; 3; 4] |> should equal 4
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``map empty list`` () =
     map (fun x -> x + 1) [] |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``map non-empty list`` () =
     map (fun x -> x + 1) [1; 3; 5; 7] |> should equal [2; 4; 6; 8]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``foldl empty list`` () =
     foldl (fun x y -> x * y) 2 [] |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``foldl direction independent function applied to non-empty list`` () =
     foldl (fun x y -> x + y) 5 [1; 2; 3; 4] |> should equal 15
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``foldl direction dependent function applied to non-empty list`` () =
     foldl (fun x y -> x / y) 5 [2; 5] |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``foldr empty list`` () =
     foldr (fun x y -> x * y) 2 [] |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``foldr direction independent function applied to non-empty list`` () =
     foldr (fun x y -> x + y) 5 [1; 2; 3; 4] |> should equal 15
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``foldr direction dependent function applied to non-empty list`` () =
     foldr (fun x y -> x / y) 5 [2; 5] |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``reverse empty list`` () =
     reverse [] |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``reverse non-empty list`` () =
     reverse [1; 3; 5; 7] |> should equal [7; 5; 3; 1]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``reverse list of lists is not flattened`` () =
     reverse [[1; 2]; [3]; []; [4; 5; 6]] |> should equal [[4; 5; 6]; []; [3]; [1; 2]]
 

--- a/exercises/luhn/LuhnTests.fs
+++ b/exercises/luhn/LuhnTests.fs
@@ -11,71 +11,71 @@ open Luhn
 let ``Single digit strings can not be valid`` () =
     valid "1" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A single zero is invalid`` () =
     valid "0" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A simple valid SIN that remains valid if reversed`` () =
     valid "059" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A simple valid SIN that becomes invalid if reversed`` () =
     valid "59" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A valid Canadian SIN`` () =
     valid "055 444 285" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid Canadian SIN`` () =
     valid "055 444 286" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid credit card`` () =
     valid "8273 1232 7352 0569" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid long number with an even remainder`` () =
     valid "1 2345 6789 1234 5678 9012" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Valid number with an even number of digits`` () =
     valid "095 245 88" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Valid number with an odd number of spaces`` () =
     valid "234 567 891 234" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Valid strings with a non-digit added at the end become invalid`` () =
     valid "059a" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Valid strings with punctuation included become invalid`` () =
     valid "055-444-285" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Valid strings with symbols included become invalid`` () =
     valid "055# 444$ 285" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Single zero with space is invalid`` () =
     valid " 0" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``More than a single zero is valid`` () =
     valid "0000 0" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Input digit 9 is correctly converted to output digit 9`` () =
     valid "091" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Using ascii value for non-doubled non-digit isn't allowed`` () =
     valid "055b 444 285" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Using ascii value for doubled non-digit isn't allowed`` () =
     valid ":9" |> should equal false
 

--- a/exercises/matching-brackets/MatchingBracketsTests.fs
+++ b/exercises/matching-brackets/MatchingBracketsTests.fs
@@ -11,67 +11,67 @@ open MatchingBrackets
 let ``Paired square brackets`` () =
     isPaired "[]" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Empty string`` () =
     isPaired "" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Unpaired brackets`` () =
     isPaired "[[" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Wrong ordered brackets`` () =
     isPaired "}{" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Wrong closing bracket`` () =
     isPaired "{]" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Paired with whitespace`` () =
     isPaired "{ }" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Partially paired brackets`` () =
     isPaired "{[])" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Simple nested brackets`` () =
     isPaired "{[]}" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Several paired brackets`` () =
     isPaired "{}[]" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Paired and nested brackets`` () =
     isPaired "([{}({}[])])" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Unopened closing brackets`` () =
     isPaired "{[)][]}" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Unpaired and nested brackets`` () =
     isPaired "([{])" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Paired and wrong nested brackets`` () =
     isPaired "[({]})" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Paired and incomplete brackets`` () =
     isPaired "{}[" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Too many closing brackets`` () =
     isPaired "[]]" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Math expression`` () =
     isPaired "(((185 + 223.85) * 15) - 543)/2" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Complex latex expression`` () =
     isPaired "\left(\begin{array}{cc} \frac{1}{3} & x\\ \mathrm{e}^{x} &... x^2 \end{array}\right)" |> should equal true
 

--- a/exercises/matrix/MatrixTests.fs
+++ b/exercises/matrix/MatrixTests.fs
@@ -11,31 +11,31 @@ open Matrix
 let ``Extract row from one number matrix`` () =
     row 1 "1" |> should equal [1]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can extract row`` () =
     row 2 "1 2\n3 4" |> should equal [3; 4]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Extract row where numbers have different widths`` () =
     row 2 "1 2\n10 20" |> should equal [10; 20]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can extract row from non-square matrix with no corresponding column`` () =
     row 4 "1 2 3\n4 5 6\n7 8 9\n8 7 6" |> should equal [8; 7; 6]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Extract column from one number matrix`` () =
     column 1 "1" |> should equal [1]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can extract column`` () =
     column 3 "1 2 3\n4 5 6\n7 8 9" |> should equal [3; 6; 9]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can extract column from non-square matrix with no corresponding row`` () =
     column 4 "1 2 3 4\n5 6 7 8\n9 8 7 6" |> should equal [4; 8; 6]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Extract column where numbers have different widths`` () =
     column 2 "89 1903 3\n18 3 1\n9 4 800" |> should equal [1903; 3; 4]
 

--- a/exercises/meetup/MeetupTests.fs
+++ b/exercises/meetup/MeetupTests.fs
@@ -12,379 +12,379 @@ open Meetup
 let ``Monteenth of May 2013`` () =
     meetup 2013 5 Week.Teenth DayOfWeek.Monday |> should equal (DateTime(2013, 5, 13))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Monteenth of August 2013`` () =
     meetup 2013 8 Week.Teenth DayOfWeek.Monday |> should equal (DateTime(2013, 8, 19))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Monteenth of September 2013`` () =
     meetup 2013 9 Week.Teenth DayOfWeek.Monday |> should equal (DateTime(2013, 9, 16))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Tuesteenth of March 2013`` () =
     meetup 2013 3 Week.Teenth DayOfWeek.Tuesday |> should equal (DateTime(2013, 3, 19))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Tuesteenth of April 2013`` () =
     meetup 2013 4 Week.Teenth DayOfWeek.Tuesday |> should equal (DateTime(2013, 4, 16))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Tuesteenth of August 2013`` () =
     meetup 2013 8 Week.Teenth DayOfWeek.Tuesday |> should equal (DateTime(2013, 8, 13))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Wednesteenth of January 2013`` () =
     meetup 2013 1 Week.Teenth DayOfWeek.Wednesday |> should equal (DateTime(2013, 1, 16))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Wednesteenth of February 2013`` () =
     meetup 2013 2 Week.Teenth DayOfWeek.Wednesday |> should equal (DateTime(2013, 2, 13))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Wednesteenth of June 2013`` () =
     meetup 2013 6 Week.Teenth DayOfWeek.Wednesday |> should equal (DateTime(2013, 6, 19))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Thursteenth of May 2013`` () =
     meetup 2013 5 Week.Teenth DayOfWeek.Thursday |> should equal (DateTime(2013, 5, 16))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Thursteenth of June 2013`` () =
     meetup 2013 6 Week.Teenth DayOfWeek.Thursday |> should equal (DateTime(2013, 6, 13))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Thursteenth of September 2013`` () =
     meetup 2013 9 Week.Teenth DayOfWeek.Thursday |> should equal (DateTime(2013, 9, 19))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Friteenth of April 2013`` () =
     meetup 2013 4 Week.Teenth DayOfWeek.Friday |> should equal (DateTime(2013, 4, 19))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Friteenth of August 2013`` () =
     meetup 2013 8 Week.Teenth DayOfWeek.Friday |> should equal (DateTime(2013, 8, 16))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Friteenth of September 2013`` () =
     meetup 2013 9 Week.Teenth DayOfWeek.Friday |> should equal (DateTime(2013, 9, 13))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Saturteenth of February 2013`` () =
     meetup 2013 2 Week.Teenth DayOfWeek.Saturday |> should equal (DateTime(2013, 2, 16))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Saturteenth of April 2013`` () =
     meetup 2013 4 Week.Teenth DayOfWeek.Saturday |> should equal (DateTime(2013, 4, 13))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Saturteenth of October 2013`` () =
     meetup 2013 10 Week.Teenth DayOfWeek.Saturday |> should equal (DateTime(2013, 10, 19))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sunteenth of May 2013`` () =
     meetup 2013 5 Week.Teenth DayOfWeek.Sunday |> should equal (DateTime(2013, 5, 19))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sunteenth of June 2013`` () =
     meetup 2013 6 Week.Teenth DayOfWeek.Sunday |> should equal (DateTime(2013, 6, 16))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sunteenth of October 2013`` () =
     meetup 2013 10 Week.Teenth DayOfWeek.Sunday |> should equal (DateTime(2013, 10, 13))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First Monday of March 2013`` () =
     meetup 2013 3 Week.First DayOfWeek.Monday |> should equal (DateTime(2013, 3, 4))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First Monday of April 2013`` () =
     meetup 2013 4 Week.First DayOfWeek.Monday |> should equal (DateTime(2013, 4, 1))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First Tuesday of May 2013`` () =
     meetup 2013 5 Week.First DayOfWeek.Tuesday |> should equal (DateTime(2013, 5, 7))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First Tuesday of June 2013`` () =
     meetup 2013 6 Week.First DayOfWeek.Tuesday |> should equal (DateTime(2013, 6, 4))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First Wednesday of July 2013`` () =
     meetup 2013 7 Week.First DayOfWeek.Wednesday |> should equal (DateTime(2013, 7, 3))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First Wednesday of August 2013`` () =
     meetup 2013 8 Week.First DayOfWeek.Wednesday |> should equal (DateTime(2013, 8, 7))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First Thursday of September 2013`` () =
     meetup 2013 9 Week.First DayOfWeek.Thursday |> should equal (DateTime(2013, 9, 5))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First Thursday of October 2013`` () =
     meetup 2013 10 Week.First DayOfWeek.Thursday |> should equal (DateTime(2013, 10, 3))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First Friday of November 2013`` () =
     meetup 2013 11 Week.First DayOfWeek.Friday |> should equal (DateTime(2013, 11, 1))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First Friday of December 2013`` () =
     meetup 2013 12 Week.First DayOfWeek.Friday |> should equal (DateTime(2013, 12, 6))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First Saturday of January 2013`` () =
     meetup 2013 1 Week.First DayOfWeek.Saturday |> should equal (DateTime(2013, 1, 5))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First Saturday of February 2013`` () =
     meetup 2013 2 Week.First DayOfWeek.Saturday |> should equal (DateTime(2013, 2, 2))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First Sunday of March 2013`` () =
     meetup 2013 3 Week.First DayOfWeek.Sunday |> should equal (DateTime(2013, 3, 3))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First Sunday of April 2013`` () =
     meetup 2013 4 Week.First DayOfWeek.Sunday |> should equal (DateTime(2013, 4, 7))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second Monday of March 2013`` () =
     meetup 2013 3 Week.Second DayOfWeek.Monday |> should equal (DateTime(2013, 3, 11))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second Monday of April 2013`` () =
     meetup 2013 4 Week.Second DayOfWeek.Monday |> should equal (DateTime(2013, 4, 8))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second Tuesday of May 2013`` () =
     meetup 2013 5 Week.Second DayOfWeek.Tuesday |> should equal (DateTime(2013, 5, 14))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second Tuesday of June 2013`` () =
     meetup 2013 6 Week.Second DayOfWeek.Tuesday |> should equal (DateTime(2013, 6, 11))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second Wednesday of July 2013`` () =
     meetup 2013 7 Week.Second DayOfWeek.Wednesday |> should equal (DateTime(2013, 7, 10))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second Wednesday of August 2013`` () =
     meetup 2013 8 Week.Second DayOfWeek.Wednesday |> should equal (DateTime(2013, 8, 14))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second Thursday of September 2013`` () =
     meetup 2013 9 Week.Second DayOfWeek.Thursday |> should equal (DateTime(2013, 9, 12))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second Thursday of October 2013`` () =
     meetup 2013 10 Week.Second DayOfWeek.Thursday |> should equal (DateTime(2013, 10, 10))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second Friday of November 2013`` () =
     meetup 2013 11 Week.Second DayOfWeek.Friday |> should equal (DateTime(2013, 11, 8))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second Friday of December 2013`` () =
     meetup 2013 12 Week.Second DayOfWeek.Friday |> should equal (DateTime(2013, 12, 13))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second Saturday of January 2013`` () =
     meetup 2013 1 Week.Second DayOfWeek.Saturday |> should equal (DateTime(2013, 1, 12))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second Saturday of February 2013`` () =
     meetup 2013 2 Week.Second DayOfWeek.Saturday |> should equal (DateTime(2013, 2, 9))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second Sunday of March 2013`` () =
     meetup 2013 3 Week.Second DayOfWeek.Sunday |> should equal (DateTime(2013, 3, 10))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second Sunday of April 2013`` () =
     meetup 2013 4 Week.Second DayOfWeek.Sunday |> should equal (DateTime(2013, 4, 14))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third Monday of March 2013`` () =
     meetup 2013 3 Week.Third DayOfWeek.Monday |> should equal (DateTime(2013, 3, 18))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third Monday of April 2013`` () =
     meetup 2013 4 Week.Third DayOfWeek.Monday |> should equal (DateTime(2013, 4, 15))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third Tuesday of May 2013`` () =
     meetup 2013 5 Week.Third DayOfWeek.Tuesday |> should equal (DateTime(2013, 5, 21))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third Tuesday of June 2013`` () =
     meetup 2013 6 Week.Third DayOfWeek.Tuesday |> should equal (DateTime(2013, 6, 18))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third Wednesday of July 2013`` () =
     meetup 2013 7 Week.Third DayOfWeek.Wednesday |> should equal (DateTime(2013, 7, 17))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third Wednesday of August 2013`` () =
     meetup 2013 8 Week.Third DayOfWeek.Wednesday |> should equal (DateTime(2013, 8, 21))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third Thursday of September 2013`` () =
     meetup 2013 9 Week.Third DayOfWeek.Thursday |> should equal (DateTime(2013, 9, 19))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third Thursday of October 2013`` () =
     meetup 2013 10 Week.Third DayOfWeek.Thursday |> should equal (DateTime(2013, 10, 17))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third Friday of November 2013`` () =
     meetup 2013 11 Week.Third DayOfWeek.Friday |> should equal (DateTime(2013, 11, 15))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third Friday of December 2013`` () =
     meetup 2013 12 Week.Third DayOfWeek.Friday |> should equal (DateTime(2013, 12, 20))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third Saturday of January 2013`` () =
     meetup 2013 1 Week.Third DayOfWeek.Saturday |> should equal (DateTime(2013, 1, 19))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third Saturday of February 2013`` () =
     meetup 2013 2 Week.Third DayOfWeek.Saturday |> should equal (DateTime(2013, 2, 16))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third Sunday of March 2013`` () =
     meetup 2013 3 Week.Third DayOfWeek.Sunday |> should equal (DateTime(2013, 3, 17))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third Sunday of April 2013`` () =
     meetup 2013 4 Week.Third DayOfWeek.Sunday |> should equal (DateTime(2013, 4, 21))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourth Monday of March 2013`` () =
     meetup 2013 3 Week.Fourth DayOfWeek.Monday |> should equal (DateTime(2013, 3, 25))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourth Monday of April 2013`` () =
     meetup 2013 4 Week.Fourth DayOfWeek.Monday |> should equal (DateTime(2013, 4, 22))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourth Tuesday of May 2013`` () =
     meetup 2013 5 Week.Fourth DayOfWeek.Tuesday |> should equal (DateTime(2013, 5, 28))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourth Tuesday of June 2013`` () =
     meetup 2013 6 Week.Fourth DayOfWeek.Tuesday |> should equal (DateTime(2013, 6, 25))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourth Wednesday of July 2013`` () =
     meetup 2013 7 Week.Fourth DayOfWeek.Wednesday |> should equal (DateTime(2013, 7, 24))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourth Wednesday of August 2013`` () =
     meetup 2013 8 Week.Fourth DayOfWeek.Wednesday |> should equal (DateTime(2013, 8, 28))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourth Thursday of September 2013`` () =
     meetup 2013 9 Week.Fourth DayOfWeek.Thursday |> should equal (DateTime(2013, 9, 26))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourth Thursday of October 2013`` () =
     meetup 2013 10 Week.Fourth DayOfWeek.Thursday |> should equal (DateTime(2013, 10, 24))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourth Friday of November 2013`` () =
     meetup 2013 11 Week.Fourth DayOfWeek.Friday |> should equal (DateTime(2013, 11, 22))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourth Friday of December 2013`` () =
     meetup 2013 12 Week.Fourth DayOfWeek.Friday |> should equal (DateTime(2013, 12, 27))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourth Saturday of January 2013`` () =
     meetup 2013 1 Week.Fourth DayOfWeek.Saturday |> should equal (DateTime(2013, 1, 26))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourth Saturday of February 2013`` () =
     meetup 2013 2 Week.Fourth DayOfWeek.Saturday |> should equal (DateTime(2013, 2, 23))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourth Sunday of March 2013`` () =
     meetup 2013 3 Week.Fourth DayOfWeek.Sunday |> should equal (DateTime(2013, 3, 24))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourth Sunday of April 2013`` () =
     meetup 2013 4 Week.Fourth DayOfWeek.Sunday |> should equal (DateTime(2013, 4, 28))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Monday of March 2013`` () =
     meetup 2013 3 Week.Last DayOfWeek.Monday |> should equal (DateTime(2013, 3, 25))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Monday of April 2013`` () =
     meetup 2013 4 Week.Last DayOfWeek.Monday |> should equal (DateTime(2013, 4, 29))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Tuesday of May 2013`` () =
     meetup 2013 5 Week.Last DayOfWeek.Tuesday |> should equal (DateTime(2013, 5, 28))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Tuesday of June 2013`` () =
     meetup 2013 6 Week.Last DayOfWeek.Tuesday |> should equal (DateTime(2013, 6, 25))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Wednesday of July 2013`` () =
     meetup 2013 7 Week.Last DayOfWeek.Wednesday |> should equal (DateTime(2013, 7, 31))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Wednesday of August 2013`` () =
     meetup 2013 8 Week.Last DayOfWeek.Wednesday |> should equal (DateTime(2013, 8, 28))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Thursday of September 2013`` () =
     meetup 2013 9 Week.Last DayOfWeek.Thursday |> should equal (DateTime(2013, 9, 26))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Thursday of October 2013`` () =
     meetup 2013 10 Week.Last DayOfWeek.Thursday |> should equal (DateTime(2013, 10, 31))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Friday of November 2013`` () =
     meetup 2013 11 Week.Last DayOfWeek.Friday |> should equal (DateTime(2013, 11, 29))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Friday of December 2013`` () =
     meetup 2013 12 Week.Last DayOfWeek.Friday |> should equal (DateTime(2013, 12, 27))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Saturday of January 2013`` () =
     meetup 2013 1 Week.Last DayOfWeek.Saturday |> should equal (DateTime(2013, 1, 26))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Saturday of February 2013`` () =
     meetup 2013 2 Week.Last DayOfWeek.Saturday |> should equal (DateTime(2013, 2, 23))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Sunday of March 2013`` () =
     meetup 2013 3 Week.Last DayOfWeek.Sunday |> should equal (DateTime(2013, 3, 31))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Sunday of April 2013`` () =
     meetup 2013 4 Week.Last DayOfWeek.Sunday |> should equal (DateTime(2013, 4, 28))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Wednesday of February 2012`` () =
     meetup 2012 2 Week.Last DayOfWeek.Wednesday |> should equal (DateTime(2012, 2, 29))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Wednesday of December 2014`` () =
     meetup 2014 12 Week.Last DayOfWeek.Wednesday |> should equal (DateTime(2014, 12, 31))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Last Sunday of February 2015`` () =
     meetup 2015 2 Week.Last DayOfWeek.Sunday |> should equal (DateTime(2015, 2, 22))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First Friday of December 2012`` () =
     meetup 2012 12 Week.First DayOfWeek.Friday |> should equal (DateTime(2012, 12, 7))
 

--- a/exercises/minesweeper/MinesweeperTests.fs
+++ b/exercises/minesweeper/MinesweeperTests.fs
@@ -13,13 +13,13 @@ let ``No rows`` () =
     let expected: string list = []
     annotate minefield |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``No columns`` () =
     let minefield = [""]
     let expected = [""]
     annotate minefield |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``No mines`` () =
     let minefield = 
         [ "   ";
@@ -31,7 +31,7 @@ let ``No mines`` () =
           "   " ]
     annotate minefield |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Minefield with only mines`` () =
     let minefield = 
         [ "***";
@@ -43,7 +43,7 @@ let ``Minefield with only mines`` () =
           "***" ]
     annotate minefield |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Mine surrounded by spaces`` () =
     let minefield = 
         [ "   ";
@@ -55,7 +55,7 @@ let ``Mine surrounded by spaces`` () =
           "111" ]
     annotate minefield |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Space surrounded by mines`` () =
     let minefield = 
         [ "***";
@@ -67,19 +67,19 @@ let ``Space surrounded by mines`` () =
           "***" ]
     annotate minefield |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Horizontal line`` () =
     let minefield = [" * * "]
     let expected = ["1*2*1"]
     annotate minefield |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Horizontal line, mines at edges`` () =
     let minefield = ["*   *"]
     let expected = ["*1 1*"]
     annotate minefield |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Vertical line`` () =
     let minefield = 
         [ " ";
@@ -95,7 +95,7 @@ let ``Vertical line`` () =
           "1" ]
     annotate minefield |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Vertical line, mines at edges`` () =
     let minefield = 
         [ "*";
@@ -111,7 +111,7 @@ let ``Vertical line, mines at edges`` () =
           "*" ]
     annotate minefield |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Cross`` () =
     let minefield = 
         [ "  *  ";
@@ -127,7 +127,7 @@ let ``Cross`` () =
           " 2*2 " ]
     annotate minefield |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Large minefield`` () =
     let minefield = 
         [ " *  * ";

--- a/exercises/nth-prime/NthPrimeTests.fs
+++ b/exercises/nth-prime/NthPrimeTests.fs
@@ -11,19 +11,19 @@ open NthPrime
 let ``First prime`` () =
     prime 1 |> should equal (Some 2)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second prime`` () =
     prime 2 |> should equal (Some 3)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sixth prime`` () =
     prime 6 |> should equal (Some 13)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Big prime`` () =
     prime 10001 |> should equal (Some 104743)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``There is no zeroth prime`` () =
     prime 0 |> should equal None
 

--- a/exercises/nucleotide-count/NucleotideCountTests.fs
+++ b/exercises/nucleotide-count/NucleotideCountTests.fs
@@ -19,7 +19,7 @@ let ``Empty strand`` () =
         |> Some
     nucleotideCounts strand |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can count one nucleotide in single-character input`` () =
     let strand = "G"
     let expected = 
@@ -31,7 +31,7 @@ let ``Can count one nucleotide in single-character input`` () =
         |> Some
     nucleotideCounts strand |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Strand with repeated nucleotide`` () =
     let strand = "GGGGGGG"
     let expected = 
@@ -43,7 +43,7 @@ let ``Strand with repeated nucleotide`` () =
         |> Some
     nucleotideCounts strand |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Strand with multiple nucleotides`` () =
     let strand = "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"
     let expected = 
@@ -55,7 +55,7 @@ let ``Strand with multiple nucleotides`` () =
         |> Some
     nucleotideCounts strand |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Strand with invalid nucleotides`` () =
     let strand = "AGXXACT"
     let expected = None

--- a/exercises/ocr-numbers/OcrNumbersTests.fs
+++ b/exercises/ocr-numbers/OcrNumbersTests.fs
@@ -16,7 +16,7 @@ let ``Recognizes 0`` () =
           "   " ]
     convert rows |> should equal (Some "0")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Recognizes 1`` () =
     let rows = 
         [ "   ";
@@ -25,7 +25,7 @@ let ``Recognizes 1`` () =
           "   " ]
     convert rows |> should equal (Some "1")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Unreadable but correctly sized inputs return ?`` () =
     let rows = 
         [ "   ";
@@ -34,7 +34,7 @@ let ``Unreadable but correctly sized inputs return ?`` () =
           "   " ]
     convert rows |> should equal (Some "?")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Input with a number of lines that is not a multiple of four raises an error`` () =
     let rows = 
         [ " _ ";
@@ -42,7 +42,7 @@ let ``Input with a number of lines that is not a multiple of four raises an erro
           "   " ]
     convert rows |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Input with a number of columns that is not a multiple of three raises an error`` () =
     let rows = 
         [ "    ";
@@ -51,7 +51,7 @@ let ``Input with a number of columns that is not a multiple of three raises an e
           "    " ]
     convert rows |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Recognizes 110101100`` () =
     let rows = 
         [ "       _     _        _  _ ";
@@ -60,7 +60,7 @@ let ``Recognizes 110101100`` () =
           "                           " ]
     convert rows |> should equal (Some "110101100")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Garbled numbers in a string are replaced with ?`` () =
     let rows = 
         [ "       _     _           _ ";
@@ -69,7 +69,7 @@ let ``Garbled numbers in a string are replaced with ?`` () =
           "                           " ]
     convert rows |> should equal (Some "11?10?1?0")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Recognizes 2`` () =
     let rows = 
         [ " _ ";
@@ -78,7 +78,7 @@ let ``Recognizes 2`` () =
           "   " ]
     convert rows |> should equal (Some "2")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Recognizes 3`` () =
     let rows = 
         [ " _ ";
@@ -87,7 +87,7 @@ let ``Recognizes 3`` () =
           "   " ]
     convert rows |> should equal (Some "3")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Recognizes 4`` () =
     let rows = 
         [ "   ";
@@ -96,7 +96,7 @@ let ``Recognizes 4`` () =
           "   " ]
     convert rows |> should equal (Some "4")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Recognizes 5`` () =
     let rows = 
         [ " _ ";
@@ -105,7 +105,7 @@ let ``Recognizes 5`` () =
           "   " ]
     convert rows |> should equal (Some "5")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Recognizes 6`` () =
     let rows = 
         [ " _ ";
@@ -114,7 +114,7 @@ let ``Recognizes 6`` () =
           "   " ]
     convert rows |> should equal (Some "6")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Recognizes 7`` () =
     let rows = 
         [ " _ ";
@@ -123,7 +123,7 @@ let ``Recognizes 7`` () =
           "   " ]
     convert rows |> should equal (Some "7")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Recognizes 8`` () =
     let rows = 
         [ " _ ";
@@ -132,7 +132,7 @@ let ``Recognizes 8`` () =
           "   " ]
     convert rows |> should equal (Some "8")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Recognizes 9`` () =
     let rows = 
         [ " _ ";
@@ -141,7 +141,7 @@ let ``Recognizes 9`` () =
           "   " ]
     convert rows |> should equal (Some "9")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Recognizes string of decimal numbers`` () =
     let rows = 
         [ "    _  _     _  _  _  _  _  _ ";
@@ -150,7 +150,7 @@ let ``Recognizes string of decimal numbers`` () =
           "                              " ]
     convert rows |> should equal (Some "1234567890")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Numbers separated by empty lines are recognized. Lines are joined by commas.`` () =
     let rows = 
         [ "    _  _ ";

--- a/exercises/octal/OctalTests.fs
+++ b/exercises/octal/OctalTests.fs
@@ -7,55 +7,55 @@ open Xunit
 
 open Octal
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Octal 1 is decimal 1`` () =
     toDecimal "1" |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Octal 10 is decimal 8`` () =
     toDecimal "10" |> should equal 8
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Octal 17 is decimal 15`` () =
     toDecimal "17" |> should equal 15
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Octal 11 is decimal 9`` () =
     toDecimal "11" |> should equal 9
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Octal 130 is decimal 88`` () =
     toDecimal "130" |> should equal 88
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Octal 2047 is decimal 1063`` () =
     toDecimal "2047" |> should equal 1063
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Octal 7777 is decimal 4095`` () =
     toDecimal "7777" |> should equal 4095
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Octal 1234567 is decimal 342391`` () =
     toDecimal "1234567" |> should equal 342391
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid Octal carrot is decimal 0`` () =
     toDecimal "carrot" |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid Octal 8 is decimal 0`` () =
     toDecimal "8" |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid Octal 9 is decimal 0`` () =
     toDecimal "9" |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid Octal 6789 is decimal 0`` () =
     toDecimal "6789" |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid Octal abc1z is decimal 0`` () =
     toDecimal "abc1z" |> should equal 0
 

--- a/exercises/palindrome-products/PalindromeProductsTests.fs
+++ b/exercises/palindrome-products/PalindromeProductsTests.fs
@@ -12,56 +12,56 @@ let ``Finds the smallest palindrome from single digit factors`` () =
     let expected: int option * (int * int) list = (Some 1, [(1, 1)])
     smallest 1 9 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Finds the largest palindrome from single digit factors`` () =
     let expected: int option * (int * int) list = (Some 9, [(1, 9); (3, 3)])
     largest 1 9 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Find the smallest palindrome from double digit factors`` () =
     let expected: int option * (int * int) list = (Some 121, [(11, 11)])
     smallest 10 99 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Find the largest palindrome from double digit factors`` () =
     let expected: int option * (int * int) list = (Some 9009, [(91, 99)])
     largest 10 99 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Find smallest palindrome from triple digit factors`` () =
     let expected: int option * (int * int) list = (Some 10201, [(101, 101)])
     smallest 100 999 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Find the largest palindrome from triple digit factors`` () =
     let expected: int option * (int * int) list = (Some 906609, [(913, 993)])
     largest 100 999 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Find smallest palindrome from four digit factors`` () =
     let expected: int option * (int * int) list = (Some 1002001, [(1001, 1001)])
     smallest 1000 9999 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Find the largest palindrome from four digit factors`` () =
     let expected: int option * (int * int) list = (Some 99000099, [(9901, 9999)])
     largest 1000 9999 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Empty result for smallest if no palindrome in the range`` () =
     let expected: int option * (int * int) list = (None, [])
     smallest 1002 1003 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Empty result for largest if no palindrome in the range`` () =
     let expected: int option * (int * int) list = (None, [])
     largest 15 15 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Error result for smallest if min is more than max`` () =
     (fun () -> smallest 10000 1 |> ignore) |> should throw typeof<System.ArgumentException>
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Error result for largest if min is more than max`` () =
     (fun () -> largest 2 1 |> ignore) |> should throw typeof<System.ArgumentException>
 

--- a/exercises/pangram/PangramTests.fs
+++ b/exercises/pangram/PangramTests.fs
@@ -11,39 +11,39 @@ open Pangram
 let ``Empty sentence`` () =
     isPangram "" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Perfect lower case`` () =
     isPangram "abcdefghijklmnopqrstuvwxyz" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Only lower case`` () =
     isPangram "the quick brown fox jumps over the lazy dog" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Missing the letter 'x'`` () =
     isPangram "a quick movement of the enemy will jeopardize five gunboats" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Missing the letter 'h'`` () =
     isPangram "five boxing wizards jump quickly at it" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``With underscores`` () =
     isPangram "the_quick_brown_fox_jumps_over_the_lazy_dog" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``With numbers`` () =
     isPangram "the 1 quick brown fox jumps over the 2 lazy dogs" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Missing letters replaced by numbers`` () =
     isPangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog" |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Mixed case and punctuation`` () =
     isPangram "\"Five quacking Zephyrs jolt my wax bed.\"" |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Case insensitive`` () =
     isPangram "the quick brown fox jumps over with lazy FX" |> should equal false
 

--- a/exercises/parallel-letter-frequency/ParallelLetterFrequencyTests.fs
+++ b/exercises/parallel-letter-frequency/ParallelLetterFrequencyTests.fs
@@ -44,45 +44,45 @@ let starSpangledBanner =
 let ``No texts mean no letters`` () =
     frequency [] |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One letter`` () =
     frequency ["a"] |> should equal (Map.ofList [('a', 1)])
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Case insensitivity`` () =
     frequency ["aA"] |> should equal (Map.ofList [('a', 2)])
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Many empty texts still mean no letters`` () =
     frequency (List.replicate 10000 "  ") |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Many times the same text gives a predictable result`` () =
     frequency (List.replicate 1000 "abc") |> should equal (Map.ofList [('a', 1000); ('b', 1000); ('c', 1000)])
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Punctuation doesn't count`` () =
     let freqs = frequency [odeAnDieFreude]
     Map.tryFind ',' freqs |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Numbers don't count`` () =
     let freqs = frequency ["Testing, 1, 2, 3"]
     Map.tryFind '1' freqs |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Letters with and without diacritics are not the same letter`` () =
     let freqs = frequency ["aä"]
     freqs |> should equal (Map.ofList [('a', 1); ('ä', 1)])
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``All three anthems, together`` () =
     let freqs = frequency [odeAnDieFreude; wilhelmus; starSpangledBanner]
     Map.tryFind 'a' freqs |> should equal <| Some 49
     Map.tryFind 't' freqs |> should equal <| Some 56
     Map.tryFind 'o' freqs |> should equal <| Some 34
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can handle large texts`` () =
     let freqs = frequency (List.replicate 1000 [odeAnDieFreude; wilhelmus; starSpangledBanner] |> List.concat)
     Map.tryFind 'a' freqs |> should equal <| Some 49000

--- a/exercises/pascals-triangle/PascalsTriangleTests.fs
+++ b/exercises/pascals-triangle/PascalsTriangleTests.fs
@@ -12,19 +12,19 @@ let ``Zero rows`` () =
     let expected: int list list = []
     rows 0 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Single row`` () =
     let expected = [[1]]
     rows 1 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two rows`` () =
     let expected = 
         [ [1];
           [1; 1] ]
     rows 2 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Three rows`` () =
     let expected = 
         [ [1];
@@ -32,7 +32,7 @@ let ``Three rows`` () =
           [1; 2; 1] ]
     rows 3 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Four rows`` () =
     let expected = 
         [ [1];
@@ -41,7 +41,7 @@ let ``Four rows`` () =
           [1; 3; 3; 1] ]
     rows 4 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Five rows`` () =
     let expected = 
         [ [1];
@@ -51,7 +51,7 @@ let ``Five rows`` () =
           [1; 4; 6; 4; 1] ]
     rows 5 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Six rows`` () =
     let expected = 
         [ [1];
@@ -62,7 +62,7 @@ let ``Six rows`` () =
           [1; 5; 10; 10; 5; 1] ]
     rows 6 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ten rows`` () =
     let expected = 
         [ [1];

--- a/exercises/perfect-numbers/PerfectNumbersTests.fs
+++ b/exercises/perfect-numbers/PerfectNumbersTests.fs
@@ -11,51 +11,51 @@ open PerfectNumbers
 let ``Smallest perfect number is classified correctly`` () =
     classify 6 |> should equal (Some Classification.Perfect)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Medium perfect number is classified correctly`` () =
     classify 28 |> should equal (Some Classification.Perfect)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Large perfect number is classified correctly`` () =
     classify 33550336 |> should equal (Some Classification.Perfect)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Smallest abundant number is classified correctly`` () =
     classify 12 |> should equal (Some Classification.Abundant)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Medium abundant number is classified correctly`` () =
     classify 30 |> should equal (Some Classification.Abundant)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Large abundant number is classified correctly`` () =
     classify 33550335 |> should equal (Some Classification.Abundant)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Smallest prime deficient number is classified correctly`` () =
     classify 2 |> should equal (Some Classification.Deficient)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Smallest non-prime deficient number is classified correctly`` () =
     classify 4 |> should equal (Some Classification.Deficient)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Medium deficient number is classified correctly`` () =
     classify 32 |> should equal (Some Classification.Deficient)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Large deficient number is classified correctly`` () =
     classify 33550337 |> should equal (Some Classification.Deficient)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Edge case (no factors other than itself) is classified correctly`` () =
     classify 1 |> should equal (Some Classification.Deficient)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Zero is rejected (not a natural number)`` () =
     classify 0 |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Negative integer is rejected (not a natural number)`` () =
     classify -1 |> should equal None
 

--- a/exercises/phone-number/PhoneNumberTests.fs
+++ b/exercises/phone-number/PhoneNumberTests.fs
@@ -12,87 +12,87 @@ let ``Cleans the number`` () =
     let expected: Result<uint64,string> = Ok 2234567890UL
     clean "(223) 456-7890" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Cleans numbers with dots`` () =
     let expected: Result<uint64,string> = Ok 2234567890UL
     clean "223.456.7890" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Cleans numbers with multiple spaces`` () =
     let expected: Result<uint64,string> = Ok 2234567890UL
     clean "223 456   7890   " |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid when 9 digits`` () =
     let expected: Result<uint64,string> = Error "incorrect number of digits"
     clean "123456789" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid when 11 digits does not start with a 1`` () =
     let expected: Result<uint64,string> = Error "11 digits must start with 1"
     clean "22234567890" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Valid when 11 digits and starting with 1`` () =
     let expected: Result<uint64,string> = Ok 2234567890UL
     clean "12234567890" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Valid when 11 digits and starting with 1 even with punctuation`` () =
     let expected: Result<uint64,string> = Ok 2234567890UL
     clean "+1 (223) 456-7890" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid when more than 11 digits`` () =
     let expected: Result<uint64,string> = Error "more than 11 digits"
     clean "321234567890" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid with letters`` () =
     let expected: Result<uint64,string> = Error "letters not permitted"
     clean "123-abc-7890" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid with punctuations`` () =
     let expected: Result<uint64,string> = Error "punctuations not permitted"
     clean "123-@:!-7890" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid if area code starts with 0`` () =
     let expected: Result<uint64,string> = Error "area code cannot start with zero"
     clean "(023) 456-7890" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid if area code starts with 1`` () =
     let expected: Result<uint64,string> = Error "area code cannot start with one"
     clean "(123) 456-7890" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid if exchange code starts with 0`` () =
     let expected: Result<uint64,string> = Error "exchange code cannot start with zero"
     clean "(223) 056-7890" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid if exchange code starts with 1`` () =
     let expected: Result<uint64,string> = Error "exchange code cannot start with one"
     clean "(223) 156-7890" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid if area code starts with 0 on valid 11-digit number`` () =
     let expected: Result<uint64,string> = Error "area code cannot start with zero"
     clean "1 (023) 456-7890" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid if area code starts with 1 on valid 11-digit number`` () =
     let expected: Result<uint64,string> = Error "area code cannot start with one"
     clean "1 (123) 456-7890" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid if exchange code starts with 0 on valid 11-digit number`` () =
     let expected: Result<uint64,string> = Error "exchange code cannot start with zero"
     clean "1 (223) 056-7890" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid if exchange code starts with 1 on valid 11-digit number`` () =
     let expected: Result<uint64,string> = Error "exchange code cannot start with one"
     clean "1 (223) 156-7890" |> should equal expected

--- a/exercises/pig-latin/PigLatinTests.fs
+++ b/exercises/pig-latin/PigLatinTests.fs
@@ -11,87 +11,87 @@ open PigLatin
 let ``Word beginning with a`` () =
     translate "apple" |> should equal "appleay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with e`` () =
     translate "ear" |> should equal "earay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with i`` () =
     translate "igloo" |> should equal "iglooay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with o`` () =
     translate "object" |> should equal "objectay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with u`` () =
     translate "under" |> should equal "underay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with a vowel and followed by a qu`` () =
     translate "equal" |> should equal "equalay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with p`` () =
     translate "pig" |> should equal "igpay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with k`` () =
     translate "koala" |> should equal "oalakay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with x`` () =
     translate "xenon" |> should equal "enonxay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with q without a following u`` () =
     translate "qat" |> should equal "atqay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with ch`` () =
     translate "chair" |> should equal "airchay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with qu`` () =
     translate "queen" |> should equal "eenquay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with qu and a preceding consonant`` () =
     translate "square" |> should equal "aresquay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with th`` () =
     translate "therapy" |> should equal "erapythay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with thr`` () =
     translate "thrush" |> should equal "ushthray"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with sch`` () =
     translate "school" |> should equal "oolschay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with yt`` () =
     translate "yttria" |> should equal "yttriaay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Word beginning with xr`` () =
     translate "xray" |> should equal "xrayay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Y is treated like a consonant at the beginning of a word`` () =
     translate "yellow" |> should equal "ellowyay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Y is treated like a vowel at the end of a consonant cluster`` () =
     translate "rhythm" |> should equal "ythmrhay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Y as second letter in two letter word`` () =
     translate "my" |> should equal "ymay"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A whole phrase`` () =
     translate "quick fast run" |> should equal "ickquay astfay unray"
 

--- a/exercises/poker/PokerTests.fs
+++ b/exercises/poker/PokerTests.fs
@@ -13,163 +13,163 @@ let ``Single hand always wins`` () =
     let expected = ["4S 5S 7H 8D JC"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Highest card out of all hands wins`` () =
     let hands = ["4D 5S 6S 8D 3C"; "2S 4C 7S 9H 10H"; "3S 4S 5D 6H JH"]
     let expected = ["3S 4S 5D 6H JH"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A tie has multiple winners`` () =
     let hands = ["4D 5S 6S 8D 3C"; "2S 4C 7S 9H 10H"; "3S 4S 5D 6H JH"; "3H 4H 5C 6C JD"]
     let expected = ["3S 4S 5D 6H JH"; "3H 4H 5C 6C JD"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple hands with the same high cards, tie compares next highest ranked, down to last card`` () =
     let hands = ["3S 5H 6S 8D 7H"; "2S 5D 6D 8C 7S"]
     let expected = ["3S 5H 6S 8D 7H"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One pair beats high card`` () =
     let hands = ["4S 5H 6C 8D KH"; "2S 4H 6S 4D JH"]
     let expected = ["2S 4H 6S 4D JH"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Highest pair wins`` () =
     let hands = ["4S 2H 6S 2D JH"; "2S 4H 6C 4D JD"]
     let expected = ["2S 4H 6C 4D JD"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two pairs beats one pair`` () =
     let hands = ["2S 8H 6S 8D JH"; "4S 5H 4C 8C 5C"]
     let expected = ["4S 5H 4C 8C 5C"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Both hands have two pairs, highest ranked pair wins`` () =
     let hands = ["2S 8H 2D 8D 3H"; "4S 5H 4C 8S 5D"]
     let expected = ["2S 8H 2D 8D 3H"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Both hands have two pairs, with the same highest ranked pair, tie goes to low pair`` () =
     let hands = ["2S QS 2C QD JH"; "JD QH JS 8D QC"]
     let expected = ["JD QH JS 8D QC"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Both hands have two identically ranked pairs, tie goes to remaining card (kicker)`` () =
     let hands = ["JD QH JS 8D QC"; "JS QS JC 2D QD"]
     let expected = ["JD QH JS 8D QC"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Three of a kind beats two pair`` () =
     let hands = ["2S 8H 2H 8D JH"; "4S 5H 4C 8S 4H"]
     let expected = ["4S 5H 4C 8S 4H"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Both hands have three of a kind, tie goes to highest ranked triplet`` () =
     let hands = ["2S 2H 2C 8D JH"; "4S AH AS 8C AD"]
     let expected = ["4S AH AS 8C AD"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``With multiple decks, two players can have same three of a kind, ties go to highest remaining cards`` () =
     let hands = ["4S AH AS 7C AD"; "4S AH AS 8C AD"]
     let expected = ["4S AH AS 8C AD"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A straight beats three of a kind`` () =
     let hands = ["4S 5H 4C 8D 4H"; "3S 4D 2S 6D 5C"]
     let expected = ["3S 4D 2S 6D 5C"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Aces can end a straight (10 J Q K A)`` () =
     let hands = ["4S 5H 4C 8D 4H"; "10D JH QS KD AC"]
     let expected = ["10D JH QS KD AC"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Aces can start a straight (A 2 3 4 5)`` () =
     let hands = ["4S 5H 4C 8D 4H"; "4D AH 3S 2D 5C"]
     let expected = ["4D AH 3S 2D 5C"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Both hands with a straight, tie goes to highest ranked card`` () =
     let hands = ["4S 6C 7S 8D 5H"; "5S 7H 8S 9D 6H"]
     let expected = ["5S 7H 8S 9D 6H"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Even though an ace is usually high, a 5-high straight is the lowest-scoring straight`` () =
     let hands = ["2H 3C 4D 5D 6H"; "4S AH 3S 2D 5H"]
     let expected = ["2H 3C 4D 5D 6H"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Flush beats a straight`` () =
     let hands = ["4C 6H 7D 8D 5H"; "2S 4S 5S 6S 7S"]
     let expected = ["2S 4S 5S 6S 7S"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Both hands have a flush, tie goes to high card, down to the last one if necessary`` () =
     let hands = ["4H 7H 8H 9H 6H"; "2S 4S 5S 6S 7S"]
     let expected = ["4H 7H 8H 9H 6H"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Full house beats a flush`` () =
     let hands = ["3H 6H 7H 8H 5H"; "4S 5H 4C 5D 4H"]
     let expected = ["4S 5H 4C 5D 4H"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Both hands have a full house, tie goes to highest-ranked triplet`` () =
     let hands = ["4H 4S 4D 9S 9D"; "5H 5S 5D 8S 8D"]
     let expected = ["5H 5S 5D 8S 8D"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``With multiple decks, both hands have a full house with the same triplet, tie goes to the pair`` () =
     let hands = ["5H 5S 5D 9S 9D"; "5H 5S 5D 8S 8D"]
     let expected = ["5H 5S 5D 9S 9D"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Four of a kind beats a full house`` () =
     let hands = ["4S 5H 4D 5D 4H"; "3S 3H 2S 3D 3C"]
     let expected = ["3S 3H 2S 3D 3C"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Both hands have four of a kind, tie goes to high quad`` () =
     let hands = ["2S 2H 2C 8D 2D"; "4S 5H 5S 5D 5C"]
     let expected = ["4S 5H 5S 5D 5C"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``With multiple decks, both hands with identical four of a kind, tie determined by kicker`` () =
     let hands = ["3S 3H 2S 3D 3C"; "3S 3H 4S 3D 3C"]
     let expected = ["3S 3H 4S 3D 3C"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Straight flush beats four of a kind`` () =
     let hands = ["4S 5H 5S 5D 5C"; "7S 8S 9S 6S 10S"]
     let expected = ["7S 8S 9S 6S 10S"]
     bestHands hands |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Both hands have straight flush, tie goes to highest-ranked card`` () =
     let hands = ["4H 6H 7H 8H 5H"; "5S 7S 8S 9S 6S"]
     let expected = ["5S 7S 8S 9S 6S"]

--- a/exercises/pov/PovTests.fs
+++ b/exercises/pov/PovTests.fs
@@ -21,77 +21,77 @@ let ``Results in the same tree if the input tree is a singleton`` () =
     let expected = mkGraph "x" []
     fromPOV "x" tree |> mapToList  |> should equal <| graphToList expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can reroot a tree with a parent and one sibling`` () =
     let tree = mkGraph "parent" [mkGraph "x" []; mkGraph "sibling" []]
     let expected = mkGraph "x" [mkGraph "parent" [mkGraph "sibling" []]]
     fromPOV "x" tree |> mapToList  |> should equal <| graphToList expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can reroot a tree with a parent and many siblings`` () =
     let tree = mkGraph "parent" [mkGraph "a" []; mkGraph "x" []; mkGraph "b" []; mkGraph "c" []]
     let expected = mkGraph "x" [mkGraph "parent" [mkGraph "a" []; mkGraph "b" []; mkGraph "c" []]]
     fromPOV "x" tree |> mapToList  |> should equal <| graphToList expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can reroot a tree with new root deeply nested in tree`` () =
     let tree = mkGraph "level-0" [mkGraph "level-1" [mkGraph "level-2" [mkGraph "level-3" [mkGraph "x" []]]]]
     let expected = mkGraph "x" [mkGraph "level-3" [mkGraph "level-2" [mkGraph "level-1" [mkGraph "level-0" []]]]]
     fromPOV "x" tree |> mapToList  |> should equal <| graphToList expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Moves children of the new root to same level as former parent`` () =
     let tree = mkGraph "parent" [mkGraph "x" [mkGraph "kid-0" []; mkGraph "kid-1" []]]
     let expected = mkGraph "x" [mkGraph "kid-0" []; mkGraph "kid-1" []; mkGraph "parent" []]
     fromPOV "x" tree |> mapToList  |> should equal <| graphToList expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can reroot a complex tree with cousins`` () =
     let tree = mkGraph "grandparent" [mkGraph "parent" [mkGraph "x" [mkGraph "kid-0" []; mkGraph "kid-1" []]; mkGraph "sibling-0" []; mkGraph "sibling-1" []]; mkGraph "uncle" [mkGraph "cousin-0" []; mkGraph "cousin-1" []]]
     let expected = mkGraph "x" [mkGraph "kid-1" []; mkGraph "kid-0" []; mkGraph "parent" [mkGraph "sibling-0" []; mkGraph "sibling-1" []; mkGraph "grandparent" [mkGraph "uncle" [mkGraph "cousin-0" []; mkGraph "cousin-1" []]]]]
     fromPOV "x" tree |> mapToList  |> should equal <| graphToList expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Errors if target does not exist in a singleton tree`` () =
     let tree = mkGraph "x" []
     fromPOV "nonexistent" tree  |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Errors if target does not exist in a large tree`` () =
     let tree = mkGraph "parent" [mkGraph "x" [mkGraph "kid-0" []; mkGraph "kid-1" []]; mkGraph "sibling-0" []; mkGraph "sibling-1" []]
     fromPOV "nonexistent" tree  |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can find path to parent`` () =
     let tree = mkGraph "parent" [mkGraph "x" []; mkGraph "sibling" []]
     tracePathBetween "x" "parent" tree |> should equal <| Some ["x"; "parent"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can find path to sibling`` () =
     let tree = mkGraph "parent" [mkGraph "a" []; mkGraph "x" []; mkGraph "b" []; mkGraph "c" []]
     tracePathBetween "x" "b" tree |> should equal <| Some ["x"; "parent"; "b"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can find path to cousin`` () =
     let tree = mkGraph "grandparent" [mkGraph "parent" [mkGraph "x" [mkGraph "kid-0" []; mkGraph "kid-1" []]; mkGraph "sibling-0" []; mkGraph "sibling-1" []]; mkGraph "uncle" [mkGraph "cousin-0" []; mkGraph "cousin-1" []]]
     tracePathBetween "x" "cousin-1" tree |> should equal <| Some ["x"; "parent"; "grandparent"; "uncle"; "cousin-1"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can find path not involving root`` () =
     let tree = mkGraph "grandparent" [mkGraph "parent" [mkGraph "x" []; mkGraph "sibling-0" []; mkGraph "sibling-1" []]]
     tracePathBetween "x" "sibling-1" tree |> should equal <| Some ["x"; "parent"; "sibling-1"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can find path from nodes other than x`` () =
     let tree = mkGraph "parent" [mkGraph "a" []; mkGraph "x" []; mkGraph "b" []; mkGraph "c" []]
     tracePathBetween "a" "c" tree |> should equal <| Some ["a"; "parent"; "c"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Errors if destination does not exist`` () =
     let tree = mkGraph "parent" [mkGraph "x" [mkGraph "kid-0" []; mkGraph "kid-1" []]; mkGraph "sibling-0" []; mkGraph "sibling-1" []]
     tracePathBetween "x" "nonexistent" tree |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Errors if source does not exist`` () =
     let tree = mkGraph "parent" [mkGraph "x" [mkGraph "kid-0" []; mkGraph "kid-1" []]; mkGraph "sibling-0" []; mkGraph "sibling-1" []]
     tracePathBetween "nonexistent" "x" tree |> should equal None

--- a/exercises/prime-factors/PrimeFactorsTests.fs
+++ b/exercises/prime-factors/PrimeFactorsTests.fs
@@ -11,27 +11,27 @@ open PrimeFactors
 let ``No factors`` () =
     factors 1L |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Prime number`` () =
     factors 2L |> should equal [2]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Square of a prime`` () =
     factors 9L |> should equal [3; 3]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Cube of a prime`` () =
     factors 8L |> should equal [2; 2; 2]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Product of primes and non-primes`` () =
     factors 12L |> should equal [2; 2; 3]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Product of primes`` () =
     factors 901255L |> should equal [5; 17; 23; 461]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Factors include a large prime`` () =
     factors 93819012551L |> should equal [11; 9539; 894119]
 

--- a/exercises/protein-translation/ProteinTranslationTests.fs
+++ b/exercises/protein-translation/ProteinTranslationTests.fs
@@ -11,91 +11,91 @@ open ProteinTranslation
 let ``Methionine RNA sequence`` () =
     proteins "AUG" |> should equal ["Methionine"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Phenylalanine RNA sequence 1`` () =
     proteins "UUU" |> should equal ["Phenylalanine"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Phenylalanine RNA sequence 2`` () =
     proteins "UUC" |> should equal ["Phenylalanine"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Leucine RNA sequence 1`` () =
     proteins "UUA" |> should equal ["Leucine"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Leucine RNA sequence 2`` () =
     proteins "UUG" |> should equal ["Leucine"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Serine RNA sequence 1`` () =
     proteins "UCU" |> should equal ["Serine"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Serine RNA sequence 2`` () =
     proteins "UCC" |> should equal ["Serine"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Serine RNA sequence 3`` () =
     proteins "UCA" |> should equal ["Serine"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Serine RNA sequence 4`` () =
     proteins "UCG" |> should equal ["Serine"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Tyrosine RNA sequence 1`` () =
     proteins "UAU" |> should equal ["Tyrosine"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Tyrosine RNA sequence 2`` () =
     proteins "UAC" |> should equal ["Tyrosine"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Cysteine RNA sequence 1`` () =
     proteins "UGU" |> should equal ["Cysteine"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Cysteine RNA sequence 2`` () =
     proteins "UGC" |> should equal ["Cysteine"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Tryptophan RNA sequence`` () =
     proteins "UGG" |> should equal ["Tryptophan"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``STOP codon RNA sequence 1`` () =
     proteins "UAA" |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``STOP codon RNA sequence 2`` () =
     proteins "UAG" |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``STOP codon RNA sequence 3`` () =
     proteins "UGA" |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Translate RNA strand into correct protein list`` () =
     proteins "AUGUUUUGG" |> should equal ["Methionine"; "Phenylalanine"; "Tryptophan"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Translation stops if STOP codon at beginning of sequence`` () =
     proteins "UAGUGG" |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Translation stops if STOP codon at end of two-codon sequence`` () =
     proteins "UGGUAG" |> should equal ["Tryptophan"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Translation stops if STOP codon at end of three-codon sequence`` () =
     proteins "AUGUUUUAA" |> should equal ["Methionine"; "Phenylalanine"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Translation stops if STOP codon in middle of three-codon sequence`` () =
     proteins "UGGUAGUGG" |> should equal ["Tryptophan"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Translation stops if STOP codon in middle of six-codon sequence`` () =
     proteins "UGGUGUUAUUAAUGGUUU" |> should equal ["Tryptophan"; "Cysteine"; "Tyrosine"]
 

--- a/exercises/proverb/ProverbTests.fs
+++ b/exercises/proverb/ProverbTests.fs
@@ -13,13 +13,13 @@ let ``Zero pieces`` () =
     let expected: string list = []
     recite strings |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One piece`` () =
     let strings = ["nail"]
     let expected = ["And all for the want of a nail."]
     recite strings |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two pieces`` () =
     let strings = ["nail"; "shoe"]
     let expected = 
@@ -27,7 +27,7 @@ let ``Two pieces`` () =
           "And all for the want of a nail." ]
     recite strings |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Three pieces`` () =
     let strings = ["nail"; "shoe"; "horse"]
     let expected = 
@@ -36,7 +36,7 @@ let ``Three pieces`` () =
           "And all for the want of a nail." ]
     recite strings |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Full proverb`` () =
     let strings = ["nail"; "shoe"; "horse"; "rider"; "message"; "battle"; "kingdom"]
     let expected = 
@@ -49,7 +49,7 @@ let ``Full proverb`` () =
           "And all for the want of a nail." ]
     recite strings |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Four pieces modernized`` () =
     let strings = ["pin"; "gun"; "soldier"; "battle"]
     let expected = 

--- a/exercises/pythagorean-triplet/PythagoreanTripletTests.fs
+++ b/exercises/pythagorean-triplet/PythagoreanTripletTests.fs
@@ -11,27 +11,27 @@ open PythagoreanTriplet
 let ``Triplets whose sum is 12`` () =
     tripletsWithSum 12 |> should equal [(3, 4, 5)]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Triplets whose sum is 108`` () =
     tripletsWithSum 108 |> should equal [(27, 36, 45)]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Triplets whose sum is 1000`` () =
     tripletsWithSum 1000 |> should equal [(200, 375, 425)]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``No matching triplets for 1001`` () =
     tripletsWithSum 1001 |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Returns all matching triplets`` () =
     tripletsWithSum 90 |> should equal [(9, 40, 41); (15, 36, 39)]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Several matching triplets`` () =
     tripletsWithSum 840 |> should equal [(40, 399, 401); (56, 390, 394); (105, 360, 375); (120, 350, 370); (140, 336, 364); (168, 315, 357); (210, 280, 350); (240, 252, 348)]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Triplets for large number`` () =
     tripletsWithSum 30000 |> should equal [(1200, 14375, 14425); (1875, 14000, 14125); (5000, 12000, 13000); (6000, 11250, 12750); (7500, 10000, 12500)]
 

--- a/exercises/queen-attack/QueenAttackTests.fs
+++ b/exercises/queen-attack/QueenAttackTests.fs
@@ -11,59 +11,59 @@ open QueenAttack
 let ``Queen with a valid position`` () =
     create (2, 2) |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Queen must have positive row`` () =
     create (-2, 2) |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Queen must have row on board`` () =
     create (8, 4) |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Queen must have positive column`` () =
     create (2, -2) |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Queen must have column on board`` () =
     create (4, 8) |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can not attack`` () =
     let whiteQueen = (2, 4)
     let blackQueen = (6, 6)
     canAttack blackQueen whiteQueen |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can attack on same row`` () =
     let whiteQueen = (2, 4)
     let blackQueen = (2, 6)
     canAttack blackQueen whiteQueen |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can attack on same column`` () =
     let whiteQueen = (4, 5)
     let blackQueen = (2, 5)
     canAttack blackQueen whiteQueen |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can attack on first diagonal`` () =
     let whiteQueen = (2, 2)
     let blackQueen = (0, 4)
     canAttack blackQueen whiteQueen |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can attack on second diagonal`` () =
     let whiteQueen = (2, 2)
     let blackQueen = (3, 1)
     canAttack blackQueen whiteQueen |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can attack on third diagonal`` () =
     let whiteQueen = (2, 2)
     let blackQueen = (1, 1)
     canAttack blackQueen whiteQueen |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can attack on fourth diagonal`` () =
     let whiteQueen = (1, 7)
     let blackQueen = (0, 6)

--- a/exercises/rail-fence-cipher/RailFenceCipherTests.fs
+++ b/exercises/rail-fence-cipher/RailFenceCipherTests.fs
@@ -14,35 +14,35 @@ let ``Encode with two rails`` () =
     let expected = "XXXXXXXXXOOOOOOOOO"
     encode rails msg |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode with three rails`` () =
     let rails = 3
     let msg = "WEAREDISCOVEREDFLEEATONCE"
     let expected = "WECRLTEERDSOEEFEAOCAIVDEN"
     encode rails msg |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode with ending in the middle`` () =
     let rails = 4
     let msg = "EXERCISES"
     let expected = "ESXIEECSR"
     encode rails msg |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode with three rails`` () =
     let rails = 3
     let msg = "TEITELHDVLSNHDTISEIIEA"
     let expected = "THEDEVILISINTHEDETAILS"
     decode rails msg |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode with five rails`` () =
     let rails = 5
     let msg = "EIEXMSMESAORIWSCE"
     let expected = "EXERCISMISAWESOME"
     decode rails msg |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode with six rails`` () =
     let rails = 6
     let msg = "133714114238148966225439541018335470986172518171757571896261"

--- a/exercises/raindrops/RaindropsTests.fs
+++ b/exercises/raindrops/RaindropsTests.fs
@@ -11,71 +11,71 @@ open Raindrops
 let ``The sound for 1 is 1`` () =
     convert 1 |> should equal "1"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 3 is Pling`` () =
     convert 3 |> should equal "Pling"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 5 is Plang`` () =
     convert 5 |> should equal "Plang"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 7 is Plong`` () =
     convert 7 |> should equal "Plong"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 6 is Pling as it has a factor 3`` () =
     convert 6 |> should equal "Pling"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base`` () =
     convert 8 |> should equal "8"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 9 is Pling as it has a factor 3`` () =
     convert 9 |> should equal "Pling"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 10 is Plang as it has a factor 5`` () =
     convert 10 |> should equal "Plang"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 14 is Plong as it has a factor of 7`` () =
     convert 14 |> should equal "Plong"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 15 is PlingPlang as it has factors 3 and 5`` () =
     convert 15 |> should equal "PlingPlang"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 21 is PlingPlong as it has factors 3 and 7`` () =
     convert 21 |> should equal "PlingPlong"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 25 is Plang as it has a factor 5`` () =
     convert 25 |> should equal "Plang"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 27 is Pling as it has a factor 3`` () =
     convert 27 |> should equal "Pling"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 35 is PlangPlong as it has factors 5 and 7`` () =
     convert 35 |> should equal "PlangPlong"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 49 is Plong as it has a factor 7`` () =
     convert 49 |> should equal "Plong"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 52 is 52`` () =
     convert 52 |> should equal "52"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7`` () =
     convert 105 |> should equal "PlingPlangPlong"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The sound for 3125 is Plang as it has a factor 5`` () =
     convert 3125 |> should equal "Plang"
 

--- a/exercises/rational-numbers/RationalNumbersTests.fs
+++ b/exercises/rational-numbers/RationalNumbersTests.fs
@@ -11,151 +11,151 @@ open RationalNumbers
 let ``Add two positive rational numbers`` () =
     add (create 1 2) (create 2 3) |> should equal (create 7 6)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add a positive rational number and a negative rational number`` () =
     add (create 1 2) (create -2 3) |> should equal (create -1 6)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add two negative rational numbers`` () =
     add (create -1 2) (create -2 3) |> should equal (create -7 6)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add a rational number to its additive inverse`` () =
     add (create 1 2) (create -1 2) |> should equal (create 0 1)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtract two positive rational numbers`` () =
     sub (create 1 2) (create 2 3) |> should equal (create -1 6)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtract a positive rational number and a negative rational number`` () =
     sub (create 1 2) (create -2 3) |> should equal (create 7 6)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtract two negative rational numbers`` () =
     sub (create -1 2) (create -2 3) |> should equal (create 1 6)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtract a rational number from itself`` () =
     sub (create 1 2) (create 1 2) |> should equal (create 0 1)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiply two positive rational numbers`` () =
     mul (create 1 2) (create 2 3) |> should equal (create 1 3)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiply a negative rational number by a positive rational number`` () =
     mul (create -1 2) (create 2 3) |> should equal (create -1 3)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiply two negative rational numbers`` () =
     mul (create -1 2) (create -2 3) |> should equal (create 1 3)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiply a rational number by its reciprocal`` () =
     mul (create 1 2) (create 2 1) |> should equal (create 1 1)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiply a rational number by 1`` () =
     mul (create 1 2) (create 1 1) |> should equal (create 1 2)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiply a rational number by 0`` () =
     mul (create 1 2) (create 0 1) |> should equal (create 0 1)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Divide two positive rational numbers`` () =
     div (create 1 2) (create 2 3) |> should equal (create 3 4)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Divide a positive rational number by a negative rational number`` () =
     div (create 1 2) (create -2 3) |> should equal (create -3 4)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Divide two negative rational numbers`` () =
     div (create -1 2) (create -2 3) |> should equal (create 3 4)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Divide a rational number by 1`` () =
     div (create 1 2) (create 1 1) |> should equal (create 1 2)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Absolute value of a positive rational number`` () =
     abs (create 1 2) |> should equal (create 1 2)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Absolute value of a positive rational number with negative numerator and denominator`` () =
     abs (create -1 -2) |> should equal (create 1 2)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Absolute value of a negative rational number`` () =
     abs (create -1 2) |> should equal (create 1 2)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Absolute value of a negative rational number with negative denominator`` () =
     abs (create 1 -2) |> should equal (create 1 2)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Absolute value of zero`` () =
     abs (create 0 1) |> should equal (create 0 1)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Raise a positive rational number to a positive integer power`` () =
     exprational 3 (create 1 2) |> should equal (create 1 8)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Raise a negative rational number to a positive integer power`` () =
     exprational 3 (create -1 2) |> should equal (create -1 8)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Raise zero to an integer power`` () =
     exprational 5 (create 0 1) |> should equal (create 0 1)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Raise one to an integer power`` () =
     exprational 4 (create 1 1) |> should equal (create 1 1)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Raise a positive rational number to the power of zero`` () =
     exprational 0 (create 1 2) |> should equal (create 1 1)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Raise a negative rational number to the power of zero`` () =
     exprational 0 (create -1 2) |> should equal (create 1 1)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Raise a real number to a positive rational number`` () =
     expreal (create 4 3) 8 |> should (equalWithin 0.01) 16
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Raise a real number to a negative rational number`` () =
     expreal (create -1 2) 9 |> should (equalWithin 0.01) 0.3333333333333333
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Raise a real number to a zero rational number`` () =
     expreal (create 0 1) 2 |> should (equalWithin 0.01) 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reduce a positive rational number to lowest terms`` () =
     reduce (create 2 4) |> should equal (create 1 2)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reduce a negative rational number to lowest terms`` () =
     reduce (create -4 6) |> should equal (create -2 3)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reduce a rational number with a negative denominator to lowest terms`` () =
     reduce (create 3 -9) |> should equal (create -1 3)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reduce zero to lowest terms`` () =
     reduce (create 0 6) |> should equal (create 0 1)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reduce an integer to lowest terms`` () =
     reduce (create -14 7) |> should equal (create -2 1)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reduce one to lowest terms`` () =
     reduce (create 13 13) |> should equal (create 1 1)
 

--- a/exercises/react/ReactTests.fs
+++ b/exercises/react/ReactTests.fs
@@ -14,21 +14,21 @@ let ``Input cells have a value`` () =
     let input = reactor.createInputCell 10
     input.Value |> should equal 10
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``An input cell's value can be set`` () =
     let reactor = new Reactor()
     let input = reactor.createInputCell 4
     input.Value <- 20
     input.Value |> should equal 20
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Compute cells calculate initial value`` () =
     let reactor = new Reactor()
     let input = reactor.createInputCell 1
     let output = reactor.createComputeCell [input] (fun values -> values.[0] + 1)
     output.Value |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Compute cells take inputs in the right order`` () =
     let reactor = new Reactor()
     let one = reactor.createInputCell 1
@@ -36,7 +36,7 @@ let ``Compute cells take inputs in the right order`` () =
     let output = reactor.createComputeCell [one; two] (fun values -> values.[0] + values.[1] * 10)
     output.Value |> should equal 21
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Compute cells update value when dependencies are changed`` () =
     let reactor = new Reactor()
     let input = reactor.createInputCell 1
@@ -44,7 +44,7 @@ let ``Compute cells update value when dependencies are changed`` () =
     input.Value <- 3
     output.Value |> should equal 4
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Compute cells can depend on other compute cells`` () =
     let reactor = new Reactor()
     let input = reactor.createInputCell 1
@@ -55,7 +55,7 @@ let ``Compute cells can depend on other compute cells`` () =
     input.Value <- 3
     output.Value |> should equal 96
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Compute cells fire callbacks`` () =
     let reactor = new Reactor()
     let input = reactor.createInputCell 1
@@ -66,7 +66,7 @@ let ``Compute cells fire callbacks`` () =
     A.CallTo(fun() -> callback1Handler.Invoke(A<obj>.``_``, 4)).MustHaveHappenedOnceExactly() |> ignore
     Fake.ClearRecordedCalls(callback1Handler) |> ignore
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Callback cells only fire on change`` () =
     let reactor = new Reactor()
     let input = reactor.createInputCell 1
@@ -79,7 +79,7 @@ let ``Callback cells only fire on change`` () =
     A.CallTo(fun() -> callback1Handler.Invoke(A<obj>.``_``, 222)).MustHaveHappenedOnceExactly() |> ignore
     Fake.ClearRecordedCalls(callback1Handler) |> ignore
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Callbacks do not report already reported values`` () =
     let reactor = new Reactor()
     let input = reactor.createInputCell 1
@@ -93,7 +93,7 @@ let ``Callbacks do not report already reported values`` () =
     A.CallTo(fun() -> callback1Handler.Invoke(A<obj>.``_``, 4)).MustHaveHappenedOnceExactly() |> ignore
     Fake.ClearRecordedCalls(callback1Handler) |> ignore
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Callbacks can fire from multiple cells`` () =
     let reactor = new Reactor()
     let input = reactor.createInputCell 1
@@ -109,7 +109,7 @@ let ``Callbacks can fire from multiple cells`` () =
     A.CallTo(fun() -> callback2Handler.Invoke(A<obj>.``_``, 9)).MustHaveHappenedOnceExactly() |> ignore
     Fake.ClearRecordedCalls(callback2Handler) |> ignore
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Callbacks can be added and removed`` () =
     let reactor = new Reactor()
     let input = reactor.createInputCell 11
@@ -133,7 +133,7 @@ let ``Callbacks can be added and removed`` () =
     Fake.ClearRecordedCalls(callback3Handler) |> ignore
     A.CallTo(fun() -> callback1Handler.Invoke(A<obj>.``_``, A<int>.``_``)).MustNotHaveHappened() |> ignore
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Removing a callback multiple times doesn't interfere with other callbacks`` () =
     let reactor = new Reactor()
     let input = reactor.createInputCell 1
@@ -150,7 +150,7 @@ let ``Removing a callback multiple times doesn't interfere with other callbacks`
     Fake.ClearRecordedCalls(callback2Handler) |> ignore
     A.CallTo(fun() -> callback1Handler.Invoke(A<obj>.``_``, A<int>.``_``)).MustNotHaveHappened() |> ignore
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Callbacks should only be called once even if multiple dependencies change`` () =
     let reactor = new Reactor()
     let input = reactor.createInputCell 1
@@ -164,7 +164,7 @@ let ``Callbacks should only be called once even if multiple dependencies change`
     A.CallTo(fun() -> callback1Handler.Invoke(A<obj>.``_``, 10)).MustHaveHappenedOnceExactly() |> ignore
     Fake.ClearRecordedCalls(callback1Handler) |> ignore
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Callbacks should not be called if dependencies change but output value doesn't change`` () =
     let reactor = new Reactor()
     let input = reactor.createInputCell 1

--- a/exercises/rectangles/RectanglesTests.fs
+++ b/exercises/rectangles/RectanglesTests.fs
@@ -12,17 +12,17 @@ let ``No rows`` () =
     let strings = []
     rectangles strings |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``No columns`` () =
     let strings = [""]
     rectangles strings |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``No rectangles`` () =
     let strings = [" "]
     rectangles strings |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One rectangle`` () =
     let strings = 
         [ "+-+";
@@ -30,7 +30,7 @@ let ``One rectangle`` () =
           "+-+" ]
     rectangles strings |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two rectangles without shared parts`` () =
     let strings = 
         [ "  +-+";
@@ -40,7 +40,7 @@ let ``Two rectangles without shared parts`` () =
           "+-+  " ]
     rectangles strings |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Five rectangles with shared parts`` () =
     let strings = 
         [ "  +-+";
@@ -50,14 +50,14 @@ let ``Five rectangles with shared parts`` () =
           "+-+-+" ]
     rectangles strings |> should equal 5
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rectangle of height 1 is counted`` () =
     let strings = 
         [ "+--+";
           "+--+" ]
     rectangles strings |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rectangle of width 1 is counted`` () =
     let strings = 
         [ "++";
@@ -65,14 +65,14 @@ let ``Rectangle of width 1 is counted`` () =
           "++" ]
     rectangles strings |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``1x1 square is counted`` () =
     let strings = 
         [ "++";
           "++" ]
     rectangles strings |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Only complete rectangles are counted`` () =
     let strings = 
         [ "  +-+";
@@ -82,7 +82,7 @@ let ``Only complete rectangles are counted`` () =
           "+-+-+" ]
     rectangles strings |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rectangles can be of different sizes`` () =
     let strings = 
         [ "+------+----+";
@@ -92,7 +92,7 @@ let ``Rectangles can be of different sizes`` () =
           "+---+-------+" ]
     rectangles strings |> should equal 3
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Corner is required for a rectangle to be complete`` () =
     let strings = 
         [ "+------+----+";
@@ -102,7 +102,7 @@ let ``Corner is required for a rectangle to be complete`` () =
           "+---+-------+" ]
     rectangles strings |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Large input with many rectangles`` () =
     let strings = 
         [ "+---+--+----+";

--- a/exercises/rest-api/RestApiTests.fs
+++ b/exercises/rest-api/RestApiTests.fs
@@ -15,7 +15,7 @@ let ``No users`` () =
     let api = RestApi(database)
     api.Get url |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Add user`` () =
     let database = """{"users":[]}"""
     let payload = """{"user":"Adam"}"""
@@ -24,7 +24,7 @@ let ``Add user`` () =
     let api = RestApi(database)
     api.Post (url, payload) |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Get single user`` () =
     let database = """{"users":[{"name":"Adam","owes":{},"owed_by":{},"balance":0.0},{"name":"Bob","owes":{},"owed_by":{},"balance":0.0}]}"""
     let payload = """{"users":["Bob"]}"""
@@ -33,7 +33,7 @@ let ``Get single user`` () =
     let api = RestApi(database)
     api.Get (url, payload) |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Both users have 0 balance`` () =
     let database = """{"users":[{"name":"Adam","owes":{},"owed_by":{},"balance":0.0},{"name":"Bob","owes":{},"owed_by":{},"balance":0.0}]}"""
     let payload = """{"lender":"Adam","borrower":"Bob","amount":3.0}"""
@@ -42,7 +42,7 @@ let ``Both users have 0 balance`` () =
     let api = RestApi(database)
     api.Post (url, payload) |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Borrower has negative balance`` () =
     let database = """{"users":[{"name":"Adam","owes":{},"owed_by":{},"balance":0.0},{"name":"Bob","owes":{"Chuck":3.0},"owed_by":{},"balance":-3.0},{"name":"Chuck","owes":{},"owed_by":{"Bob":3.0},"balance":3.0}]}"""
     let payload = """{"lender":"Adam","borrower":"Bob","amount":3.0}"""
@@ -51,7 +51,7 @@ let ``Borrower has negative balance`` () =
     let api = RestApi(database)
     api.Post (url, payload) |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Lender has negative balance`` () =
     let database = """{"users":[{"name":"Adam","owes":{},"owed_by":{},"balance":0.0},{"name":"Bob","owes":{"Chuck":3.0},"owed_by":{},"balance":-3.0},{"name":"Chuck","owes":{},"owed_by":{"Bob":3.0},"balance":3.0}]}"""
     let payload = """{"lender":"Bob","borrower":"Adam","amount":3.0}"""
@@ -60,7 +60,7 @@ let ``Lender has negative balance`` () =
     let api = RestApi(database)
     api.Post (url, payload) |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Lender owes borrower`` () =
     let database = """{"users":[{"name":"Adam","owes":{"Bob":3.0},"owed_by":{},"balance":-3.0},{"name":"Bob","owes":{},"owed_by":{"Adam":3.0},"balance":3.0}]}"""
     let payload = """{"lender":"Adam","borrower":"Bob","amount":2.0}"""
@@ -69,7 +69,7 @@ let ``Lender owes borrower`` () =
     let api = RestApi(database)
     api.Post (url, payload) |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Lender owes borrower less than new loan`` () =
     let database = """{"users":[{"name":"Adam","owes":{"Bob":3.0},"owed_by":{},"balance":-3.0},{"name":"Bob","owes":{},"owed_by":{"Adam":3.0},"balance":3.0}]}"""
     let payload = """{"lender":"Adam","borrower":"Bob","amount":4.0}"""
@@ -78,7 +78,7 @@ let ``Lender owes borrower less than new loan`` () =
     let api = RestApi(database)
     api.Post (url, payload) |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Lender owes borrower same as new loan`` () =
     let database = """{"users":[{"name":"Adam","owes":{"Bob":3.0},"owed_by":{},"balance":-3.0},{"name":"Bob","owes":{},"owed_by":{"Adam":3.0},"balance":3.0}]}"""
     let payload = """{"lender":"Adam","borrower":"Bob","amount":3.0}"""

--- a/exercises/reverse-string/ReverseStringTests.fs
+++ b/exercises/reverse-string/ReverseStringTests.fs
@@ -11,23 +11,23 @@ open ReverseString
 let ``An empty string`` () =
     reverse "" |> should equal ""
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A word`` () =
     reverse "robot" |> should equal "tobor"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A capitalized word`` () =
     reverse "Ramen" |> should equal "nemaR"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A sentence with punctuation`` () =
     reverse "I'm hungry!" |> should equal "!yrgnuh m'I"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A palindrome`` () =
     reverse "racecar" |> should equal "racecar"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``An even-sized word`` () =
     reverse "drawer" |> should equal "reward"
 

--- a/exercises/rna-transcription/RnaTranscriptionTests.fs
+++ b/exercises/rna-transcription/RnaTranscriptionTests.fs
@@ -11,23 +11,23 @@ open RnaTranscription
 let ``Empty RNA sequence`` () =
     toRna "" |> should equal ""
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``RNA complement of cytosine is guanine`` () =
     toRna "C" |> should equal "G"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``RNA complement of guanine is cytosine`` () =
     toRna "G" |> should equal "C"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``RNA complement of thymine is adenine`` () =
     toRna "T" |> should equal "A"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``RNA complement of adenine is uracil`` () =
     toRna "A" |> should equal "U"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``RNA complement`` () =
     toRna "ACGTGGTCTTAA" |> should equal "UGCACCAGAAUU"
 

--- a/exercises/robot-name/RobotNameTests.fs
+++ b/exercises/robot-name/RobotNameTests.fs
@@ -12,18 +12,18 @@ let ``Robot has a name`` () =
     let robot = mkRobot()
     Regex.IsMatch(name robot, @"^[A-Z]{2}\d{3}$") |> should equal true
     
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Name is the same each time`` () =     
     let robot = mkRobot()
     name robot |> should equal (name robot)
     
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Different robots have different names`` () = 
     let robot = mkRobot()
     let robot2 = mkRobot()
     name robot |> should not' (equal (name robot2))
     
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can reset the name`` () =  
     let robot = mkRobot()
     let originalName = name robot

--- a/exercises/robot-simulator/RobotSimulatorTests.fs
+++ b/exercises/robot-simulator/RobotSimulatorTests.fs
@@ -12,102 +12,102 @@ let ``At origin facing north`` () =
     let expected = create Direction.North (0, 0)
     create Direction.North (0, 0) |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``At negative position facing south`` () =
     let expected = create Direction.South (-1, -1)
     create Direction.South (-1, -1) |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Changes north to east`` () =
     let robot = create Direction.North (0, 0)
     let expected = create Direction.East (0, 0)
     move "R" robot |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Changes east to south`` () =
     let robot = create Direction.East (0, 0)
     let expected = create Direction.South (0, 0)
     move "R" robot |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Changes south to west`` () =
     let robot = create Direction.South (0, 0)
     let expected = create Direction.West (0, 0)
     move "R" robot |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Changes west to north`` () =
     let robot = create Direction.West (0, 0)
     let expected = create Direction.North (0, 0)
     move "R" robot |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Changes north to west`` () =
     let robot = create Direction.North (0, 0)
     let expected = create Direction.West (0, 0)
     move "L" robot |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Changes west to south`` () =
     let robot = create Direction.West (0, 0)
     let expected = create Direction.South (0, 0)
     move "L" robot |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Changes south to east`` () =
     let robot = create Direction.South (0, 0)
     let expected = create Direction.East (0, 0)
     move "L" robot |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Changes east to north`` () =
     let robot = create Direction.East (0, 0)
     let expected = create Direction.North (0, 0)
     move "L" robot |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Facing north increments Y`` () =
     let robot = create Direction.North (0, 0)
     let expected = create Direction.North (0, 1)
     move "A" robot |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Facing south decrements Y`` () =
     let robot = create Direction.South (0, 0)
     let expected = create Direction.South (0, -1)
     move "A" robot |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Facing east increments X`` () =
     let robot = create Direction.East (0, 0)
     let expected = create Direction.East (1, 0)
     move "A" robot |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Facing west decrements X`` () =
     let robot = create Direction.West (0, 0)
     let expected = create Direction.West (-1, 0)
     move "A" robot |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Moving east and north from README`` () =
     let robot = create Direction.North (7, 3)
     let expected = create Direction.West (9, 4)
     move "RAALAL" robot |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Moving west and north`` () =
     let robot = create Direction.North (0, 0)
     let expected = create Direction.West (-4, 1)
     move "LAAARALA" robot |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Moving west and south`` () =
     let robot = create Direction.East (2, -7)
     let expected = create Direction.South (-3, -8)
     move "RRAAAAALA" robot |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Moving east and north`` () =
     let robot = create Direction.South (8, 4)
     let expected = create Direction.North (11, 5)

--- a/exercises/roman-numerals/RomanNumeralsTests.fs
+++ b/exercises/roman-numerals/RomanNumeralsTests.fs
@@ -11,75 +11,75 @@ open RomanNumerals
 let ``1 is a single I`` () =
     roman 1 |> should equal "I"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``2 is two I's`` () =
     roman 2 |> should equal "II"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``3 is three I's`` () =
     roman 3 |> should equal "III"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``4, being 5 - 1, is IV`` () =
     roman 4 |> should equal "IV"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``5 is a single V`` () =
     roman 5 |> should equal "V"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``6, being 5 + 1, is VI`` () =
     roman 6 |> should equal "VI"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``9, being 10 - 1, is IX`` () =
     roman 9 |> should equal "IX"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``20 is two X's`` () =
     roman 27 |> should equal "XXVII"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``48 is not 50 - 2 but rather 40 + 8`` () =
     roman 48 |> should equal "XLVIII"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1`` () =
     roman 49 |> should equal "XLIX"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``50 is a single L`` () =
     roman 59 |> should equal "LIX"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``90, being 100 - 10, is XC`` () =
     roman 93 |> should equal "XCIII"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``100 is a single C`` () =
     roman 141 |> should equal "CXLI"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``60, being 50 + 10, is LX`` () =
     roman 163 |> should equal "CLXIII"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``400, being 500 - 100, is CD`` () =
     roman 402 |> should equal "CDII"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``500 is a single D`` () =
     roman 575 |> should equal "DLXXV"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``900, being 1000 - 100, is CM`` () =
     roman 911 |> should equal "CMXI"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``1000 is a single M`` () =
     roman 1024 |> should equal "MXXIV"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``3000 is three M's`` () =
     roman 3000 |> should equal "MMM"
 

--- a/exercises/rotational-cipher/RotationalCipherTests.fs
+++ b/exercises/rotational-cipher/RotationalCipherTests.fs
@@ -11,39 +11,39 @@ open RotationalCipher
 let ``Rotate a by 0, same output as input`` () =
     rotate 0 "a" |> should equal "a"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rotate a by 1`` () =
     rotate 1 "a" |> should equal "b"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rotate a by 26, same output as input`` () =
     rotate 26 "a" |> should equal "a"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rotate m by 13`` () =
     rotate 13 "m" |> should equal "z"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rotate n by 13 with wrap around alphabet`` () =
     rotate 13 "n" |> should equal "a"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rotate capital letters`` () =
     rotate 5 "OMG" |> should equal "TRL"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rotate spaces`` () =
     rotate 5 "O M G" |> should equal "T R L"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rotate numbers`` () =
     rotate 4 "Testing 1 2 3 testing" |> should equal "Xiwxmrk 1 2 3 xiwxmrk"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rotate punctuation`` () =
     rotate 21 "Let's eat, Grandma!" |> should equal "Gzo'n zvo, Bmviyhv!"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rotate all letters`` () =
     rotate 13 "The quick brown fox jumps over the lazy dog." |> should equal "Gur dhvpx oebja sbk whzcf bire gur ynml qbt."
 

--- a/exercises/run-length-encoding/RunLengthEncodingTests.fs
+++ b/exercises/run-length-encoding/RunLengthEncodingTests.fs
@@ -11,51 +11,51 @@ open RunLengthEncoding
 let ``Encode empty string`` () =
     encode "" |> should equal ""
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode single characters only are encoded without count`` () =
     encode "XYZ" |> should equal "XYZ"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode string with no single characters`` () =
     encode "AABBBCCCC" |> should equal "2A3B4C"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode single characters mixed with repeated characters`` () =
     encode "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB" |> should equal "12WB12W3B24WB"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode multiple whitespace mixed in string`` () =
     encode "  hsqq qww  " |> should equal "2 hs2q q2w2 "
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode lowercase characters`` () =
     encode "aabbbcccc" |> should equal "2a3b4c"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode empty string`` () =
     decode "" |> should equal ""
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode single characters only`` () =
     decode "XYZ" |> should equal "XYZ"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode string with no single characters`` () =
     decode "2A3B4C" |> should equal "AABBBCCCC"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode single characters with repeated characters`` () =
     decode "12WB12W3B24WB" |> should equal "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode multiple whitespace mixed in string`` () =
     decode "2 hs2q q2w2 " |> should equal "  hsqq qww  "
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Decode lower case string`` () =
     decode "2a3b4c" |> should equal "aabbbcccc"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Encode followed by decode gives original string`` () =
     "zzz ZZ  zZ" |> encode |> decode |> should equal "zzz ZZ  zZ"
 

--- a/exercises/saddle-points/SaddlePointsTests.fs
+++ b/exercises/saddle-points/SaddlePointsTests.fs
@@ -15,12 +15,12 @@ let ``Can identify single saddle point`` () =
           [6; 6; 7] ]
     saddlePoints matrix |> should equal [(2, 1)]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can identify that empty matrix has no saddle points`` () =
     let matrix = [[]]
     saddlePoints matrix |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can identify lack of saddle points when there are none`` () =
     let matrix = 
         [ [1; 2; 3];
@@ -28,7 +28,7 @@ let ``Can identify lack of saddle points when there are none`` () =
           [2; 3; 1] ]
     saddlePoints matrix |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can identify multiple saddle points in a column`` () =
     let matrix = 
         [ [4; 5; 4];
@@ -36,7 +36,7 @@ let ``Can identify multiple saddle points in a column`` () =
           [1; 5; 4] ]
     saddlePoints matrix |> should equal [(1, 2); (2, 2); (3, 2)]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can identify multiple saddle points in a row`` () =
     let matrix = 
         [ [6; 7; 8];
@@ -44,7 +44,7 @@ let ``Can identify multiple saddle points in a row`` () =
           [7; 5; 6] ]
     saddlePoints matrix |> should equal [(2, 1); (2, 2); (2, 3)]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can identify saddle point in bottom right corner`` () =
     let matrix = 
         [ [8; 7; 9];
@@ -52,14 +52,14 @@ let ``Can identify saddle point in bottom right corner`` () =
           [3; 2; 5] ]
     saddlePoints matrix |> should equal [(3, 3)]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can identify saddle points in a non square matrix`` () =
     let matrix = 
         [ [3; 1; 3];
           [3; 2; 4] ]
     saddlePoints matrix |> should equal [(1, 1); (1, 3)]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can identify that saddle points in a single column matrix are those with the minimum value`` () =
     let matrix = 
         [ [2];
@@ -68,7 +68,7 @@ let ``Can identify that saddle points in a single column matrix are those with t
           [1] ]
     saddlePoints matrix |> should equal [(2, 1); (4, 1)]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Can identify that saddle points in a single row matrix are those with the maximum value`` () =
     let matrix = [[2; 5; 3; 5]]
     saddlePoints matrix |> should equal [(1, 2); (1, 4)]

--- a/exercises/say/SayTests.fs
+++ b/exercises/say/SayTests.fs
@@ -11,59 +11,59 @@ open Say
 let ``Zero`` () =
     say 0L |> should equal (Some "zero")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One`` () =
     say 1L |> should equal (Some "one")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourteen`` () =
     say 14L |> should equal (Some "fourteen")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Twenty`` () =
     say 20L |> should equal (Some "twenty")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Twenty-two`` () =
     say 22L |> should equal (Some "twenty-two")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One hundred`` () =
     say 100L |> should equal (Some "one hundred")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One hundred twenty-three`` () =
     say 123L |> should equal (Some "one hundred twenty-three")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One thousand`` () =
     say 1000L |> should equal (Some "one thousand")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One thousand two hundred thirty-four`` () =
     say 1234L |> should equal (Some "one thousand two hundred thirty-four")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One million`` () =
     say 1000000L |> should equal (Some "one million")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One million two thousand three hundred forty-five`` () =
     say 1002345L |> should equal (Some "one million two thousand three hundred forty-five")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One billion`` () =
     say 1000000000L |> should equal (Some "one billion")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A big number`` () =
     say 987654321123L |> should equal (Some "nine hundred eighty-seven billion six hundred fifty-four million three hundred twenty-one thousand one hundred twenty-three")
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Numbers below zero are out of range`` () =
     say -1L |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Numbers above 999,999,999,999 are out of range`` () =
     say 1000000000000L |> should equal None
 

--- a/exercises/scale-generator/ScaleGeneratorTests.fs
+++ b/exercises/scale-generator/ScaleGeneratorTests.fs
@@ -11,67 +11,67 @@ open ScaleGenerator
 let ``Chromatic scale with sharps`` () =
     chromatic "C" |> should equal ["C"; "C#"; "D"; "D#"; "E"; "F"; "F#"; "G"; "G#"; "A"; "A#"; "B"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Chromatic scale with flats`` () =
     chromatic "F" |> should equal ["F"; "Gb"; "G"; "Ab"; "A"; "Bb"; "B"; "C"; "Db"; "D"; "Eb"; "E"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Simple major scale`` () =
     interval "MMmMMMm" "C" |> should equal ["C"; "D"; "E"; "F"; "G"; "A"; "B"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Major scale with sharps`` () =
     interval "MMmMMMm" "G" |> should equal ["G"; "A"; "B"; "C"; "D"; "E"; "F#"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Major scale with flats`` () =
     interval "MMmMMMm" "F" |> should equal ["F"; "G"; "A"; "Bb"; "C"; "D"; "E"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Minor scale with sharps`` () =
     interval "MmMMmMM" "f#" |> should equal ["F#"; "G#"; "A"; "B"; "C#"; "D"; "E"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Minor scale with flats`` () =
     interval "MmMMmMM" "bb" |> should equal ["Bb"; "C"; "Db"; "Eb"; "F"; "Gb"; "Ab"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Dorian mode`` () =
     interval "MmMMMmM" "d" |> should equal ["D"; "E"; "F"; "G"; "A"; "B"; "C"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Mixolydian mode`` () =
     interval "MMmMMmM" "Eb" |> should equal ["Eb"; "F"; "G"; "Ab"; "Bb"; "C"; "Db"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Lydian mode`` () =
     interval "MMMmMMm" "a" |> should equal ["A"; "B"; "C#"; "D#"; "E"; "F#"; "G#"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Phrygian mode`` () =
     interval "mMMMmMM" "e" |> should equal ["E"; "F"; "G"; "A"; "B"; "C"; "D"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Locrian mode`` () =
     interval "mMMmMMM" "g" |> should equal ["G"; "Ab"; "Bb"; "C"; "Db"; "Eb"; "F"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Harmonic minor`` () =
     interval "MmMMmAm" "d" |> should equal ["D"; "E"; "F"; "G"; "A"; "Bb"; "Db"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Octatonic`` () =
     interval "MmMmMmMm" "C" |> should equal ["C"; "D"; "D#"; "F"; "F#"; "G#"; "A"; "B"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Hexatonic`` () =
     interval "MMMMMM" "Db" |> should equal ["Db"; "Eb"; "F"; "G"; "A"; "B"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Pentatonic`` () =
     interval "MMAMA" "A" |> should equal ["A"; "B"; "C#"; "E"; "F#"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Enigmatic`` () =
     interval "mAMMMmm" "G" |> should equal ["G"; "G#"; "B"; "C#"; "D#"; "F"; "F#"]
 

--- a/exercises/scrabble-score/ScrabbleScoreTests.fs
+++ b/exercises/scrabble-score/ScrabbleScoreTests.fs
@@ -11,43 +11,43 @@ open ScrabbleScore
 let ``Lowercase letter`` () =
     score "a" |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Uppercase letter`` () =
     score "A" |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Valuable letter`` () =
     score "f" |> should equal 4
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Short word`` () =
     score "at" |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Short, valuable word`` () =
     score "zoo" |> should equal 12
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Medium word`` () =
     score "street" |> should equal 6
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Medium, valuable word`` () =
     score "quirky" |> should equal 22
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Long, mixed-case word`` () =
     score "OxyphenButazone" |> should equal 41
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``English-like word`` () =
     score "pinata" |> should equal 8
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Empty input`` () =
     score "" |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Entire alphabet available`` () =
     score "abcdefghijklmnopqrstuvwxyz" |> should equal 87
 

--- a/exercises/secret-handshake/SecretHandshakeTests.fs
+++ b/exercises/secret-handshake/SecretHandshakeTests.fs
@@ -11,43 +11,43 @@ open SecretHandshake
 let ``Wink for 1`` () =
     commands 1 |> should equal ["wink"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Double blink for 10`` () =
     commands 2 |> should equal ["double blink"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Close your eyes for 100`` () =
     commands 4 |> should equal ["close your eyes"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Jump for 1000`` () =
     commands 8 |> should equal ["jump"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Combine two actions`` () =
     commands 3 |> should equal ["wink"; "double blink"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reverse two actions`` () =
     commands 19 |> should equal ["double blink"; "wink"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reversing one action gives the same action`` () =
     commands 24 |> should equal ["jump"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reversing no actions still gives no actions`` () =
     commands 16 |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``All possible actions`` () =
     commands 15 |> should equal ["wink"; "double blink"; "close your eyes"; "jump"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reverse all possible actions`` () =
     commands 31 |> should equal ["jump"; "close your eyes"; "double blink"; "wink"]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Do nothing for zero`` () =
     commands 0 |> should be Empty
 

--- a/exercises/series/SeriesTests.fs
+++ b/exercises/series/SeriesTests.fs
@@ -11,39 +11,39 @@ open Series
 let ``Slices of one from one`` () =
     slices "1" 1 |> should equal (Some ["1"])
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Slices of one from two`` () =
     slices "12" 1 |> should equal (Some ["1"; "2"])
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Slices of two`` () =
     slices "35" 2 |> should equal (Some ["35"])
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Slices of two overlap`` () =
     slices "9142" 2 |> should equal (Some ["91"; "14"; "42"])
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Slices can include duplicates`` () =
     slices "777777" 3 |> should equal (Some ["777"; "777"; "777"; "777"])
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Slices of a long series`` () =
     slices "918493904243" 5 |> should equal (Some ["91849"; "18493"; "84939"; "49390"; "93904"; "39042"; "90424"; "04243"])
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Slice length is too large`` () =
     slices "12345" 6 |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Slice length cannot be zero`` () =
     slices "12345" 0 |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Slice length cannot be negative`` () =
     slices "123" -1 |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Empty series is invalid`` () =
     slices "" 1 |> should equal None
 

--- a/exercises/sgf-parsing/SgfParsingTests.fs
+++ b/exercises/sgf-parsing/SgfParsingTests.fs
@@ -12,62 +12,62 @@ let ``Empty input`` () =
     let expected = None
     parse "" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Tree with no nodes`` () =
     let expected = None
     parse "()" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Node without tree`` () =
     let expected = None
     parse ";" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Node without properties`` () =
     let expected = Some (Node (Map.ofList [], []))
     parse "(;)" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Single node tree`` () =
     let expected = Some (Node (Map.ofList [("A", ["B"])], []))
     parse "(;A[B])" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple properties`` () =
     let expected = Some (Node (Map.ofList [("A", ["b"]); ("C", ["d"])], []))
     parse "(;A[b]C[d])" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Properties without delimiter`` () =
     let expected = None
     parse "(;A)" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``All lowercase property`` () =
     let expected = None
     parse "(;a[b])" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Upper and lowercase property`` () =
     let expected = None
     parse "(;Aa[b])" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two nodes`` () =
     let expected = Some (Node (Map.ofList [("A", ["B"])], [Node (Map.ofList [("B", ["C"])], [])]))
     parse "(;A[B];B[C])" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two child trees`` () =
     let expected = Some (Node (Map.ofList [("A", ["B"])], [Node (Map.ofList [("B", ["C"])], []); Node (Map.ofList [("C", ["D"])], [])]))
     parse "(;A[B](;B[C])(;C[D]))" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple property values`` () =
     let expected = Some (Node (Map.ofList [("A", ["b"; "c"; "d"])], []))
     parse "(;A[b][c][d])" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Escaped property`` () =
     let expected = Some (Node (Map.ofList [("A", ["]b\nc\nd  e \n]"])], []))
     parse "(;A[\]b\nc\nd\t\te \n\]])" |> should equal expected

--- a/exercises/sieve/SieveTests.fs
+++ b/exercises/sieve/SieveTests.fs
@@ -11,19 +11,19 @@ open Sieve
 let ``No primes under two`` () =
     primes 1 |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Find first prime`` () =
     primes 2 |> should equal [2]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Find primes up to 10`` () =
     primes 10 |> should equal [2; 3; 5; 7]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Limit is prime`` () =
     primes 13 |> should equal [2; 3; 5; 7; 11; 13]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Find primes up to 1000`` () =
     primes 1000 |> should equal [2; 3; 5; 7; 11; 13; 17; 19; 23; 29; 31; 37; 41; 43; 47; 53; 59; 61; 67; 71; 73; 79; 83; 89; 97; 101; 103; 107; 109; 113; 127; 131; 137; 139; 149; 151; 157; 163; 167; 173; 179; 181; 191; 193; 197; 199; 211; 223; 227; 229; 233; 239; 241; 251; 257; 263; 269; 271; 277; 281; 283; 293; 307; 311; 313; 317; 331; 337; 347; 349; 353; 359; 367; 373; 379; 383; 389; 397; 401; 409; 419; 421; 431; 433; 439; 443; 449; 457; 461; 463; 467; 479; 487; 491; 499; 503; 509; 521; 523; 541; 547; 557; 563; 569; 571; 577; 587; 593; 599; 601; 607; 613; 617; 619; 631; 641; 643; 647; 653; 659; 661; 673; 677; 683; 691; 701; 709; 719; 727; 733; 739; 743; 751; 757; 761; 769; 773; 787; 797; 809; 811; 821; 823; 827; 829; 839; 853; 857; 859; 863; 877; 881; 883; 887; 907; 911; 919; 929; 937; 941; 947; 953; 967; 971; 977; 983; 991; 997]
 

--- a/exercises/simple-cipher/SimpleCipherTests.fs
+++ b/exercises/simple-cipher/SimpleCipherTests.fs
@@ -14,57 +14,57 @@ let ``Random key cipher - Can encode`` () =
     let sut = SimpleCipher()
     sut.Encode("aaaaaaaaaa") |> should equal sut.Key.[0..9]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Random key cipher - Can decode`` () =
     let sut = SimpleCipher()
     sut.Decode(sut.Key.[0..9]) |> should equal "aaaaaaaaaa"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Random key cipher - Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method`` () =
     let sut = SimpleCipher()
     sut.Decode(sut.Encode("abcdefghij")) |> should equal "abcdefghij"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Random key cipher - Key is made only of lowercase letters`` () =
     let sut = SimpleCipher()
     Regex.IsMatch(sut.Key, "^[a-z]+$") |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Substitution cipher - Can encode`` () =
     let sut = SimpleCipher("abcdefghij")
     sut.Encode("aaaaaaaaaa") |> should equal "abcdefghij"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Substitution cipher - Can decode`` () =
     let sut = SimpleCipher("abcdefghij")
     sut.Decode("abcdefghij") |> should equal "aaaaaaaaaa"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Substitution cipher - Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method`` () =
     let sut = SimpleCipher("abcdefghij")
     sut.Decode(sut.Encode("abcdefghij")) |> should equal "abcdefghij"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Substitution cipher - Can double shift encode`` () =
     let sut = SimpleCipher("iamapandabear")
     sut.Encode("iamapandabear") |> should equal "qayaeaagaciai"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Substitution cipher - Can wrap on encode`` () =
     let sut = SimpleCipher("abcdefghij")
     sut.Encode("zzzzzzzzzz") |> should equal "zabcdefghi"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Substitution cipher - Can wrap on decode`` () =
     let sut = SimpleCipher("abcdefghij")
     sut.Decode("zabcdefghi") |> should equal "zzzzzzzzzz"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Substitution cipher - Can encode messages longer than the key`` () =
     let sut = SimpleCipher("abc")
     sut.Encode("iamapandabear") |> should equal "iboaqcnecbfcr"
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Substitution cipher - Can decode messages longer than the key`` () =
     let sut = SimpleCipher("abc")
     sut.Decode("iboaqcnecbfcr") |> should equal "iamapandabear"

--- a/exercises/simple-linked-list/SimpleLinkedListTests.fs
+++ b/exercises/simple-linked-list/SimpleLinkedListTests.fs
@@ -12,37 +12,37 @@ let ``Empty list`` () =
     let list = nil
     isNil list |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Single item list value`` () =
     let list = create 1 nil
     datum list |> should equal 1
         
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Single item list has no next item`` () =
     let list = create 1 nil
     next list |> isNil |> should equal true
         
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two item list first value`` () =
     let list = create 2 (create 1 nil)
     datum list |> should equal 2
     
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two item list second value`` () =
     let list = create 2 (create 1 nil)
     next list |> datum |> should equal 1
     
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two item list second item has no next`` () =
     let list = create 2 (create 1 nil)
     next list |> next |> isNil |> should equal true
         
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``To list`` () =
     let values = create 2 (create 1 nil) |> toList
     values |> should equal [2; 1]
         
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``From list`` () =
     let list = fromList [11; 7; 5; 3; 2]
     list |> datum |> should equal 11
@@ -51,7 +51,7 @@ let ``From list`` () =
     list |> next |> next |> next |> datum |> should equal 3
     list |> next |> next |> next |> next |> datum |> should equal 2
 
-[<Theory(Skip = "Remove to run test")>]
+[<Theory(Skip = "Remove this Skip property to run this test")>]
 [<InlineData(1)>]
 [<InlineData(2)>]
 [<InlineData(10)>]
@@ -62,7 +62,7 @@ let ``Reverse`` (length: int) =
     let reversed = reverse list
     reversed |> toList |> should equal <| List.rev values 
     
-[<Theory(Skip = "Remove to run test")>]
+[<Theory(Skip = "Remove this Skip property to run this test")>]
 [<InlineData(1)>]
 [<InlineData(2)>]
 [<InlineData(10)>]

--- a/exercises/space-age/SpaceAgeTests.fs
+++ b/exercises/space-age/SpaceAgeTests.fs
@@ -11,31 +11,31 @@ open SpaceAge
 let ``Age on Earth`` () =
     age Earth 1000000000L |> should (equalWithin 0.01) 31.69
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Age on Mercury`` () =
     age Mercury 2134835688L |> should (equalWithin 0.01) 280.88
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Age on Venus`` () =
     age Venus 189839836L |> should (equalWithin 0.01) 9.78
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Age on Mars`` () =
     age Mars 2129871239L |> should (equalWithin 0.01) 35.88
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Age on Jupiter`` () =
     age Jupiter 901876382L |> should (equalWithin 0.01) 2.41
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Age on Saturn`` () =
     age Saturn 2000000000L |> should (equalWithin 0.01) 2.15
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Age on Uranus`` () =
     age Uranus 1210123456L |> should (equalWithin 0.01) 0.46
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Age on Neptune`` () =
     age Neptune 1821023456L |> should (equalWithin 0.01) 0.35
 

--- a/exercises/spiral-matrix/SpiralMatrixTests.fs
+++ b/exercises/spiral-matrix/SpiralMatrixTests.fs
@@ -11,24 +11,24 @@ open SpiralMatrix
 let ``Empty spiral`` () =
     spiralMatrix 0 |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Trivial spiral`` () =
     spiralMatrix 1 |> should equal [[1]]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Spiral of size 2`` () =
     spiralMatrix 2 |> should equal 
         [ [1; 2];
           [4; 3] ]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Spiral of size 3`` () =
     spiralMatrix 3 |> should equal 
         [ [1; 2; 3];
           [8; 9; 4];
           [7; 6; 5] ]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Spiral of size 4`` () =
     spiralMatrix 4 |> should equal 
         [ [1; 2; 3; 4];
@@ -36,7 +36,7 @@ let ``Spiral of size 4`` () =
           [11; 16; 15; 6];
           [10; 9; 8; 7] ]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Spiral of size 5`` () =
     spiralMatrix 5 |> should equal 
         [ [1; 2; 3; 4; 5];

--- a/exercises/strain/StrainTests.fs
+++ b/exercises/strain/StrainTests.fs
@@ -10,24 +10,24 @@ open FsUnit.Xunit
 let ``Empty keep`` () =
     [] |> Seq.keep (fun x -> x < 10) |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]  
+[<Fact(Skip = "Remove this Skip property to run this test")>]  
 let ``Keep everything`` () =
     set [1; 2; 3] |> Seq.keep (fun x -> x < 10) |> Seq.toList |> should equal <| [1; 2; 3]
 
-[<Fact(Skip = "Remove to run test")>] 
+[<Fact(Skip = "Remove this Skip property to run this test")>] 
 let ``Keep first and last`` () =
     [|1; 2; 3|] |> Seq.keep (fun x -> x % 2 <> 0) |> Seq.toList |> should equal [1; 3]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Keep neither first nor last`` () =
     [1; 2; 3; 4; 5] |> Seq.keep (fun x -> x % 2 = 0) |> Seq.toList |> should equal [2; 4]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Keep strings`` () =
     let words = "apple zebra banana zombies cherimoya zelot".Split(' ');
     words |> Seq.keep (fun (x:string) -> x.StartsWith("z")) |> Seq.toList |> should equal <| List.ofArray("zebra zombies zelot".Split(' '))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Keep arrays`` () =
     let actual = [|
                     [|1; 2; 3|];
@@ -41,28 +41,28 @@ let ``Keep arrays`` () =
     let expected = [ [|5; 5; 5|]; [|5; 1; 2|]; [|1; 5; 2|]; [|1; 2; 5|] ]
     actual |> Seq.keep (Array.exists ((=) 5)) |> Seq.toList |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Empty discard`` () =
     [] |> Seq.discard (fun x -> x < 10) |> should be Empty
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Discard nothing`` () =
     set [1; 2; 3] |> Seq.discard (fun x -> x > 10) |> Seq.toList |> should equal <| [1; 2; 3]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Discard first and last`` () =
     [|1; 2; 3|] |> Seq.discard (fun x -> x % 2 <> 0) |> Seq.toList |> should equal [2]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Discard neither first nor last`` () =
     [1; 2; 3; 4; 5] |> Seq.discard (fun x -> x % 2 = 0) |> Seq.toList |> should equal [1; 3; 5]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Discard strings`` () =
     let words = "apple zebra banana zombies cherimoya zelot".Split(' ')
     words |> Seq.discard (fun (x:string) -> x.StartsWith("z")) |> Seq.toList |> should equal <| List.ofArray("apple banana cherimoya".Split(' '))
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Discard arrays`` () =
     let actual = [|
                     [|1; 2; 3|];

--- a/exercises/sublist/SublistTests.fs
+++ b/exercises/sublist/SublistTests.fs
@@ -13,97 +13,97 @@ let ``Empty lists`` () =
     let listTwo = []
     sublist listOne listTwo |> should equal SublistType.Equal
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Empty list within non empty list`` () =
     let listOne = []
     let listTwo = [1; 2; 3]
     sublist listOne listTwo |> should equal SublistType.Sublist
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Non empty list contains empty list`` () =
     let listOne = [1; 2; 3]
     let listTwo = []
     sublist listOne listTwo |> should equal SublistType.Superlist
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``List equals itself`` () =
     let listOne = [1; 2; 3]
     let listTwo = [1; 2; 3]
     sublist listOne listTwo |> should equal SublistType.Equal
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Different lists`` () =
     let listOne = [1; 2; 3]
     let listTwo = [2; 3; 4]
     sublist listOne listTwo |> should equal SublistType.Unequal
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``False start`` () =
     let listOne = [1; 2; 5]
     let listTwo = [0; 1; 2; 3; 1; 2; 5; 6]
     sublist listOne listTwo |> should equal SublistType.Sublist
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Consecutive`` () =
     let listOne = [1; 1; 2]
     let listTwo = [0; 1; 1; 1; 2; 1; 2]
     sublist listOne listTwo |> should equal SublistType.Sublist
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sublist at start`` () =
     let listOne = [0; 1; 2]
     let listTwo = [0; 1; 2; 3; 4; 5]
     sublist listOne listTwo |> should equal SublistType.Sublist
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sublist in middle`` () =
     let listOne = [2; 3; 4]
     let listTwo = [0; 1; 2; 3; 4; 5]
     sublist listOne listTwo |> should equal SublistType.Sublist
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sublist at end`` () =
     let listOne = [3; 4; 5]
     let listTwo = [0; 1; 2; 3; 4; 5]
     sublist listOne listTwo |> should equal SublistType.Sublist
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``At start of superlist`` () =
     let listOne = [0; 1; 2; 3; 4; 5]
     let listTwo = [0; 1; 2]
     sublist listOne listTwo |> should equal SublistType.Superlist
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``In middle of superlist`` () =
     let listOne = [0; 1; 2; 3; 4; 5]
     let listTwo = [2; 3]
     sublist listOne listTwo |> should equal SublistType.Superlist
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``At end of superlist`` () =
     let listOne = [0; 1; 2; 3; 4; 5]
     let listTwo = [3; 4; 5]
     sublist listOne listTwo |> should equal SublistType.Superlist
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First list missing element from second list`` () =
     let listOne = [1; 3]
     let listTwo = [1; 2; 3]
     sublist listOne listTwo |> should equal SublistType.Unequal
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second list missing element from first list`` () =
     let listOne = [1; 2; 3]
     let listTwo = [1; 3]
     sublist listOne listTwo |> should equal SublistType.Unequal
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Order matters to a list`` () =
     let listOne = [1; 2; 3]
     let listTwo = [3; 2; 1]
     sublist listOne listTwo |> should equal SublistType.Unequal
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Same digits but different numbers`` () =
     let listOne = [1; 0; 1]
     let listTwo = [10; 1]

--- a/exercises/sum-of-multiples/SumOfMultiplesTests.fs
+++ b/exercises/sum-of-multiples/SumOfMultiplesTests.fs
@@ -11,63 +11,63 @@ open SumOfMultiples
 let ``No multiples within limit`` () =
     sum [3; 5] 1 |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One factor has multiples within limit`` () =
     sum [3; 5] 4 |> should equal 3
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``More than one multiple within limit`` () =
     sum [3] 7 |> should equal 9
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``More than one factor with multiples within limit`` () =
     sum [3; 5] 10 |> should equal 23
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Each multiple is only counted once`` () =
     sum [3; 5] 100 |> should equal 2318
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A much larger limit`` () =
     sum [3; 5] 1000 |> should equal 233168
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Three factors`` () =
     sum [7; 13; 17] 20 |> should equal 51
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Factors not relatively prime`` () =
     sum [4; 6] 15 |> should equal 30
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Some pairs of factors relatively prime and some not`` () =
     sum [5; 6; 8] 150 |> should equal 4419
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One factor is a multiple of another`` () =
     sum [5; 25] 51 |> should equal 275
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Much larger factors`` () =
     sum [43; 47] 10000 |> should equal 2203160
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``All numbers are multiples of 1`` () =
     sum [1] 100 |> should equal 4950
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``No factors means an empty sum`` () =
     sum [] 10000 |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The only multiple of 0 is 0`` () =
     sum [0] 1 |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``The factor 0 does not affect the sum of multiples of other factors`` () =
     sum [3; 0] 4 |> should equal 3
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Solutions using include-exclude must extend to cardinality greater than 3`` () =
     sum [2; 3; 5; 7; 11] 10000 |> should equal 39614537
 

--- a/exercises/tournament/TournamentTests.fs
+++ b/exercises/tournament/TournamentTests.fs
@@ -13,7 +13,7 @@ let ``Just the header if no input`` () =
     let expected = ["Team                           | MP |  W |  D |  L |  P"]
     tally rows |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A win is three points, a loss is zero points`` () =
     let rows = ["Allegoric Alaskans;Blithering Badgers;win"]
     let expected = 
@@ -22,7 +22,7 @@ let ``A win is three points, a loss is zero points`` () =
           "Blithering Badgers             |  1 |  0 |  0 |  1 |  0" ]
     tally rows |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A win can also be expressed as a loss`` () =
     let rows = ["Blithering Badgers;Allegoric Alaskans;loss"]
     let expected = 
@@ -31,7 +31,7 @@ let ``A win can also be expressed as a loss`` () =
           "Blithering Badgers             |  1 |  0 |  0 |  1 |  0" ]
     tally rows |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A different team can win`` () =
     let rows = ["Blithering Badgers;Allegoric Alaskans;win"]
     let expected = 
@@ -40,7 +40,7 @@ let ``A different team can win`` () =
           "Allegoric Alaskans             |  1 |  0 |  0 |  1 |  0" ]
     tally rows |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A draw is one point each`` () =
     let rows = ["Allegoric Alaskans;Blithering Badgers;draw"]
     let expected = 
@@ -49,7 +49,7 @@ let ``A draw is one point each`` () =
           "Blithering Badgers             |  1 |  0 |  1 |  0 |  1" ]
     tally rows |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``There can be more than one match`` () =
     let rows = 
         [ "Allegoric Alaskans;Blithering Badgers;win";
@@ -60,7 +60,7 @@ let ``There can be more than one match`` () =
           "Blithering Badgers             |  2 |  0 |  0 |  2 |  0" ]
     tally rows |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``There can be more than one winner`` () =
     let rows = 
         [ "Allegoric Alaskans;Blithering Badgers;loss";
@@ -71,7 +71,7 @@ let ``There can be more than one winner`` () =
           "Blithering Badgers             |  2 |  1 |  0 |  1 |  3" ]
     tally rows |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``There can be more than two teams`` () =
     let rows = 
         [ "Allegoric Alaskans;Blithering Badgers;win";
@@ -84,7 +84,7 @@ let ``There can be more than two teams`` () =
           "Courageous Californians        |  2 |  0 |  0 |  2 |  0" ]
     tally rows |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Typical input`` () =
     let rows = 
         [ "Allegoric Alaskans;Blithering Badgers;win";
@@ -101,7 +101,7 @@ let ``Typical input`` () =
           "Courageous Californians        |  3 |  0 |  1 |  2 |  1" ]
     tally rows |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Incomplete competition (not all pairs have played)`` () =
     let rows = 
         [ "Allegoric Alaskans;Blithering Badgers;loss";
@@ -116,7 +116,7 @@ let ``Incomplete competition (not all pairs have played)`` () =
           "Devastating Donkeys            |  1 |  0 |  0 |  1 |  0" ]
     tally rows |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ties broken alphabetically`` () =
     let rows = 
         [ "Courageous Californians;Devastating Donkeys;win";

--- a/exercises/transpose/TransposeTests.fs
+++ b/exercises/transpose/TransposeTests.fs
@@ -13,7 +13,7 @@ let ``Empty string`` () =
     let expected: string list = []
     transpose lines |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two characters in a row`` () =
     let lines = ["A1"]
     let expected = 
@@ -21,7 +21,7 @@ let ``Two characters in a row`` () =
           "1" ]
     transpose lines |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two characters in a column`` () =
     let lines = 
         [ "A";
@@ -29,7 +29,7 @@ let ``Two characters in a column`` () =
     let expected = ["A1"]
     transpose lines |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Simple`` () =
     let lines = 
         [ "ABC";
@@ -40,7 +40,7 @@ let ``Simple`` () =
           "C3" ]
     transpose lines |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Single line`` () =
     let lines = ["Single line."]
     let expected = 
@@ -58,7 +58,7 @@ let ``Single line`` () =
           "." ]
     transpose lines |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``First line longer than second line`` () =
     let lines = 
         [ "The fourth line.";
@@ -82,7 +82,7 @@ let ``First line longer than second line`` () =
           "." ]
     transpose lines |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second line longer than first line`` () =
     let lines = 
         [ "The first line.";
@@ -106,7 +106,7 @@ let ``Second line longer than first line`` () =
           " ." ]
     transpose lines |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Mixed line length`` () =
     let lines = 
         [ "The longest line.";
@@ -133,7 +133,7 @@ let ``Mixed line length`` () =
           "." ]
     transpose lines |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Square`` () =
     let lines = 
         [ "HEART";
@@ -149,7 +149,7 @@ let ``Square`` () =
           "TREND" ]
     transpose lines |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Rectangle`` () =
     let lines = 
         [ "FRACTURE";
@@ -167,7 +167,7 @@ let ``Rectangle`` () =
           "EDGE" ]
     transpose lines |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Triangle`` () =
     let lines = 
         [ "T";

--- a/exercises/triangle/TriangleTests.fs
+++ b/exercises/triangle/TriangleTests.fs
@@ -11,75 +11,75 @@ open Triangle
 let ``Equilateral returns all sides are equal`` () =
     equilateral [2.0; 2.0; 2.0] |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Equilateral returns any side is unequal`` () =
     equilateral [2.0; 3.0; 2.0] |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Equilateral returns no sides are equal`` () =
     equilateral [5.0; 4.0; 6.0] |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Equilateral returns all zero sides is not a triangle`` () =
     equilateral [0.0; 0.0; 0.0] |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Equilateral returns sides may be floats`` () =
     equilateral [0.5; 0.5; 0.5] |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Isosceles returns last two sides are equal`` () =
     isosceles [3.0; 4.0; 4.0] |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Isosceles returns first two sides are equal`` () =
     isosceles [4.0; 4.0; 3.0] |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Isosceles returns first and last sides are equal`` () =
     isosceles [4.0; 3.0; 4.0] |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Equilateral triangles are also isosceles`` () =
     isosceles [4.0; 4.0; 4.0] |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Isosceles returns no sides are equal`` () =
     isosceles [2.0; 3.0; 4.0] |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Isosceles returns first triangle inequality violation`` () =
     isosceles [1.0; 1.0; 3.0] |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Isosceles returns second triangle inequality violation`` () =
     isosceles [1.0; 3.0; 1.0] |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Isosceles returns third triangle inequality violation`` () =
     isosceles [3.0; 1.0; 1.0] |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Isosceles returns sides may be floats`` () =
     isosceles [0.5; 0.4; 0.5] |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Scalene returns no sides are equal`` () =
     scalene [5.0; 4.0; 6.0] |> should equal true
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Scalene returns all sides are equal`` () =
     scalene [4.0; 4.0; 4.0] |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Scalene returns two sides are equal`` () =
     scalene [4.0; 4.0; 3.0] |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Scalene returns may not violate triangle inequality`` () =
     scalene [7.0; 3.0; 2.0] |> should equal false
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Scalene returns sides may be floats`` () =
     scalene [0.5; 0.4; 0.6] |> should equal true
 

--- a/exercises/trinary/TrinaryTests.fs
+++ b/exercises/trinary/TrinaryTests.fs
@@ -11,43 +11,43 @@ open Trinary
 let ``Trinary_1_is_decimal_1`` () =
     toDecimal "1" |> should equal 1
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Trinary_2_is_decimal_2`` () =
     toDecimal "2" |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Trinary_10_is_decimal_3`` () =
     toDecimal "10" |> should equal 3
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Trinary_11_is_decimal_4`` () =
     toDecimal "11" |> should equal 4
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Trinary_100_is_decimal_9`` () =
     toDecimal "100" |> should equal 9
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Trinary_112_is_decimal_14`` () =
     toDecimal "112" |> should equal 14
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Trinary_222_is_decimal_26`` () =
     toDecimal "222" |> should equal 26
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Trinary_1122000120_is_decimal_32091`` () =
     toDecimal "1122000120" |> should equal 32091
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid_trinary_digits_returns_0`` () =
     toDecimal "1234" |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid_word_as_input_returns_0`` () =
     toDecimal "carrot" |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Invalid_numbers_with_letters_as_input_returns_0`` () =
     toDecimal "0a1b2c" |> should equal 0
 

--- a/exercises/twelve-days/TwelveDaysTests.fs
+++ b/exercises/twelve-days/TwelveDaysTests.fs
@@ -12,62 +12,62 @@ let ``First day a partridge in a pear tree`` () =
     let expected = ["On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree."]
     recite 1 1 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Second day two turtle doves`` () =
     let expected = ["On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree."]
     recite 2 2 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Third day three french hens`` () =
     let expected = ["On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."]
     recite 3 3 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fourth day four calling birds`` () =
     let expected = ["On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."]
     recite 4 4 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fifth day five gold rings`` () =
     let expected = ["On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."]
     recite 5 5 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sixth day six geese-a-laying`` () =
     let expected = ["On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."]
     recite 6 6 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Seventh day seven swans-a-swimming`` () =
     let expected = ["On the seventh day of Christmas my true love gave to me: seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."]
     recite 7 7 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Eighth day eight maids-a-milking`` () =
     let expected = ["On the eighth day of Christmas my true love gave to me: eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."]
     recite 8 8 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ninth day nine ladies dancing`` () =
     let expected = ["On the ninth day of Christmas my true love gave to me: nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."]
     recite 9 9 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Tenth day ten lords-a-leaping`` () =
     let expected = ["On the tenth day of Christmas my true love gave to me: ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."]
     recite 10 10 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Eleventh day eleven pipers piping`` () =
     let expected = ["On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."]
     recite 11 11 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Twelfth day twelve drummers drumming`` () =
     let expected = ["On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."]
     recite 12 12 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Recites first three verses of the song`` () =
     let expected = 
         [ "On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree.";
@@ -75,7 +75,7 @@ let ``Recites first three verses of the song`` () =
           "On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree." ]
     recite 1 3 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Recites three verses from the middle of the song`` () =
     let expected = 
         [ "On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.";
@@ -83,7 +83,7 @@ let ``Recites three verses from the middle of the song`` () =
           "On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree." ]
     recite 4 6 |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Recites the whole song`` () =
     let expected = 
         [ "On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree.";

--- a/exercises/two-bucket/TwoBucketTests.fs
+++ b/exercises/two-bucket/TwoBucketTests.fs
@@ -16,7 +16,7 @@ let ``Measure using bucket one of size 3 and bucket two of size 5 - start with b
     let expected = { Moves = 4; GoalBucket = Bucket.One; OtherBucket = 5 }
     measure bucketOne bucketTwo goal startBucket |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two`` () =
     let bucketOne = 3
     let bucketTwo = 5
@@ -25,7 +25,7 @@ let ``Measure using bucket one of size 3 and bucket two of size 5 - start with b
     let expected = { Moves = 8; GoalBucket = Bucket.Two; OtherBucket = 3 }
     measure bucketOne bucketTwo goal startBucket |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one`` () =
     let bucketOne = 7
     let bucketTwo = 11
@@ -34,7 +34,7 @@ let ``Measure using bucket one of size 7 and bucket two of size 11 - start with 
     let expected = { Moves = 14; GoalBucket = Bucket.One; OtherBucket = 11 }
     measure bucketOne bucketTwo goal startBucket |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two`` () =
     let bucketOne = 7
     let bucketTwo = 11
@@ -43,7 +43,7 @@ let ``Measure using bucket one of size 7 and bucket two of size 11 - start with 
     let expected = { Moves = 18; GoalBucket = Bucket.Two; OtherBucket = 7 }
     measure bucketOne bucketTwo goal startBucket |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two`` () =
     let bucketOne = 1
     let bucketTwo = 3
@@ -52,7 +52,7 @@ let ``Measure one step using bucket one of size 1 and bucket two of size 3 - sta
     let expected = { Moves = 1; GoalBucket = Bucket.Two; OtherBucket = 0 }
     measure bucketOne bucketTwo goal startBucket |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two`` () =
     let bucketOne = 2
     let bucketTwo = 3

--- a/exercises/two-fer/TwoFerTests.fs
+++ b/exercises/two-fer/TwoFerTests.fs
@@ -11,11 +11,11 @@ open TwoFer
 let ``No name given`` () =
     twoFer None |> should equal "One for you, one for me."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``A name given`` () =
     twoFer (Some "Alice") |> should equal "One for Alice, one for me."
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Another name given`` () =
     twoFer (Some "Bob") |> should equal "One for Bob, one for me."
 

--- a/exercises/variable-length-quantity/VariableLengthQuantityTests.fs
+++ b/exercises/variable-length-quantity/VariableLengthQuantityTests.fs
@@ -11,103 +11,103 @@ open VariableLengthQuantity
 let ``Zero`` () =
     encode [0x0u] |> should equal [0x0uy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Arbitrary single byte`` () =
     encode [0x40u] |> should equal [0x40uy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Largest single byte`` () =
     encode [0x7fu] |> should equal [0x7fuy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Smallest double byte`` () =
     encode [0x80u] |> should equal [0x81uy; 0x0uy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Arbitrary double byte`` () =
     encode [0x2000u] |> should equal [0xc0uy; 0x0uy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Largest double byte`` () =
     encode [0x3fffu] |> should equal [0xffuy; 0x7fuy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Smallest triple byte`` () =
     encode [0x4000u] |> should equal [0x81uy; 0x80uy; 0x0uy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Arbitrary triple byte`` () =
     encode [0x100000u] |> should equal [0xc0uy; 0x80uy; 0x0uy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Largest triple byte`` () =
     encode [0x1fffffu] |> should equal [0xffuy; 0xffuy; 0x7fuy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Smallest quadruple byte`` () =
     encode [0x200000u] |> should equal [0x81uy; 0x80uy; 0x80uy; 0x0uy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Arbitrary quadruple byte`` () =
     encode [0x8000000u] |> should equal [0xc0uy; 0x80uy; 0x80uy; 0x0uy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Largest quadruple byte`` () =
     encode [0xfffffffu] |> should equal [0xffuy; 0xffuy; 0xffuy; 0x7fuy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Smallest quintuple byte`` () =
     encode [0x10000000u] |> should equal [0x81uy; 0x80uy; 0x80uy; 0x80uy; 0x0uy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Arbitrary quintuple byte`` () =
     encode [0xff000000u] |> should equal [0x8fuy; 0xf8uy; 0x80uy; 0x80uy; 0x0uy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Maximum 32-bit integer input`` () =
     encode [0xffffffffu] |> should equal [0x8fuy; 0xffuy; 0xffuy; 0xffuy; 0x7fuy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two single-byte values`` () =
     encode [0x40u; 0x7fu] |> should equal [0x40uy; 0x7fuy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two multi-byte values`` () =
     encode [0x4000u; 0x123456u] |> should equal [0x81uy; 0x80uy; 0x0uy; 0xc8uy; 0xe8uy; 0x56uy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Many multi-byte values`` () =
     encode [0x2000u; 0x123456u; 0xfffffffu; 0x0u; 0x3fffu; 0x4000u] |> should equal [0xc0uy; 0x0uy; 0xc8uy; 0xe8uy; 0x56uy; 0xffuy; 0xffuy; 0xffuy; 0x7fuy; 0x0uy; 0xffuy; 0x7fuy; 0x81uy; 0x80uy; 0x0uy]
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``One byte`` () =
     decode [0x7fuy] |> should equal (Some [0x7fu])
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two bytes`` () =
     decode [0xc0uy; 0x0uy] |> should equal (Some [0x2000u])
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Three bytes`` () =
     decode [0xffuy; 0xffuy; 0x7fuy] |> should equal (Some [0x1fffffu])
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Four bytes`` () =
     decode [0x81uy; 0x80uy; 0x80uy; 0x0uy] |> should equal (Some [0x200000u])
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Maximum 32-bit integer`` () =
     decode [0x8fuy; 0xffuy; 0xffuy; 0xffuy; 0x7fuy] |> should equal (Some [0xffffffffu])
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Incomplete sequence causes error`` () =
     decode [0xffuy] |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Incomplete sequence causes error, even if value is zero`` () =
     decode [0x80uy] |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple values`` () =
     decode [0xc0uy; 0x0uy; 0xc8uy; 0xe8uy; 0x56uy; 0xffuy; 0xffuy; 0xffuy; 0x7fuy; 0x0uy; 0xffuy; 0x7fuy; 0x81uy; 0x80uy; 0x0uy] |> should equal (Some [0x2000u; 0x123456u; 0xfffffffu; 0x0u; 0x3fffu; 0x4000u])
 

--- a/exercises/word-count/WordCountTests.fs
+++ b/exercises/word-count/WordCountTests.fs
@@ -12,7 +12,7 @@ let ``Count one word`` () =
     let expected = [("word", 1)] |> Map.ofList
     countWords "word" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Count one of each word`` () =
     let expected = 
         [ ("one", 1);
@@ -21,7 +21,7 @@ let ``Count one of each word`` () =
         |> Map.ofList
     countWords "one of each" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple occurrences of a word`` () =
     let expected = 
         [ ("one", 1);
@@ -32,7 +32,7 @@ let ``Multiple occurrences of a word`` () =
         |> Map.ofList
     countWords "one fish two fish red fish blue fish" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Handles cramped lists`` () =
     let expected = 
         [ ("one", 1);
@@ -41,7 +41,7 @@ let ``Handles cramped lists`` () =
         |> Map.ofList
     countWords "one,two,three" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Handles expanded lists`` () =
     let expected = 
         [ ("one", 1);
@@ -50,7 +50,7 @@ let ``Handles expanded lists`` () =
         |> Map.ofList
     countWords "one,\ntwo,\nthree" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ignore punctuation`` () =
     let expected = 
         [ ("car", 1);
@@ -61,7 +61,7 @@ let ``Ignore punctuation`` () =
         |> Map.ofList
     countWords "car: carpet as java: javascript!!&@$%^&" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Include numbers`` () =
     let expected = 
         [ ("testing", 2);
@@ -70,7 +70,7 @@ let ``Include numbers`` () =
         |> Map.ofList
     countWords "testing, 1, 2 testing" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Normalize case`` () =
     let expected = 
         [ ("go", 3);
@@ -78,7 +78,7 @@ let ``Normalize case`` () =
         |> Map.ofList
     countWords "go Go GO Stop stop" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``With apostrophes`` () =
     let expected = 
         [ ("first", 1);
@@ -89,7 +89,7 @@ let ``With apostrophes`` () =
         |> Map.ofList
     countWords "First: don't laugh. Then: don't cry." |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``With quotations`` () =
     let expected = 
         [ ("joe", 1);
@@ -101,7 +101,7 @@ let ``With quotations`` () =
         |> Map.ofList
     countWords "Joe can't tell between 'large' and large." |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Substrings from the beginning`` () =
     let expected = 
         [ ("joe", 1);
@@ -115,7 +115,7 @@ let ``Substrings from the beginning`` () =
         |> Map.ofList
     countWords "Joe can't tell between app, apple and a." |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple spaces not detected as a word`` () =
     let expected = 
         [ ("multiple", 1);
@@ -123,7 +123,7 @@ let ``Multiple spaces not detected as a word`` () =
         |> Map.ofList
     countWords " multiple   whitespaces" |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Alternating word separators not detected as a word`` () =
     let expected = 
         [ ("one", 1);

--- a/exercises/word-search/WordSearchTests.fs
+++ b/exercises/word-search/WordSearchTests.fs
@@ -14,35 +14,35 @@ let ``Should accept an initial game grid and a target search word`` () =
     let expected = [("clojure", Option<((int * int) * (int * int))>.None)] |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate one word written left to right`` () =
     let grid = ["clojurermt"]
     let wordsToSearchFor = ["clojure"]
     let expected = [("clojure", Some ((1, 1), (7, 1)))] |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate the same word written left to right in a different position`` () =
     let grid = ["mtclojurer"]
     let wordsToSearchFor = ["clojure"]
     let expected = [("clojure", Some ((3, 1), (9, 1)))] |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate a different left to right word`` () =
     let grid = ["coffeelplx"]
     let wordsToSearchFor = ["coffee"]
     let expected = [("coffee", Some ((1, 1), (6, 1)))] |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate that different left to right word in a different position`` () =
     let grid = ["xcoffeezlp"]
     let wordsToSearchFor = ["coffee"]
     let expected = [("coffee", Some ((2, 1), (7, 1)))] |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate a left to right word in two line grid`` () =
     let grid = 
         [ "jefblpepre";
@@ -51,7 +51,7 @@ let ``Should locate a left to right word in two line grid`` () =
     let expected = [("clojure", Some ((2, 2), (8, 2)))] |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate a left to right word in three line grid`` () =
     let grid = 
         [ "camdcimgtc";
@@ -61,7 +61,7 @@ let ``Should locate a left to right word in three line grid`` () =
     let expected = [("clojure", Some ((1, 3), (7, 3)))] |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate a left to right word in ten line grid`` () =
     let grid = 
         [ "jefblpepre";
@@ -78,7 +78,7 @@ let ``Should locate a left to right word in ten line grid`` () =
     let expected = [("clojure", Some ((1, 10), (7, 10)))] |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate that left to right word in a different position in a ten line grid`` () =
     let grid = 
         [ "jefblpepre";
@@ -95,7 +95,7 @@ let ``Should locate that left to right word in a different position in a ten lin
     let expected = [("clojure", Some ((1, 9), (7, 9)))] |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate a different left to right word in a ten line grid`` () =
     let grid = 
         [ "jefblpepre";
@@ -112,7 +112,7 @@ let ``Should locate a different left to right word in a ten line grid`` () =
     let expected = [("fortran", Some ((1, 7), (7, 7)))] |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate multiple words`` () =
     let grid = 
         [ "jefblpepre";
@@ -132,14 +132,14 @@ let ``Should locate multiple words`` () =
         |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate a single word written right to left`` () =
     let grid = ["rixilelhrs"]
     let wordsToSearchFor = ["elixir"]
     let expected = [("elixir", Some ((6, 1), (1, 1)))] |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate multiple words written in different horizontal directions`` () =
     let grid = 
         [ "jefblpepre";
@@ -159,7 +159,7 @@ let ``Should locate multiple words written in different horizontal directions`` 
         |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate words written top to bottom`` () =
     let grid = 
         [ "jefblpepre";
@@ -180,7 +180,7 @@ let ``Should locate words written top to bottom`` () =
         |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate words written bottom to top`` () =
     let grid = 
         [ "jefblpepre";
@@ -202,7 +202,7 @@ let ``Should locate words written bottom to top`` () =
         |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate words written top left to bottom right`` () =
     let grid = 
         [ "jefblpepre";
@@ -225,7 +225,7 @@ let ``Should locate words written top left to bottom right`` () =
         |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate words written bottom right to top left`` () =
     let grid = 
         [ "jefblpepre";
@@ -249,7 +249,7 @@ let ``Should locate words written bottom right to top left`` () =
         |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate words written bottom left to top right`` () =
     let grid = 
         [ "jefblpepre";
@@ -274,7 +274,7 @@ let ``Should locate words written bottom left to top right`` () =
         |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should locate words written top right to bottom left`` () =
     let grid = 
         [ "jefblpepre";
@@ -300,7 +300,7 @@ let ``Should locate words written top right to bottom left`` () =
         |> Map.ofList
     search grid wordsToSearchFor |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Should fail to locate a word that is not in the puzzle`` () =
     let grid = 
         [ "jefblpepre";

--- a/exercises/wordy/WordyTests.fs
+++ b/exercises/wordy/WordyTests.fs
@@ -11,91 +11,91 @@ open Wordy
 let ``Just a number`` () =
     answer "What is 5?" |> should equal (Some 5)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Addition`` () =
     answer "What is 1 plus 1?" |> should equal (Some 2)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``More addition`` () =
     answer "What is 53 plus 2?" |> should equal (Some 55)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Addition with negative numbers`` () =
     answer "What is -1 plus -10?" |> should equal (Some -11)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Large addition`` () =
     answer "What is 123 plus 45678?" |> should equal (Some 45801)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtraction`` () =
     answer "What is 4 minus -12?" |> should equal (Some 16)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiplication`` () =
     answer "What is -3 multiplied by 25?" |> should equal (Some -75)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Division`` () =
     answer "What is 33 divided by -3?" |> should equal (Some -11)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple additions`` () =
     answer "What is 1 plus 1 plus 1?" |> should equal (Some 3)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Addition and subtraction`` () =
     answer "What is 1 plus 5 minus -2?" |> should equal (Some 8)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple subtraction`` () =
     answer "What is 20 minus 4 minus 13?" |> should equal (Some 3)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Subtraction then addition`` () =
     answer "What is 17 minus 6 plus 3?" |> should equal (Some 14)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple multiplication`` () =
     answer "What is 2 multiplied by -2 multiplied by 3?" |> should equal (Some -12)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Addition and multiplication`` () =
     answer "What is -3 plus 7 multiplied by -2?" |> should equal (Some -8)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Multiple division`` () =
     answer "What is -12 divided by 2 divided by -3?" |> should equal (Some 2)
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Unknown operation`` () =
     answer "What is 52 cubed?" |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Non math question`` () =
     answer "Who is the President of the United States?" |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reject problem missing an operand`` () =
     answer "What is 1 plus?" |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reject problem with no operands or operators`` () =
     answer "What is?" |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reject two operations in a row`` () =
     answer "What is 1 plus plus 2?" |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reject two numbers in a row`` () =
     answer "What is 1 plus 2 1?" |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reject postfix notation`` () =
     answer "What is 1 2 plus?" |> should equal None
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Reject prefix notation`` () =
     answer "What is plus 1 2?" |> should equal None
 

--- a/exercises/yacht/YachtTests.fs
+++ b/exercises/yacht/YachtTests.fs
@@ -11,111 +11,111 @@ open Yacht
 let ``Yacht`` () =
     score Category.Yacht [Die.Five; Die.Five; Die.Five; Die.Five; Die.Five] |> should equal 50
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Not Yacht`` () =
     score Category.Yacht [Die.One; Die.Three; Die.Three; Die.Two; Die.Five] |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ones`` () =
     score Category.Ones [Die.One; Die.One; Die.One; Die.Three; Die.Five] |> should equal 3
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Ones, out of order`` () =
     score Category.Ones [Die.Three; Die.One; Die.One; Die.Five; Die.One] |> should equal 3
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``No ones`` () =
     score Category.Ones [Die.Four; Die.Three; Die.Six; Die.Five; Die.Five] |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Twos`` () =
     score Category.Twos [Die.Two; Die.Three; Die.Four; Die.Five; Die.Six] |> should equal 2
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Fours`` () =
     score Category.Fours [Die.One; Die.Four; Die.One; Die.Four; Die.One] |> should equal 8
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Yacht counted as threes`` () =
     score Category.Threes [Die.Three; Die.Three; Die.Three; Die.Three; Die.Three] |> should equal 15
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Yacht of 3s counted as fives`` () =
     score Category.Fives [Die.Three; Die.Three; Die.Three; Die.Three; Die.Three] |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Sixes`` () =
     score Category.Sixes [Die.Two; Die.Three; Die.Four; Die.Five; Die.Six] |> should equal 6
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Full house two small, three big`` () =
     score Category.FullHouse [Die.Two; Die.Two; Die.Four; Die.Four; Die.Four] |> should equal 16
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Full house three small, two big`` () =
     score Category.FullHouse [Die.Five; Die.Three; Die.Three; Die.Five; Die.Three] |> should equal 19
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Two pair is not a full house`` () =
     score Category.FullHouse [Die.Two; Die.Two; Die.Four; Die.Four; Die.Five] |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Four of a kind is not a full house`` () =
     score Category.FullHouse [Die.One; Die.Four; Die.Four; Die.Four; Die.Four] |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Yacht is not a full house`` () =
     score Category.FullHouse [Die.Two; Die.Two; Die.Two; Die.Two; Die.Two] |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Four of a Kind`` () =
     score Category.FourOfAKind [Die.Six; Die.Six; Die.Four; Die.Six; Die.Six] |> should equal 24
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Yacht can be scored as Four of a Kind`` () =
     score Category.FourOfAKind [Die.Three; Die.Three; Die.Three; Die.Three; Die.Three] |> should equal 12
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Full house is not Four of a Kind`` () =
     score Category.FourOfAKind [Die.Three; Die.Three; Die.Three; Die.Five; Die.Five] |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Little Straight`` () =
     score Category.LittleStraight [Die.Three; Die.Five; Die.Four; Die.One; Die.Two] |> should equal 30
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Little Straight as Big Straight`` () =
     score Category.BigStraight [Die.One; Die.Two; Die.Three; Die.Four; Die.Five] |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Four in order but not a little straight`` () =
     score Category.LittleStraight [Die.One; Die.One; Die.Two; Die.Three; Die.Four] |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``No pairs but not a little straight`` () =
     score Category.LittleStraight [Die.One; Die.Two; Die.Three; Die.Four; Die.Six] |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Minimum is 1, maximum is 5, but not a little straight`` () =
     score Category.LittleStraight [Die.One; Die.One; Die.Three; Die.Four; Die.Five] |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Big Straight`` () =
     score Category.BigStraight [Die.Four; Die.Six; Die.Two; Die.Five; Die.Three] |> should equal 30
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Big Straight as little straight`` () =
     score Category.LittleStraight [Die.Six; Die.Five; Die.Four; Die.Three; Die.Two] |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``No pairs but not a big straight`` () =
     score Category.BigStraight [Die.Six; Die.Five; Die.Four; Die.Three; Die.One] |> should equal 0
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Choice`` () =
     score Category.Choice [Die.Three; Die.Three; Die.Five; Die.Six; Die.Six] |> should equal 23
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Yacht as choice`` () =
     score Category.Choice [Die.Two; Die.Two; Die.Two; Die.Two; Die.Two] |> should equal 10
 

--- a/exercises/zebra-puzzle/ZebraPuzzleTests.fs
+++ b/exercises/zebra-puzzle/ZebraPuzzleTests.fs
@@ -11,7 +11,7 @@ open ZebraPuzzle
 let ``Resident who drinks water`` () =
     drinksWater |> should equal Norwegian
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Resident who owns zebra`` () =
     ownsZebra |> should equal Japanese
 

--- a/exercises/zipper/ZipperTests.fs
+++ b/exercises/zipper/ZipperTests.fs
@@ -17,84 +17,84 @@ let ``Data is retained`` () =
     let expected = tree 1 (subTree 2 None (leaf 3)) (leaf 4)
     sut |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Left, right and value`` () =
     let zipper = fromTree (tree 1 (subTree 2 None (leaf 3)) (leaf 4))
     let sut = zipper |> left |> Option.get |> right |> Option.get |> value
     let expected = 3
     sut |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Dead end`` () =
     let zipper = fromTree (tree 1 (subTree 2 None (leaf 3)) (leaf 4))
     let sut = zipper |> left |> Option.get |> left
     let expected = None
     sut |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Tree from deep focus`` () =
     let zipper = fromTree (tree 1 (subTree 2 None (leaf 3)) (leaf 4))
     let sut = zipper |> left |> Option.get |> right |> Option.get |> toTree
     let expected = tree 1 (subTree 2 None (leaf 3)) (leaf 4)
     sut |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Traversing up from top`` () =
     let zipper = fromTree (tree 1 (subTree 2 None (leaf 3)) (leaf 4))
     let sut = zipper |> up
     let expected = None
     sut |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Left, right, and up`` () =
     let zipper = fromTree (tree 1 (subTree 2 None (leaf 3)) (leaf 4))
     let sut = zipper |> left |> Option.get |> up |> Option.get |> right |> Option.get |> up |> Option.get |> left |> Option.get |> right |> Option.get |> value
     let expected = 3
     sut |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Set value`` () =
     let zipper = fromTree (tree 1 (subTree 2 None (leaf 3)) (leaf 4))
     let sut = zipper |> left |> Option.get |> setValue 5 |> toTree
     let expected = tree 1 (subTree 5 None (leaf 3)) (leaf 4)
     sut |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Set value after traversing up`` () =
     let zipper = fromTree (tree 1 (subTree 2 None (leaf 3)) (leaf 4))
     let sut = zipper |> left |> Option.get |> right |> Option.get |> up |> Option.get |> setValue 5 |> toTree
     let expected = tree 1 (subTree 5 None (leaf 3)) (leaf 4)
     sut |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Set left with leaf`` () =
     let zipper = fromTree (tree 1 (subTree 2 None (leaf 3)) (leaf 4))
     let sut = zipper |> left |> Option.get |> setLeft (Some (tree 5 None None)) |> toTree
     let expected = tree 1 (subTree 2 (leaf 5) (leaf 3)) (leaf 4)
     sut |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Set right with null`` () =
     let zipper = fromTree (tree 1 (subTree 2 None (leaf 3)) (leaf 4))
     let sut = zipper |> left |> Option.get |> setRight None |> toTree
     let expected = tree 1 (leaf 2) (leaf 4)
     sut |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Set right with subtree`` () =
     let zipper = fromTree (tree 1 (subTree 2 None (leaf 3)) (leaf 4))
     let sut = zipper |> setRight (Some (tree 6 (leaf 7) (leaf 8))) |> toTree
     let expected = tree 1 (subTree 2 None (leaf 3)) (subTree 6 (leaf 7) (leaf 8))
     sut |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Set value on deep focus`` () =
     let zipper = fromTree (tree 1 (subTree 2 None (leaf 3)) (leaf 4))
     let sut = zipper |> left |> Option.get |> right |> Option.get |> setValue 5 |> toTree
     let expected = tree 1 (subTree 2 None (leaf 5)) (leaf 4)
     sut |> should equal expected
 
-[<Fact(Skip = "Remove to run test")>]
+[<Fact(Skip = "Remove this Skip property to run this test")>]
 let ``Different paths to same zipper`` () =
     let zipper = fromTree (tree 1 (subTree 2 None (leaf 3)) (leaf 4))
     let sut = zipper |> left |> Option.get |> up |> Option.get |> right

--- a/generators/Templates/_TestFunction.liquid
+++ b/generators/Templates/_TestFunction.liquid
@@ -1,3 +1,3 @@
-[<Fact{% if Skip %}(Skip = "Remove to run test"){% endif %}>]
+[<Fact{% if Skip %}(Skip = "Remove this Skip property to run this test"){% endif %}>]
 let ``{{ Name }}`` () =
 {{ Body }}

--- a/generators/Templates/_TestMember.liquid
+++ b/generators/Templates/_TestMember.liquid
@@ -1,3 +1,3 @@
-[<Fact{% if Skip %}(Skip = "Remove to run test"){% endif %}>]
+[<Fact{% if Skip %}(Skip = "Remove this Skip property to run this test"){% endif %}>]
     member this.``{{ Name }}`` () =
 {{ Body }}

--- a/test.ps1
+++ b/test.ps1
@@ -52,7 +52,7 @@ function Copy-Exercises {
 function Enable-All-Tests {
     Write-Output "Enabling all tests"
     Get-ChildItem -Path $buildDir -Include "*Tests.fs" -Recurse | ForEach-Object {
-        (Get-Content $_.FullName) -replace "Skip = ""Remove to run test""", "" | Set-Content $_.FullName
+        (Get-Content $_.FullName) -replace "Skip = ""Remove this Skip property to run this test""", "" | Set-Content $_.FullName
     }
 }
 


### PR DESCRIPTION
Per exercism/v3#1047

PR is paired with same change for v3: exercism/v3#1083

Ran: `grep -ril "Remove to run test" . | xargs sed -i "s/Remove to run test/Remove this Skip property to run this test/"`

Any other repos with tooling for this track that may need updating?