### PR TITLE
Fix code examples in pattern matching concept docs

### DIFF
--- a/concepts/pattern-matching/about.md
+++ b/concepts/pattern-matching/about.md
@@ -16,7 +16,7 @@ While this may look like `switch` statements in other languages, pattern matchin
 ```fsharp
 match number with
 | 0 -> "Zero"
-| i -> sprintf: "Non zero: %d" i
+| i -> sprintf "Non zero: %d" i
 ```
 
 In some cases, you may want to add an additional condition to a pattern. This is known as a _guard_ (clause), which can be added using the `when` keyword:
@@ -44,7 +44,7 @@ Note that the compiler cannot use `when` clauses to infer exhaustiveness:
 ```fsharp
 match number with
 | i when i < 0 -> "Negative number"
-| i when i >= -> "Positive number"
+| i when i >= 0 -> "Positive number"
 
 // Compiler warning
 ```

--- a/concepts/pattern-matching/introduction.md
+++ b/concepts/pattern-matching/introduction.md
@@ -16,7 +16,7 @@ While this may look like `switch` statements in other languages, pattern matchin
 ```fsharp
 match number with
 | 0 -> "Zero"
-| i -> sprintf: "Non zero: %d" i
+| i -> sprintf "Non zero: %d" i
 ```
 
 In some cases, you may want to add an additional condition to a pattern. This is known as a _guard_ (clause), which can be added using the `when` keyword:

--- a/exercises/concept/valentines-day/.docs/introduction.md
+++ b/exercises/concept/valentines-day/.docs/introduction.md
@@ -21,7 +21,7 @@ type Number =
     | Invalid
 ```
 
-Creating a value for a specific case can be done by referring to its name (e.g, `Success`). As case names are just constructor functions, associated data can be passed as a regular function argument. If another discriminated union has defined a case with the same name, you'll need to use its full name (e.g. `Result.Succes`).
+Creating a value for a specific case can be done by referring to its name (e.g, `Success`). As case names are just constructor functions, associated data can be passed as a regular function argument. If another discriminated union has defined a case with the same name, you'll need to use its full name (e.g. `Result.Success`).
 
 ```fsharp
 let byName = Integer 2
@@ -36,6 +36,6 @@ While one can use `if/elif/else` expressions to work with discriminated unions, 
 let describe number =
     match number with
     | Integer i -> sprintf "Integer: %d" i
-    | Float d  -> sprintf "Float: %d" i
+    | Float d  -> sprintf "Float: %f" d
     | Invalid   -> "Invalid"
 ```


### PR DESCRIPTION
Corrects the code blocks in the public-facing Markdown pages that contained syntax errors, and one minor typo.