### PR TITLE
🤖 Fix invalid UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -38,7 +38,7 @@
       {
         "slug": "lucians-luscious-lasagna",
         "name": "Lucian's Luscious Lasagna",
-        "uuid": "1fc8216e-6519-11ea-bc55-0242ac130003",
+        "uuid": "b439e87d-6acf-40bd-848f-fb7c77dad229",
         "concepts": [
           "basics"
         ],
@@ -48,7 +48,7 @@
       {
         "slug": "annalyns-infiltration",
         "name": "Annalyn's Infiltration",
-        "uuid": "82470e36-6447-11ea-bc55-0242ac130003",
+        "uuid": "6ef2a45b-1994-4fb8-b064-637e37881848",
         "concepts": [
           "booleans"
         ],
@@ -60,7 +60,7 @@
       {
         "slug": "booking-up-for-beauty",
         "name": "Booking up for Beauty",
-        "uuid": "160d7d56-5a0e-11ea-8e2d-0242ac130003",
+        "uuid": "04379e4b-05b0-40cd-992f-705b2494d645",
         "concepts": [
           "datetimes"
         ],
@@ -74,7 +74,7 @@
       {
         "slug": "valentines-day",
         "name": "Valentine's Day",
-        "uuid": "263670c8-6915-11ea-bc55-0242ac130003",
+        "uuid": "d5305eb9-f87f-44db-a4a4-9e0b5069afe0",
         "concepts": [
           "discriminated-unions"
         ],
@@ -99,7 +99,7 @@
       {
         "slug": "tracks-on-tracks-on-tracks",
         "name": "Tracks on Tracks on Tracks",
-        "uuid": "ef2df8b0-63a8-11ea-bc55-0242ac130003",
+        "uuid": "51f626a6-8e84-4dba-9c9f-b7830000fbe8",
         "concepts": [
           "lists"
         ],
@@ -112,7 +112,7 @@
       {
         "slug": "cars-assemble",
         "name": "Cars, Assemble!",
-        "uuid": "6ea2765e-5885-11ea-82b4-0242ac130003",
+        "uuid": "85c32aba-5dc0-4dba-9226-63939f3db882",
         "concepts": [
           "conditionals",
           "numbers"
@@ -153,7 +153,7 @@
       {
         "slug": "pizza-pricing",
         "name": "Pizza Pricing",
-        "uuid": "fad55806-69e9-11ea-bc55-0242ac130003",
+        "uuid": "33a9ea6f-b8c8-4b8e-85c2-45fec1684ea6",
         "concepts": [
           "recursion"
         ],
@@ -168,7 +168,7 @@
       {
         "slug": "log-levels",
         "name": "Log Levels",
-        "uuid": "9c2aad8a-53ee-11ea-8d77-2e728ce88125",
+        "uuid": "ab0e683f-46e8-4679-99d2-def4c337e4b8",
         "concepts": [
           "strings"
         ],

--- a/config.json
+++ b/config.json
@@ -86,7 +86,7 @@
       {
         "slug": "interest-is-interesting",
         "name": "Interest is Interesting",
-        "uuid": "4eb8d86f-7123-473e-9d96-7939e9652608",
+        "uuid": "fd82bfe4-8725-486b-bc46-1639a83ae158",
         "concepts": [
           "floating-point-numbers"
         ],


### PR DESCRIPTION
This PR regenerates each UUID on the track that was invalid.

To be valid, each value of a `uuid` key must:
- Be a well-formed version 4 UUID (compliant with RFC 4122) in the
  canonical textual representation [1]
- Not exist elsewhere on the track
- Not exist elsewhere on Exercism

A track can generate a suitable UUID by running `configlet uuid`.

In the future, `configlet lint` will produce an error for an invalid
UUID.

[1] That is, it must match this regular expression:
```
^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
```

## Tracking

https://github.com/exercism/v3-launch/issues/29
