### PR TITLE
Add `open System.Globalization` to be able to use `CultureInfo` class

### DIFF
--- a/exercises/concept/booking-up-for-beauty/BookingUpForBeauty.fs
+++ b/exercises/concept/booking-up-for-beauty/BookingUpForBeauty.fs
@@ -2,6 +2,8 @@ module BookingUpForBeauty
 
 // The following line is needed to use the DateTime type
 open System
+// The following line is needed to use the CultureInfo class for date string formatting
+open System.Globalization
 
 let schedule (appointmentDateDescription: string): DateTime = failwith "Please implement the 'schedule' function"
 


### PR DESCRIPTION
I propose adding `open System.Globalization` to "hint" students and lead them to explore the `CultureInfo` class instead of manually formatting the date string. Of course, the latter remains as a possibility.