### PR TITLE
🤖 Sync exercise files keys based on file path patterns

### DIFF
--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Accumulate.fs"
+    ],
+    "test": [
+      "AccumulateTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Acronym.fs"
+    ],
+    "test": [
+      "AcronymTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "AffineCipher.fs"
+    ],
+    "test": [
+      "AffineCipherTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "AllYourBase.fs"
+    ],
+    "test": [
+      "AllYourBaseTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Allergies.fs"
+    ],
+    "test": [
+      "AllergiesTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Alphametics.fs"
+    ],
+    "test": [
+      "AlphameticsTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Anagram.fs"
+    ],
+    "test": [
+      "AnagramTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "ArmstrongNumbers.fs"
+    ],
+    "test": [
+      "ArmstrongNumbersTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "AtbashCipher.fs"
+    ],
+    "test": [
+      "AtbashCipherTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/bank-account/.meta/config.json
+++ b/exercises/practice/bank-account/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "BankAccount.fs"
+    ],
+    "test": [
+      "BankAccountTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "BeerSong.fs"
+    ],
+    "test": [
+      "BeerSongTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "BinarySearchTree.fs"
+    ],
+    "test": [
+      "BinarySearchTreeTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "BinarySearch.fs"
+    ],
+    "test": [
+      "BinarySearchTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Binary.fs"
+    ],
+    "test": [
+      "BinaryTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Bob.fs"
+    ],
+    "test": [
+      "BobTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "BookStore.fs"
+    ],
+    "test": [
+      "BookStoreTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Bowling.fs"
+    ],
+    "test": [
+      "BowlingTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Change.fs"
+    ],
+    "test": [
+      "ChangeTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "CircularBuffer.fs"
+    ],
+    "test": [
+      "CircularBufferTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Clock.fs"
+    ],
+    "test": [
+      "ClockTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "CollatzConjecture.fs"
+    ],
+    "test": [
+      "CollatzConjectureTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "ComplexNumbers.fs"
+    ],
+    "test": [
+      "ComplexNumbersTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Connect.fs"
+    ],
+    "test": [
+      "ConnectTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "CryptoSquare.fs"
+    ],
+    "test": [
+      "CryptoSquareTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "CustomSet.fs"
+    ],
+    "test": [
+      "CustomSetTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Darts.fs"
+    ],
+    "test": [
+      "DartsTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Diamond.fs"
+    ],
+    "test": [
+      "DiamondTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "DifferenceOfSquares.fs"
+    ],
+    "test": [
+      "DifferenceOfSquaresTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/diffie-hellman/.meta/config.json
+++ b/exercises/practice/diffie-hellman/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "DiffieHellman.fs"
+    ],
+    "test": [
+      "DiffieHellmanTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/dnd-character/.meta/config.json
+++ b/exercises/practice/dnd-character/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "DndCharacter.fs"
+    ],
+    "test": [
+      "DndCharacterTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Dominoes.fs"
+    ],
+    "test": [
+      "DominoesTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/dot-dsl/.meta/config.json
+++ b/exercises/practice/dot-dsl/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "DotDsl.fs"
+    ],
+    "test": [
+      "DotDslTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/error-handling/.meta/config.json
+++ b/exercises/practice/error-handling/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "ErrorHandling.fs"
+    ],
+    "test": [
+      "ErrorHandlingTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Etl.fs"
+    ],
+    "test": [
+      "EtlTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "FoodChain.fs"
+    ],
+    "test": [
+      "FoodChainTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Forth.fs"
+    ],
+    "test": [
+      "ForthTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Gigasecond.fs"
+    ],
+    "test": [
+      "GigasecondTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/go-counting/.meta/config.json
+++ b/exercises/practice/go-counting/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "GoCounting.fs"
+    ],
+    "test": [
+      "GoCountingTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "GradeSchool.fs"
+    ],
+    "test": [
+      "GradeSchoolTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Grains.fs"
+    ],
+    "test": [
+      "GrainsTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Grep.fs"
+    ],
+    "test": [
+      "GrepTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Hamming.fs"
+    ],
+    "test": [
+      "HammingTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/hangman/.meta/config.json
+++ b/exercises/practice/hangman/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Hangman.fs"
+    ],
+    "test": [
+      "HangmanTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "HelloWorld.fs"
+    ],
+    "test": [
+      "HelloWorldTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/hexadecimal/.meta/config.json
+++ b/exercises/practice/hexadecimal/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Hexadecimal.fs"
+    ],
+    "test": [
+      "HexadecimalTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "HighScores.fs"
+    ],
+    "test": [
+      "HighScoresTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "House.fs"
+    ],
+    "test": [
+      "HouseTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "IsbnVerifier.fs"
+    ],
+    "test": [
+      "IsbnVerifierTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Isogram.fs"
+    ],
+    "test": [
+      "IsogramTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "KindergartenGarden.fs"
+    ],
+    "test": [
+      "KindergartenGardenTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "LargestSeriesProduct.fs"
+    ],
+    "test": [
+      "LargestSeriesProductTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Leap.fs"
+    ],
+    "test": [
+      "LeapTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/ledger/.meta/config.json
+++ b/exercises/practice/ledger/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Ledger.fs"
+    ],
+    "test": [
+      "LedgerTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/lens-person/.meta/config.json
+++ b/exercises/practice/lens-person/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "LensPerson.fs"
+    ],
+    "test": [
+      "LensPersonTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "LinkedList.fs"
+    ],
+    "test": [
+      "LinkedListTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "ListOps.fs"
+    ],
+    "test": [
+      "ListOpsTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Luhn.fs"
+    ],
+    "test": [
+      "LuhnTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/markdown/.meta/config.json
+++ b/exercises/practice/markdown/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Markdown.fs"
+    ],
+    "test": [
+      "MarkdownTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "MatchingBrackets.fs"
+    ],
+    "test": [
+      "MatchingBracketsTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Matrix.fs"
+    ],
+    "test": [
+      "MatrixTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Meetup.fs"
+    ],
+    "test": [
+      "MeetupTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Minesweeper.fs"
+    ],
+    "test": [
+      "MinesweeperTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "NthPrime.fs"
+    ],
+    "test": [
+      "NthPrimeTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "NucleotideCount.fs"
+    ],
+    "test": [
+      "NucleotideCountTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "OcrNumbers.fs"
+    ],
+    "test": [
+      "OcrNumbersTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/octal/.meta/config.json
+++ b/exercises/practice/octal/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Octal.fs"
+    ],
+    "test": [
+      "OctalTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "PalindromeProducts.fs"
+    ],
+    "test": [
+      "PalindromeProductsTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Pangram.fs"
+    ],
+    "test": [
+      "PangramTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/parallel-letter-frequency/.meta/config.json
+++ b/exercises/practice/parallel-letter-frequency/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "ParallelLetterFrequency.fs"
+    ],
+    "test": [
+      "ParallelLetterFrequencyTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "PascalsTriangle.fs"
+    ],
+    "test": [
+      "PascalsTriangleTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "PerfectNumbers.fs"
+    ],
+    "test": [
+      "PerfectNumbersTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "PhoneNumber.fs"
+    ],
+    "test": [
+      "PhoneNumberTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "PigLatin.fs"
+    ],
+    "test": [
+      "PigLatinTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/poker/.meta/config.json
+++ b/exercises/practice/poker/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Poker.fs"
+    ],
+    "test": [
+      "PokerTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/pov/.meta/config.json
+++ b/exercises/practice/pov/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Pov.fs"
+    ],
+    "test": [
+      "PovTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "PrimeFactors.fs"
+    ],
+    "test": [
+      "PrimeFactorsTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "ProteinTranslation.fs"
+    ],
+    "test": [
+      "ProteinTranslationTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Proverb.fs"
+    ],
+    "test": [
+      "ProverbTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "PythagoreanTriplet.fs"
+    ],
+    "test": [
+      "PythagoreanTripletTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "QueenAttack.fs"
+    ],
+    "test": [
+      "QueenAttackTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "RailFenceCipher.fs"
+    ],
+    "test": [
+      "RailFenceCipherTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Raindrops.fs"
+    ],
+    "test": [
+      "RaindropsTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "RationalNumbers.fs"
+    ],
+    "test": [
+      "RationalNumbersTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "React.fs"
+    ],
+    "test": [
+      "ReactTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Rectangles.fs"
+    ],
+    "test": [
+      "RectanglesTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/rest-api/.meta/config.json
+++ b/exercises/practice/rest-api/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "RestApi.fs"
+    ],
+    "test": [
+      "RestApiTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "ReverseString.fs"
+    ],
+    "test": [
+      "ReverseStringTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "RnaTranscription.fs"
+    ],
+    "test": [
+      "RnaTranscriptionTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "RobotName.fs"
+    ],
+    "test": [
+      "RobotNameTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "RobotSimulator.fs"
+    ],
+    "test": [
+      "RobotSimulatorTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "RomanNumerals.fs"
+    ],
+    "test": [
+      "RomanNumeralsTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "RotationalCipher.fs"
+    ],
+    "test": [
+      "RotationalCipherTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "RunLengthEncoding.fs"
+    ],
+    "test": [
+      "RunLengthEncodingTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "SaddlePoints.fs"
+    ],
+    "test": [
+      "SaddlePointsTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Say.fs"
+    ],
+    "test": [
+      "SayTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "ScaleGenerator.fs"
+    ],
+    "test": [
+      "ScaleGeneratorTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "ScrabbleScore.fs"
+    ],
+    "test": [
+      "ScrabbleScoreTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "SecretHandshake.fs"
+    ],
+    "test": [
+      "SecretHandshakeTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Series.fs"
+    ],
+    "test": [
+      "SeriesTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/sgf-parsing/.meta/config.json
+++ b/exercises/practice/sgf-parsing/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "SgfParsing.fs"
+    ],
+    "test": [
+      "SgfParsingTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Sieve.fs"
+    ],
+    "test": [
+      "SieveTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "SimpleCipher.fs"
+    ],
+    "test": [
+      "SimpleCipherTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "SimpleLinkedList.fs"
+    ],
+    "test": [
+      "SimpleLinkedListTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "SpaceAge.fs"
+    ],
+    "test": [
+      "SpaceAgeTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "SpiralMatrix.fs"
+    ],
+    "test": [
+      "SpiralMatrixTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Strain.fs"
+    ],
+    "test": [
+      "StrainTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Sublist.fs"
+    ],
+    "test": [
+      "SublistTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "SumOfMultiples.fs"
+    ],
+    "test": [
+      "SumOfMultiplesTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/tournament/.meta/config.json
+++ b/exercises/practice/tournament/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Tournament.fs"
+    ],
+    "test": [
+      "TournamentTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Transpose.fs"
+    ],
+    "test": [
+      "TransposeTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/tree-building/.meta/config.json
+++ b/exercises/practice/tree-building/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "TreeBuilding.fs"
+    ],
+    "test": [
+      "TreeBuildingTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Triangle.fs"
+    ],
+    "test": [
+      "TriangleTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Trinary.fs"
+    ],
+    "test": [
+      "TrinaryTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "TwelveDays.fs"
+    ],
+    "test": [
+      "TwelveDaysTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "TwoBucket.fs"
+    ],
+    "test": [
+      "TwoBucketTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "TwoFer.fs"
+    ],
+    "test": [
+      "TwoFerTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "VariableLengthQuantity.fs"
+    ],
+    "test": [
+      "VariableLengthQuantityTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "WordCount.fs"
+    ],
+    "test": [
+      "WordCountTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/word-search/.meta/config.json
+++ b/exercises/practice/word-search/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "WordSearch.fs"
+    ],
+    "test": [
+      "WordSearchTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Wordy.fs"
+    ],
+    "test": [
+      "WordyTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Yacht.fs"
+    ],
+    "test": [
+      "YachtTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/zebra-puzzle/.meta/config.json
+++ b/exercises/practice/zebra-puzzle/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "ZebraPuzzle.fs"
+    ],
+    "test": [
+      "ZebraPuzzleTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]

--- a/exercises/practice/zipper/.meta/config.json
+++ b/exercises/practice/zipper/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "Zipper.fs"
+    ],
+    "test": [
+      "ZipperTests.fs"
+    ],
     "example": [
       ".meta/Example.fs"
     ]


### PR DESCRIPTION
To help tracks define the files in the exercise's `.meta/config.json` file, we've added support for defining these file patterns in the track's `config.json` file. See [this PR](https://github.com/exercism/docs/pull/58).

This PR updates the file paths defined in the `files` property of each exercise's `.meta/config.json` file according to the file patterns defined in the track's `config.json` file.

We only update a file path in the `.meta/config.json` file if:

- The file path pattern is a non-empty array in the `config.json` file
- The file path pattern is either not set or an empty array in the `.meta/config.json` file

This means that exercises that had already defined files in the `.meta/config.json` won't be touched in this PR.

Note that this PR is just an easy way for tracks to populate the files in the `.meta/config.json` files. Tracks are completely free to add/change/remove the files in their `.meta/config.json` files.

In the future, we'll update `configlet` to include this functionality. If you'd like me to re-run the script because changes have been made, feel free to ping me on Slack (@erikschierboom).

## Tracking

https://github.com/exercism/v3-launch/issues/20

