### PR TITLE
🤖 Flatten authors and contributors in .meta/config.json files

### DIFF
--- a/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for annalyns-infiltration exercise",
   "authors": [
-    {
-      "github_username": "ErikSchierboom",
-      "exercism_username": "ErikSchierboom"
-    }
+    "ErikSchierboom"
   ],
   "forked_from": [
     "javascript/booleans"

--- a/exercises/concept/bandwagoner/.meta/config.json
+++ b/exercises/concept/bandwagoner/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "TODO: add blurb for bandwagoner exercise",
   "contributors": [
-    {
-      "github_username": "valentin-p",
-      "exercism_username": "valentin-p"
-    }
+    "valentin-p"
   ],
   "authors": [
-    {
-      "github_username": "ErikSchierboom",
-      "exercism_username": "ErikSchierboom"
-    }
+    "ErikSchierboom"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/bird-watcher/.meta/config.json
+++ b/exercises/concept/bird-watcher/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for bird-watcher exercise",
   "authors": [
-    {
-      "github_username": "ErikSchierboom",
-      "exercism_username": "ErikSchierboom"
-    }
+    "ErikSchierboom"
   ],
   "forked_from": [
     "csharp/arrays"

--- a/exercises/concept/booking-up-for-beauty/.meta/config.json
+++ b/exercises/concept/booking-up-for-beauty/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for booking-up-for-beauty exercise",
   "authors": [
-    {
-      "github_username": "ErikSchierboom",
-      "exercism_username": "ErikSchierboom"
-    }
+    "ErikSchierboom"
   ],
   "forked_from": [
     "csharp/datetimes"

--- a/exercises/concept/cars-assemble/.meta/config.json
+++ b/exercises/concept/cars-assemble/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for cars-assemble exercise",
   "authors": [
-    {
-      "github_username": "ErikSchierboom",
-      "exercism_username": "ErikSchierboom"
-    }
+    "ErikSchierboom"
   ],
   "forked_from": [
     "csharp/numbers"

--- a/exercises/concept/guessing-game/.meta/config.json
+++ b/exercises/concept/guessing-game/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for guessing-game exercise",
   "authors": [
-    {
-      "github_username": "ErikSchierboom",
-      "exercism_username": "ErikSchierboom"
-    }
+    "ErikSchierboom"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/interest-is-interesting/.meta/config.json
+++ b/exercises/concept/interest-is-interesting/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for interest-is-interesting exercise",
   "authors": [
-    {
-      "github_username": "ErikSchierboom",
-      "exercism_username": "ErikSchierboom"
-    }
+    "ErikSchierboom"
   ],
   "forked_from": [
     "csharp/floating-point-numbers"

--- a/exercises/concept/log-levels/.meta/config.json
+++ b/exercises/concept/log-levels/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for log-levels exercise",
   "authors": [
-    {
-      "github_username": "ErikSchierboom",
-      "exercism_username": "ErikSchierboom"
-    }
+    "ErikSchierboom"
   ],
   "forked_from": [
     "csharp/strings"

--- a/exercises/concept/lucians-luscious-lasagna/.meta/config.json
+++ b/exercises/concept/lucians-luscious-lasagna/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for lucians-luscious-lasagna exercise",
   "authors": [
-    {
-      "github_username": "ErikSchierboom",
-      "exercism_username": "ErikSchierboom"
-    }
+    "ErikSchierboom"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/pizza-pricing/.meta/config.json
+++ b/exercises/concept/pizza-pricing/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for pizza-pricing exercise",
   "authors": [
-    {
-      "github_username": "ErikSchierboom",
-      "exercism_username": "ErikSchierboom"
-    }
+    "ErikSchierboom"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
+++ b/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for tracks-on-tracks-on-tracks exercise",
   "authors": [
-    {
-      "github_username": "ErikSchierboom",
-      "exercism_username": "ErikSchierboom"
-    }
+    "ErikSchierboom"
   ],
   "forked_from": [
     "clojure/lists"

--- a/exercises/concept/valentines-day/.meta/config.json
+++ b/exercises/concept/valentines-day/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for valentines-day exercise",
   "authors": [
-    {
-      "github_username": "ErikSchierboom",
-      "exercism_username": "ErikSchierboom"
-    }
+    "ErikSchierboom"
   ],
   "files": {
     "solution": [


### PR DESCRIPTION
The authors and contributors of exercises are stored in an array of objects in the exercises' `.meta/config.json` files.
Each author/contributor used to have two properties: their GitHub username _and_ their Exercism username.
As we're only using the GitHub username, we're flattening the `authors` and `contributors` array to an array of strings representing the GitHub usernames.

We will update `configlet` to validate the new structure, so you might be seeing build failures once we've implemented this change. 

See https://github.com/exercism/docs/pull/90/files

## Automatic Merging

We will automatically merge this PR immediately to be able to submit a different PR in which we'll add the authors/contributors for practice exercises.

## Tracking

https://github.com/exercism/v3-launch/issues/26
