### PR TITLE
Clarifying getting values from tuple example

### DIFF
--- a/concepts/tuples/about.md
+++ b/concepts/tuples/about.md
@@ -38,7 +38,7 @@ let person = ("Jordan", 170)
 
 // Option 1: fst/snd
 let name1 = fst person
-let length2 = snd person
+let length1 = snd person
 
 // Option 2: deconstruction
 let (name2, length2) = person


### PR DESCRIPTION
Hey, I think this example would be a bit more clear if length2 was named length1 in the first example of getting values out of tuples.