### PR TITLE
Alphametics tests to handle timeouts for longer tests

### DIFF
--- a/exercises/practice/alphametics/AlphameticsTests.fs
+++ b/exercises/practice/alphametics/AlphameticsTests.fs
@@ -6,7 +6,7 @@ open Xunit
 open Alphametics
 
 [<Fact>]
-let ``Puzzle with three letters`` () =
+let ``Puzzle with three letters`` () = async {
     let puzzle = "I + BB == ILL"
     let expected = 
         [ ('I', 1);
@@ -14,22 +14,25 @@ let ``Puzzle with three letters`` () =
           ('L', 0) ]
         |> Map.ofList
         |> Some
-    solve puzzle |> should equal expected
+    return solve puzzle |> should equal expected
+    }
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Solution must have unique value for each letter`` () =
+let ``Solution must have unique value for each letter`` () = async {
     let puzzle = "A == B"
     let expected = None
-    solve puzzle |> should equal expected
+    return solve puzzle |> should equal expected
+    }
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Leading zero solution is invalid`` () =
+let ``Leading zero solution is invalid`` () = async {
     let puzzle = "ACA + DD == BD"
     let expected = None
-    solve puzzle |> should equal expected
+    return solve puzzle |> should equal expected
+    }
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Puzzle with two digits final carry`` () =
+let ``Puzzle with two digits final carry`` () = async {
     let puzzle = "A + A + A + A + A + A + A + A + A + A + A + B == BCC"
     let expected = 
         [ ('A', 9);
@@ -37,10 +40,11 @@ let ``Puzzle with two digits final carry`` () =
           ('C', 0) ]
         |> Map.ofList
         |> Some
-    solve puzzle |> should equal expected
+    return solve puzzle |> should equal expected
+    }
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Puzzle with four letters`` () =
+let ``Puzzle with four letters`` () = async {
     let puzzle = "AS + A == MOM"
     let expected = 
         [ ('A', 9);
@@ -49,10 +53,11 @@ let ``Puzzle with four letters`` () =
           ('O', 0) ]
         |> Map.ofList
         |> Some
-    solve puzzle |> should equal expected
+    return solve puzzle |> should equal expected
+    }
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Puzzle with six letters`` () =
+let ``Puzzle with six letters`` () = async {
     let puzzle = "NO + NO + TOO == LATE"
     let expected = 
         [ ('N', 7);
@@ -63,10 +68,11 @@ let ``Puzzle with six letters`` () =
           ('E', 2) ]
         |> Map.ofList
         |> Some
-    solve puzzle |> should equal expected
+    return solve puzzle |> should equal expected
+    }
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Puzzle with seven letters`` () =
+let ``Puzzle with seven letters`` () = async {
     let puzzle = "HE + SEES + THE == LIGHT"
     let expected = 
         [ ('E', 4);
@@ -78,10 +84,11 @@ let ``Puzzle with seven letters`` () =
           ('T', 7) ]
         |> Map.ofList
         |> Some
-    solve puzzle |> should equal expected
+    return solve puzzle |> should equal expected
+    }
 
-[<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Puzzle with eight letters`` () =
+[<Fact(Timeout=2000,Skip = "Remove this Skip property to run this test")>]
+let ``Puzzle with eight letters`` () = async {
     let puzzle = "SEND + MORE == MONEY"
     let expected = 
         [ ('S', 9);
@@ -94,10 +101,11 @@ let ``Puzzle with eight letters`` () =
           ('Y', 2) ]
         |> Map.ofList
         |> Some
-    solve puzzle |> should equal expected
+    return solve puzzle |> should equal expected
+    }
 
-[<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Puzzle with ten letters`` () =
+[<Fact(Timeout=5000,Skip = "Remove this Skip property to run this test")>]
+let ``Puzzle with ten letters`` () = async {
     let puzzle = "AND + A + STRONG + OFFENSE + AS + A + GOOD == DEFENSE"
     let expected = 
         [ ('A', 5);
@@ -112,10 +120,11 @@ let ``Puzzle with ten letters`` () =
           ('T', 9) ]
         |> Map.ofList
         |> Some
-    solve puzzle |> should equal expected
+    return solve puzzle |> should equal expected
+    }
 
-[<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Puzzle with ten letters and 199 addends`` () =
+[<Fact(Timeout=5000,Skip = "Remove this Skip property to run this test")>]
+let ``Puzzle with ten letters and 199 addends`` () = async {
     let puzzle = "THIS + A + FIRE + THEREFORE + FOR + ALL + HISTORIES + I + TELL + A + TALE + THAT + FALSIFIES + ITS + TITLE + TIS + A + LIE + THE + TALE + OF + THE + LAST + FIRE + HORSES + LATE + AFTER + THE + FIRST + FATHERS + FORESEE + THE + HORRORS + THE + LAST + FREE + TROLL + TERRIFIES + THE + HORSES + OF + FIRE + THE + TROLL + RESTS + AT + THE + HOLE + OF + LOSSES + IT + IS + THERE + THAT + SHE + STORES + ROLES + OF + LEATHERS + AFTER + SHE + SATISFIES + HER + HATE + OFF + THOSE + FEARS + A + TASTE + RISES + AS + SHE + HEARS + THE + LEAST + FAR + HORSE + THOSE + FAST + HORSES + THAT + FIRST + HEAR + THE + TROLL + FLEE + OFF + TO + THE + FOREST + THE + HORSES + THAT + ALERTS + RAISE + THE + STARES + OF + THE + OTHERS + AS + THE + TROLL + ASSAILS + AT + THE + TOTAL + SHIFT + HER + TEETH + TEAR + HOOF + OFF + TORSO + AS + THE + LAST + HORSE + FORFEITS + ITS + LIFE + THE + FIRST + FATHERS + HEAR + OF + THE + HORRORS + THEIR + FEARS + THAT + THE + FIRES + FOR + THEIR + FEASTS + ARREST + AS + THE + FIRST + FATHERS + RESETTLE + THE + LAST + OF + THE + FIRE + HORSES + THE + LAST + TROLL + HARASSES + THE + FOREST + HEART + FREE + AT + LAST + OF + THE + LAST + TROLL + ALL + OFFER + THEIR + FIRE + HEAT + TO + THE + ASSISTERS + FAR + OFF + THE + TROLL + FASTS + ITS + LIFE + SHORTER + AS + STARS + RISE + THE + HORSES + REST + SAFE + AFTER + ALL + SHARE + HOT + FISH + AS + THEIR + AFFILIATES + TAILOR + A + ROOFS + FOR + THEIR + SAFE == FORTRESSES"
     let expected = 
         [ ('A', 1);
@@ -130,5 +139,7 @@ let ``Puzzle with ten letters and 199 addends`` () =
           ('T', 9) ]
         |> Map.ofList
         |> Some
-    solve puzzle |> should equal expected
+    return solve puzzle |> should equal expected
+    }
+
 


### PR DESCRIPTION
Changed alphameticstests.fs to make all tests async and added xunit Timeout attribute to longest 3 tests with 2 secs for ``Puzzle with eight letters`` and 5 seconds each for ``Puzzle with ten letters and 199 addends`` and ``Puzzle with ten letters`` exercises.

And switch back on testrunner for this exercise.