### PR TITLE
Updating update-exercise-tools.ps1

### DIFF
--- a/update-exercise-tools.ps1
+++ b/update-exercise-tools.ps1
@@ -2,10 +2,19 @@
 .SYNOPSIS
     Add dotnet tools to exercises.
 .DESCRIPTION
-    For each exercise, create a tool manifest and add fantomas.
+    For each exercise, create a tool manifest and add/upgrade fantomas.
+.PARAMETER FantomasVersion
+    Target version of the `fantomas-tool` NuGet package (defaults to current latest version).
 .EXAMPLE
     PS C:\> ./update-exercise-tools.ps1
+.EXAMPLE
+    PS C:\> ./update-exercise-tools.ps1 4.4.0
 #>
+
+param (
+    [Parameter(Position = 0, Mandatory = $false)]
+    [string]$FantomasVersion="4.5.2"
+)
 
 # Import shared functionality
 . ./shared.ps1
@@ -20,11 +29,33 @@ function Add-Tools {
     If ($dir.Count -eq 0) {
         # make sure this directory contains a project
         $isProjectDir=(Test-Path "$Path/*.fsproj")
-	
-        If ($isProjectDir) {
+        $manifestPath="$Path/.config/dotnet-tools.json"
+
+        # check for an existing tool manifest
+        $hasManifest=(Test-Path $manifestPath)
+
+        # validate version number
+        $hasValidToolVersion=($FantomasVersion -match '^(\d+\.){2}\d+$')
+
+        # assume tools are out of date
+        $needsUpdate=$true
+        $versionArg=$null
+
+        If ($hasValidToolVersion -and $hasManifest) {
+            $currentVersion=(
+                Get-Content -Raw -Path $manifestPath | ConvertFrom-Json
+            ).tools."fantomas-tool".version
+
+            $needsUpdate=($currentVersion -ne $FantomasVersion)
+        }
+
+        If ($isProjectDir -and $needsUpdate) {
+            If ($hasValidToolVersion) {
+                $versionArg="--version $FantomasVersion"
+            }
             Write-Output "Writing tool manifest to $Path/.config"
             Run-Command "dotnet new tool-manifest -o $Path --force"
-            Run-Command "dotnet tool install --tool-manifest $Path/.config/dotnet-tools.json fantomas-tool"
+            Run-Command "dotnet tool install --tool-manifest $manifestPath fantomas-tool $versionArg"
         }
     } Else {
         $dir | ForEach-Object {Add-Tools $_.FullName}


### PR DESCRIPTION
A fair bit of work for just one script, but here goes:

e704a4b fixes #959 by:

- searching recursively, but no deeper than the root of a project (unlike [a previous attempt](https://github.com/rdipardo/fsharp/commit/ec68ba6b94e2ddcd02e66d0eea0cb34927c5630d) that could be fooled into searching the `bin` or `obj` artifacts of a compiled project)
- checking that a project descriptor exists before writing a tool manifest
- overwriting an existing manifest on later runs

The first run should affect the 135 files listed in the output pasted below (mostly `fantomas-tool` version upgrades).

A maintainer can decide what to commit afterwards, once they've had the chance to try it out locally.

<details>
 <summary><code>dotnet pwsh ./update-exercise-tools.ps1 && git status --porcelain=1</code></summary>
 <pre>
A  exercises/concept/annalyns-infiltration/.config/dotnet-tools.json
A  exercises/concept/bandwagoner/.config/dotnet-tools.json
A  exercises/concept/bird-watcher/.config/dotnet-tools.json
A  exercises/concept/booking-up-for-beauty/.config/dotnet-tools.json
A  exercises/concept/cars-assemble/.config/dotnet-tools.json
A  exercises/concept/guessing-game/.config/dotnet-tools.json
A  exercises/concept/interest-is-interesting/.config/dotnet-tools.json
A  exercises/concept/log-levels/.config/dotnet-tools.json
A  exercises/concept/lucians-luscious-lasagna/.config/dotnet-tools.json
A  exercises/concept/pizza-pricing/.config/dotnet-tools.json
A  exercises/concept/tracks-on-tracks-on-tracks/.config/dotnet-tools.json
A  exercises/concept/valentines-day/.config/dotnet-tools.json
 M exercises/practice/accumulate/.config/dotnet-tools.json
 M exercises/practice/acronym/.config/dotnet-tools.json
 M exercises/practice/affine-cipher/.config/dotnet-tools.json
 M exercises/practice/all-your-base/.config/dotnet-tools.json
 M exercises/practice/allergies/.config/dotnet-tools.json
 M exercises/practice/alphametics/.config/dotnet-tools.json
 M exercises/practice/anagram/.config/dotnet-tools.json
 M exercises/practice/armstrong-numbers/.config/dotnet-tools.json
 M exercises/practice/atbash-cipher/.config/dotnet-tools.json
 M exercises/practice/bank-account/.config/dotnet-tools.json
 M exercises/practice/beer-song/.config/dotnet-tools.json
 M exercises/practice/binary-search-tree/.config/dotnet-tools.json
 M exercises/practice/binary-search/.config/dotnet-tools.json
 M exercises/practice/binary/.config/dotnet-tools.json
 M exercises/practice/bob/.config/dotnet-tools.json
 M exercises/practice/book-store/.config/dotnet-tools.json
 M exercises/practice/bowling/.config/dotnet-tools.json
 M exercises/practice/change/.config/dotnet-tools.json
 M exercises/practice/circular-buffer/.config/dotnet-tools.json
 M exercises/practice/clock/.config/dotnet-tools.json
 M exercises/practice/collatz-conjecture/.config/dotnet-tools.json
 M exercises/practice/complex-numbers/.config/dotnet-tools.json
 M exercises/practice/connect/.config/dotnet-tools.json
 M exercises/practice/crypto-square/.config/dotnet-tools.json
 M exercises/practice/custom-set/.config/dotnet-tools.json
 M exercises/practice/darts/.config/dotnet-tools.json
 M exercises/practice/diamond/.config/dotnet-tools.json
 M exercises/practice/difference-of-squares/.config/dotnet-tools.json
 M exercises/practice/diffie-hellman/.config/dotnet-tools.json
 M exercises/practice/dnd-character/.config/dotnet-tools.json
 M exercises/practice/dominoes/.config/dotnet-tools.json
 M exercises/practice/dot-dsl/.config/dotnet-tools.json
 M exercises/practice/error-handling/.config/dotnet-tools.json
 M exercises/practice/etl/.config/dotnet-tools.json
 M exercises/practice/food-chain/.config/dotnet-tools.json
 M exercises/practice/forth/.config/dotnet-tools.json
 M exercises/practice/gigasecond/.config/dotnet-tools.json
 M exercises/practice/go-counting/.config/dotnet-tools.json
 M exercises/practice/grade-school/.config/dotnet-tools.json
 M exercises/practice/grains/.config/dotnet-tools.json
 M exercises/practice/grep/.config/dotnet-tools.json
 M exercises/practice/hamming/.config/dotnet-tools.json
 M exercises/practice/hangman/.config/dotnet-tools.json
 M exercises/practice/hello-world/.config/dotnet-tools.json
 M exercises/practice/hexadecimal/.config/dotnet-tools.json
 M exercises/practice/high-scores/.config/dotnet-tools.json
 M exercises/practice/house/.config/dotnet-tools.json
 M exercises/practice/isbn-verifier/.config/dotnet-tools.json
 M exercises/practice/isogram/.config/dotnet-tools.json
 M exercises/practice/kindergarten-garden/.config/dotnet-tools.json
 M exercises/practice/largest-series-product/.config/dotnet-tools.json
 M exercises/practice/leap/.config/dotnet-tools.json
 M exercises/practice/ledger/.config/dotnet-tools.json
 M exercises/practice/lens-person/.config/dotnet-tools.json
 M exercises/practice/linked-list/.config/dotnet-tools.json
 M exercises/practice/list-ops/.config/dotnet-tools.json
 M exercises/practice/luhn/.config/dotnet-tools.json
 M exercises/practice/markdown/.config/dotnet-tools.json
 M exercises/practice/matching-brackets/.config/dotnet-tools.json
 M exercises/practice/matrix/.config/dotnet-tools.json
 M exercises/practice/meetup/.config/dotnet-tools.json
 M exercises/practice/minesweeper/.config/dotnet-tools.json
 M exercises/practice/nth-prime/.config/dotnet-tools.json
 M exercises/practice/nucleotide-count/.config/dotnet-tools.json
 M exercises/practice/ocr-numbers/.config/dotnet-tools.json
 M exercises/practice/octal/.config/dotnet-tools.json
 M exercises/practice/palindrome-products/.config/dotnet-tools.json
 M exercises/practice/pangram/.config/dotnet-tools.json
 M exercises/practice/parallel-letter-frequency/.config/dotnet-tools.json
 M exercises/practice/pascals-triangle/.config/dotnet-tools.json
 M exercises/practice/perfect-numbers/.config/dotnet-tools.json
 M exercises/practice/phone-number/.config/dotnet-tools.json
 M exercises/practice/pig-latin/.config/dotnet-tools.json
 M exercises/practice/poker/.config/dotnet-tools.json
 M exercises/practice/pov/.config/dotnet-tools.json
 M exercises/practice/prime-factors/.config/dotnet-tools.json
 M exercises/practice/protein-translation/.config/dotnet-tools.json
 M exercises/practice/proverb/.config/dotnet-tools.json
 M exercises/practice/pythagorean-triplet/.config/dotnet-tools.json
 M exercises/practice/queen-attack/.config/dotnet-tools.json
 M exercises/practice/rail-fence-cipher/.config/dotnet-tools.json
 M exercises/practice/raindrops/.config/dotnet-tools.json
 M exercises/practice/rational-numbers/.config/dotnet-tools.json
 M exercises/practice/react/.config/dotnet-tools.json
 M exercises/practice/rectangles/.config/dotnet-tools.json
 M exercises/practice/rest-api/.config/dotnet-tools.json
 M exercises/practice/reverse-string/.config/dotnet-tools.json
 M exercises/practice/rna-transcription/.config/dotnet-tools.json
 M exercises/practice/robot-name/.config/dotnet-tools.json
 M exercises/practice/robot-simulator/.config/dotnet-tools.json
 M exercises/practice/roman-numerals/.config/dotnet-tools.json
 M exercises/practice/rotational-cipher/.config/dotnet-tools.json
 M exercises/practice/run-length-encoding/.config/dotnet-tools.json
 M exercises/practice/saddle-points/.config/dotnet-tools.json
 M exercises/practice/say/.config/dotnet-tools.json
 M exercises/practice/scale-generator/.config/dotnet-tools.json
 M exercises/practice/scrabble-score/.config/dotnet-tools.json
 M exercises/practice/secret-handshake/.config/dotnet-tools.json
 M exercises/practice/series/.config/dotnet-tools.json
 M exercises/practice/sgf-parsing/.config/dotnet-tools.json
 M exercises/practice/sieve/.config/dotnet-tools.json
 M exercises/practice/simple-cipher/.config/dotnet-tools.json
 M exercises/practice/simple-linked-list/.config/dotnet-tools.json
 M exercises/practice/space-age/.config/dotnet-tools.json
 M exercises/practice/spiral-matrix/.config/dotnet-tools.json
 M exercises/practice/strain/.config/dotnet-tools.json
 M exercises/practice/sublist/.config/dotnet-tools.json
 M exercises/practice/sum-of-multiples/.config/dotnet-tools.json
 M exercises/practice/tournament/.config/dotnet-tools.json
 M exercises/practice/transpose/.config/dotnet-tools.json
 M exercises/practice/tree-building/.config/dotnet-tools.json
 M exercises/practice/triangle/.config/dotnet-tools.json
 M exercises/practice/trinary/.config/dotnet-tools.json
 M exercises/practice/twelve-days/.config/dotnet-tools.json
 M exercises/practice/two-bucket/.config/dotnet-tools.json
 M exercises/practice/two-fer/.config/dotnet-tools.json
 M exercises/practice/variable-length-quantity/.config/dotnet-tools.json
 M exercises/practice/word-count/.config/dotnet-tools.json
 M exercises/practice/word-search/.config/dotnet-tools.json
 M exercises/practice/wordy/.config/dotnet-tools.json
 M exercises/practice/yacht/.config/dotnet-tools.json
 M exercises/practice/zebra-puzzle/.config/dotnet-tools.json
 M exercises/practice/zipper/.config/dotnet-tools.json
 </pre>
</details>

----

93429e5 deals with the main drawback of forced overwrites &#x2014; writing brand new manifests when there may be some perfectly good ones already there. The fix I settled on was providing an optional parameter for the desired `fantomas-tool` version; the default value of "4.5.2" can be adjusted as new releases come out. If the version string is missing or not in valid semver format, we fall back to bulk overwrites for every project.

The script should be usable with Windows PowerShell 5.1.22 and up, or PowerShell Core 6.2.3 thru 7.1.3 (the ones I tried).
