### PR TITLE
Fix more code examples in concept docs

### DIFF
--- a/concepts/discriminated-unions/about.md
+++ b/concepts/discriminated-unions/about.md
@@ -36,7 +36,7 @@ The preferred way to work with discriminated unions is through [pattern matching
 let describe number =
     match number with
     | Integer i -> sprintf "Integer: %d" i
-    | Float d  -> sprintf "Float: %d" i
+    | Float d  -> sprintf "Float: %f" d
     | Invalid   -> "Invalid"
 ```
 

--- a/concepts/discriminated-unions/introduction.md
+++ b/concepts/discriminated-unions/introduction.md
@@ -21,7 +21,7 @@ type Number =
     | Invalid
 ```
 
-Creating a value for a specific case can be done by referring to its name (e.g, `Success`). As case names are just constructor functions, associated data can be passed as a regular function argument. If another discriminated union has defined a case with the same name, you'll need to use its full name (e.g. `Result.Succes`).
+Creating a value for a specific case can be done by referring to its name (e.g, `Success`). As case names are just constructor functions, associated data can be passed as a regular function argument. If another discriminated union has defined a case with the same name, you'll need to use its full name (e.g. `Result.Success`).
 
 ```fsharp
 let byName = Integer 2
@@ -36,6 +36,6 @@ While one can use `if/elif/else` expressions to work with discriminated unions, 
 let describe number =
     match number with
     | Integer i -> sprintf "Integer: %d" i
-    | Float d  -> sprintf "Float: %d" i
+    | Float d  -> sprintf "Float: %f" d
     | Invalid   -> "Invalid"
 ```

--- a/concepts/recursion/about.md
+++ b/concepts/recursion/about.md
@@ -60,7 +60,7 @@ let length list =
 F# supports [recursive types through discriminated union types][recursive-types]. A recursive discriminated union type has one or more of its cases refer to the discriminated union type itself in their data. Like recursive functions, recursive types must have a base case. Unlike recursive functions, recursive types don't use the `rec` keyword.
 
 ```fsharp
-type RussianDoll
+type RussianDoll =
     | Doll                 // Base case
     | Layer of RussianDoll // Recursive case
 ```

--- a/concepts/recursion/introduction.md
+++ b/concepts/recursion/introduction.md
@@ -19,7 +19,7 @@ let rec factorial x =
 F# also supports recursive types through discriminated union types. A recursive discriminated union type has one or more of its cases refer to the discriminated union type itself in their data. Like recursive functions, recursive types must have a base case. Unlike recursive functions, recursive types don't use the `rec` keyword.
 
 ```fsharp
-type RussianDoll
+type RussianDoll =
     | Doll                 // Base case
     | Layer of RussianDoll // Recursive case
 ```

--- a/exercises/concept/booking-up-for-beauty/.docs/instructions.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/instructions.md
@@ -50,7 +50,7 @@ description (DateTime(2019, 03, 29, 15, 0, 0))
 
 Implement the `anniversaryDate` function that returns this year's anniversary date, which is September 15th:
 
-```csharp
+```fsharp
 anniversaryDate()
 // => DateTime(2019, 9, 15, 0, 0, 0)
 ```

--- a/exercises/concept/guessing-game/.docs/introduction.md
+++ b/exercises/concept/guessing-game/.docs/introduction.md
@@ -16,7 +16,7 @@ While this may look like `switch` statements in other languages, pattern matchin
 ```fsharp
 match number with
 | 0 -> "Zero"
-| i -> sprintf: "Non zero: %d" i
+| i -> sprintf "Non zero: %d" i
 ```
 
 In some cases, you may want to add an additional condition to a pattern. This is known as a _guard_ (clause), which can be added using the `when` keyword:

--- a/exercises/concept/pizza-pricing/.docs/introduction.md
+++ b/exercises/concept/pizza-pricing/.docs/introduction.md
@@ -19,7 +19,7 @@ let rec factorial x =
 F# also supports recursive types through discriminated union types. A recursive discriminated union type has one or more of its cases refer to the discriminated union type itself in their data. Like recursive functions, recursive types must have a base case. Unlike recursive functions, recursive types don't use the `rec` keyword.
 
 ```fsharp
-type RussianDoll
+type RussianDoll =
     | Doll                 // Base case
     | Layer of RussianDoll // Recursive case
 ```

--- a/exercises/shared/.docs/debug.md
+++ b/exercises/shared/.docs/debug.md
@@ -2,8 +2,8 @@
 
 When a test fails, a message is displayed describing what went wrong and for which input. You can also use the fact that any [console output][printf] will be shown too. You can write to the console using:
 
-```csharp
-printfn  "Debug message";
+```fsharp
+printfn "Debug message"
 ```
 
 [printf]: https://fsharpforfunandprofit.com/posts/printf/


### PR DESCRIPTION
This corrects the syntax of some more code snippets in concept exercise documentation.

Two files missed by https://github.com/exercism/fsharp/pull/927 were in need of similar corrections:
- [concepts/discriminated-unions/about.md](https://github.com/exercism/fsharp/blob/981b2da5f65e6cc0307500894aaf992cd8c9d11a/concepts/discriminated-unions/about.md)
- [concepts/discriminated-unions/introduction.md](https://github.com/exercism/fsharp/blob/981b2da5f65e6cc0307500894aaf992cd8c9d11a/concepts/discriminated-unions/introduction.md)

A couple of code blocks were labelled `csharp`; [one of these][] also ended a statement with a semi-colon.

Looking ahead, it would be nice to have a tool or script that could automate syntax checking of embedded code snippets.
That might be the subject of a future PR . . . 😉 

[one of these]: https://github.com/exercism/fsharp/blob/981b2da5f65e6cc0307500894aaf992cd8c9d11a/exercises/shared/.docs/debug.md

