### PR TITLE
Fix namespace for concept exercise examples

### DIFF
--- a/exercises/concept/annalyns-infiltration/.meta/Exemplar.fs
+++ b/exercises/concept/annalyns-infiltration/.meta/Exemplar.fs
@@ -1,4 +1,4 @@
-module Booleans
+module AnnalynsInfiltration
 
 let canFastAttack (knightIsAwake: bool): bool = not knightIsAwake
 

--- a/exercises/concept/bandwagoner/.meta/Exemplar.fs
+++ b/exercises/concept/bandwagoner/.meta/Exemplar.fs
@@ -1,4 +1,4 @@
-module Stats
+module Bandwagoner
 
 type Coach = { Name: string; FormerPlayer: bool }
 

--- a/exercises/concept/bird-watcher/.meta/Exemplar.fs
+++ b/exercises/concept/bird-watcher/.meta/Exemplar.fs
@@ -1,4 +1,4 @@
-module Arrays
+module BirdWatcher
 
 let lastWeek: int [] = [| 0; 2; 5; 3; 7; 8; 4 |]
 

--- a/exercises/concept/booking-up-for-beauty/.meta/Exemplar.fs
+++ b/exercises/concept/booking-up-for-beauty/.meta/Exemplar.fs
@@ -1,4 +1,4 @@
-module Datetimes
+module BookingUpForBeauty
 
 open System
 

--- a/exercises/concept/cars-assemble/.meta/Exemplar.fs
+++ b/exercises/concept/cars-assemble/.meta/Exemplar.fs
@@ -1,4 +1,4 @@
-module Numbers
+module CarsAssemble
 
 let private ProductionRatePerHourForDefaultSpeed = 221
 

--- a/exercises/concept/guessing-game/.meta/Exemplar.fs
+++ b/exercises/concept/guessing-game/.meta/Exemplar.fs
@@ -1,4 +1,4 @@
-module PatternMatching
+module GuessingGame
 
 let reply guess =
     match guess with

--- a/exercises/concept/interest-is-interesting/.meta/Exemplar.fs
+++ b/exercises/concept/interest-is-interesting/.meta/Exemplar.fs
@@ -1,4 +1,4 @@
-module FloatingPointNumbers
+module InterestIsInteresting
 
 let interestRate (balance: decimal): single =
     if balance < 0.0m then -3.213f

--- a/exercises/concept/log-levels/.meta/Exemplar.fs
+++ b/exercises/concept/log-levels/.meta/Exemplar.fs
@@ -1,4 +1,4 @@
-module Strings
+module LogLevels
 
 let message (logLine: string): string = logLine.Substring(logLine.IndexOf(':') + 1).Trim()
 

--- a/exercises/concept/lucians-luscious-lasagna/.meta/Exemplar.fs
+++ b/exercises/concept/lucians-luscious-lasagna/.meta/Exemplar.fs
@@ -1,4 +1,4 @@
-module Basics
+module LuciansLusciousLasagna
 
 let expectedMinutesInOven = 40
 

--- a/exercises/concept/pizza-pricing/.meta/Exemplar.fs
+++ b/exercises/concept/pizza-pricing/.meta/Exemplar.fs
@@ -1,4 +1,4 @@
-module Recursion
+module PizzaPricing
 
 type Pizza =
     | Margherita

--- a/exercises/concept/tracks-on-tracks-on-tracks/.meta/Exemplar.fs
+++ b/exercises/concept/tracks-on-tracks-on-tracks/.meta/Exemplar.fs
@@ -1,4 +1,4 @@
-module Lists
+module TracksOnTracksOnTracks
 
 let newList: string list = []
 

--- a/exercises/concept/valentines-day/.meta/Exemplar.fs
+++ b/exercises/concept/valentines-day/.meta/Exemplar.fs
@@ -1,4 +1,4 @@
-module DiscriminatedUnions
+module ValentinesDay
 
 type Approval =
     | Yes


### PR DESCRIPTION
* Pending on the previous PR #883. #883 needs to be merged first to main.
* Change module in each concept example file. For instance: rename module Stats to Bandwagoner in the file Exemplar.fs