### PR TITLE
Improve example in the practice exercise: triangle 

### DIFF
--- a/exercises/practice/triangle/Example.fs
+++ b/exercises/practice/triangle/Example.fs
@@ -3,8 +3,9 @@
 let private isValid triangle = 
     let nonZero = List.sum triangle <> 0.0
     let equality =
-        let [x; y; z] = triangle
-        x + y >= z && x + z >= y && y + z >= x
+        match triangle with
+        | [ x; y; z ] -> x + y >= z && x + z >= y && y + z >= x
+        | _ -> false
     
     equality && nonZero
 


### PR DESCRIPTION
Improving the example file for the practice exercise triangle.

The warning raised by the IDE is:
`Incomplete pattern matches on this expression. For example, the value '[_;_;_;_]' may indicate a case not covered by the pattern`