### PR TITLE
Use the wording from the current concept

### DIFF
--- a/exercises/concept/bandwagoner/Bandwagoner.fs
+++ b/exercises/concept/bandwagoner/Bandwagoner.fs
@@ -1,10 +1,10 @@
 module Bandwagoner
 
-// TODO: please define the 'Coach' discriminated union type
+// TODO: please define the 'Coach' record type
 
-// TODO: please define the 'Stats' discriminated union type
+// TODO: please define the 'Stats' record type
 
-// TODO: please define the 'Team' discriminated union type
+// TODO: please define the 'Team' record type
 
 let createCoach (name: string) (formerPlayer: bool): Coach =
     failwith "Please implement the 'createCoach' function"


### PR DESCRIPTION
Replaces the term "discriminated union" with "record" to match the conceptual context of the exercise Bandwagon.

Fixes #980.