### PR TITLE
Fix tests.ps1 to pass the practice tests

### DIFF
--- a/exercises/concept/bandwagoner/.meta/Exemplar.fs
+++ b/exercises/concept/bandwagoner/.meta/Exemplar.fs
@@ -1,4 +1,4 @@
-module Bandwagoner
+module Stats
 
 type Coach = { Name: string; FormerPlayer: bool }
 

--- a/exercises/concept/bandwagoner/.meta/Exemplar.fs
+++ b/exercises/concept/bandwagoner/.meta/Exemplar.fs
@@ -1,4 +1,4 @@
-module Stats
+module Bandwagoner
 
 type Coach = { Name: string; FormerPlayer: bool }
 

--- a/exercises/concept/bandwagoner/.meta/config.json
+++ b/exercises/concept/bandwagoner/.meta/config.json
@@ -1,4 +1,10 @@
 {
+  "contributors": [
+    {
+      "github_username": "valentin-p",
+      "exercism_username": "valentin-p"
+    }
+  ],
   "authors": [
     {
       "github_username": "ErikSchierboom",

--- a/exercises/concept/bandwagoner/BandwagonerTests.fs
+++ b/exercises/concept/bandwagoner/BandwagonerTests.fs
@@ -104,7 +104,7 @@ let ``Same team is duplicate`` () =
     let stats = createStats 57 25
     let team = createTeam "Los Angeles Lakers" coach stats
 
-    isDuplicate team team
+    isSameTeam team team
     |> should equal true
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
@@ -116,7 +116,7 @@ let ``Same team with different stats is not a duplicate`` () =
     let newStats = createStats 62 20
     let teamWithDifferentStats = createTeam "Los Angeles Lakers" coach newStats
 
-    isDuplicate team teamWithDifferentStats
+    isSameTeam team teamWithDifferentStats
     |> should equal false
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
@@ -128,7 +128,7 @@ let ``Same team with different coach is not a duplicate`` () =
     let newCoach = createCoach "John Kundla" true
     let teamWithDifferentCoach = createTeam "Los Angeles Lakers" newCoach stats
 
-    isDuplicate team teamWithDifferentCoach
+    isSameTeam team teamWithDifferentCoach
     |> should equal false
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
@@ -139,7 +139,7 @@ let ``Different team with same coach and stats`` () =
     let team = createTeam "Denver Nuggets" coach stats
     let otherTeam = createTeam "Phoenix Suns" coach stats
 
-    isDuplicate team otherTeam
+    isSameTeam team otherTeam
     |> should equal false
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
@@ -152,7 +152,7 @@ let ``Different team with different coach and stats`` () =
     let otherCoach = createCoach "Larry Costello" true
     let otherTeam = createTeam "Milwaukee Bucks" otherCoach otherStats
 
-    isDuplicate team otherTeam
+    isSameTeam team otherTeam
     |> should equal false
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]

--- a/exercises/practice/tree-building/Program.fs
+++ b/exercises/practice/tree-building/Program.fs
@@ -35,8 +35,8 @@ type AllocatedColumnProvider() =
 
 [<EntryPoint>]
 let main _ =
-    let  manuelConfig = ManualConfig()
-    let benchmarkConfig = manuelConfig.AddColumnProvider(new AllocatedColumnProvider()).AddDiagnoser(MemoryDiagnoser.Default).AddLogger(ConsoleLogger.Default);
+    let manualConfig = ManualConfig()
+    let benchmarkConfig = manualConfig.AddColumnProvider(new AllocatedColumnProvider()).AddDiagnoser(MemoryDiagnoser.Default).AddLogger(ConsoleLogger.Default);
 
     BenchmarkRunner.Run<Benchmarks>(benchmarkConfig) |> ignore
 

--- a/generators/Program.fs
+++ b/generators/Program.fs
@@ -11,7 +11,7 @@ let private isNotFilteredByName options (exercise: Exercise) =
     match options.Exercise with
     | Some filteredExerciseName -> filteredExerciseName = exerciseName exercise
     | None -> true
-    
+
 let private regenerateTestClass options =
     let parseCanonicalData' = parseCanonicalData options
 
@@ -34,31 +34,31 @@ let private regenerateTestClasses options =
     Log.Information("Re-generating test classes...")
 
     let regenerateTestClass' = regenerateTestClass options
-    
+
     createExercises options
     |> List.filter (isNotFilteredByName options)
     |> function
         | [] -> Log.Warning "No exercises matched given options."
         | exercises ->
             List.iter regenerateTestClass' exercises
-            Log.Information("Re-generated test classes.")     
+            Log.Information("Re-generated test classes.")
 
 [<EntryPoint>]
-let main argv = 
+let main argv =
     Logging.setupLogger()
 
     match parseOptions argv with
-    | Ok(options) when options.Status.IsSome && options.Exercise.IsSome -> 
+    | Ok(options) when options.Status.IsSome && options.Exercise.IsSome ->
         Log.Error("Can't have both -s/--status and -e/--exercise.")
         1
-    | Ok(options) when options.Status.IsSome -> 
+    | Ok(options) when options.Status.IsSome ->
         listExercises options
         0
-    | Ok(options) -> 
+    | Ok(options) ->
         regenerateTestClasses options
         0
     | Error(errors) when errors |> Seq.contains "CommandLine.HelpRequestedError" ->
         0
-    | Error(errors) -> 
+    | Error(errors) ->
         Log.Error("Error(s) parsing commandline arguments: {Errors}", errors)
         1

--- a/test.ps1
+++ b/test.ps1
@@ -26,7 +26,7 @@ param (
 . ./shared.ps1
 
 $buildDir = Join-Path $PSScriptRoot "build"
-$exercisesDir = Resolve-Path "exercises"
+$exercisesDir = Resolve-Path "exercises/practice"
 
 function Configlet-Lint {
     Write-Output "Linting config.json"
@@ -77,7 +77,7 @@ function Add-Packages-Used-In-Example-Implementations {
 
 function Test-Using-Example-Implementation {
     Write-Output "Running tests"
-    $testTarget = if ($Exercise) { "$buildDir/$Exercise" } else { "$buildDir/Exercises.sln" }
+    $testTarget = if ($Exercise) { "$buildDir/$Exercise" } else { "$buildDir/Practices.sln" }
     Run-Command "dotnet test $testTarget"
 }
 


### PR DESCRIPTION
* Pending on the previous PR #888. #888 needs to be merged first to main.
* Pending on the previous PR #884. #884 needs to be merged first to main.
* Update the path /exercises to /exercises/practice so the tests can execute.
* Update the test files to pass the practice exercises the way it was passing before the incorporation of v3.

Out of scope:
* Including the concept exercises in the tests would be done in a later PR, this one is just to rehabilitate the functionality 