### PR TITLE
🤖 Update name of `dnd-character` exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -1625,7 +1625,7 @@
       },
       {
         "slug": "dnd-character",
-        "name": "Dnd Character",
+        "name": "D&D Character",
         "uuid": "93550ca5-cd8c-42e3-88f3-e6ce41608342",
         "practices": [],
         "prerequisites": [],


### PR DESCRIPTION
This PR correct the name of the `dnd-character` exercise to its correct value: "D&D Character"