### PR TITLE
Bird Watcher: Update tests to catch wrong implementations

### DIFF
--- a/exercises/concept/bird-watcher/BirdWatcherTests.fs
+++ b/exercises/concept/bird-watcher/BirdWatcherTests.fs
@@ -112,11 +112,11 @@ let ``Odd week for second week that does not match odd pattern`` () =
 [<Fact>]
 [<Task(6)>]
 let ``Odd week for third week that does not match odd pattern`` () =
-    oddWeek [| 2; 0; 1; 10; 1; 10; 1 |]
+    oddWeek [| 2; 9; 1; 10; 1; 11; 1 |]
     |> should equal false
 
 [<Fact>]
 [<Task(6)>]
 let ``Odd week for fourth week that does not match odd pattern`` () =
-    oddWeek [| 5; 0; 5; 1; 1; 0; 5 |]
+    oddWeek [| 5; 0; 5; 1; 4; 0; 6 |]
     |> should equal false


### PR DESCRIPTION
The tests did not fail, if the implementation would test the sum of the specific week days to be correct.
Example:

``` F#
let oddWeek(counts: int[]): bool =
    counts.[1] + counts.[3] + counts.[5] = 0 // implementation probably ok, if we say birdcount cannot be negative
    || counts.[1] + counts.[3] + counts.[5] = 30 // not cought by test
    || counts.[0] + counts.[2] + counts.[4] + counts.[6] = 20 // not cought by test
```