### PR TITLE
fix build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e # v2
-      - uses: actions/setup-dotnet@b7821147f564527086410e8edd122d89b4b9602f # 1.4.0
+      - uses: actions/setup-dotnet@v1.7.2
         with:
           dotnet-version: "3.0.100"
       - run: pwsh ./test.ps1


### PR DESCRIPTION
The build was failing due to an old `setup_dotnet` GHA task version, which seems to internally use the now-disabled `set-env`:

https://github.com/exercism/fsharp/runs/1480591608?check_suite_focus=true

This PR updates it, and pins a version rather than a commit hash.