### PR TITLE
Remove reference to Gitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Exercism exercises in F#
 
 ## Support and Discussion
 
-We have a [gitter channel](https://gitter.im/exercism/xfsharp) where you can get support for any issues you might be facing (build setup, failing tests, etc.) or brainstorm with other people for the solution.
+We have an [F# subcategory](https://forum.exercism.org/c/programming/f/67) on the [Exercism forum](https://forum.exercism.org/) where you can get support for any issues you might be facing (build setup, failing tests, etc.) or brainstorm with other people for the solution.
 
 
 ## Contributing Guide

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -10,8 +10,6 @@
 * The [F# channel](https://functionalprogramming.slack.com/messages/fsharp/) of the [functionalprogramming slack account](https://functionalprogramming.slack.com/). To join, go to [fpchat-invite.herokuapp.com](https://fpchat-invite.herokuapp.com/).
 * The [F# slack account](https://fsharp.slack.com). To join, you have to [become a member of the F# foundation](http://fsharp.org/guides/slack/).
 * [/r/fsharp](https://www.reddit.com/r/fsharp) is the F# subreddit.
-* The [Gitter channel](https://gitter.im/exercism/xfsharp) can be used to ask questions and get support for any issues related to the F# track. 
-
 
 ## Videos
 * The [Community for F#](https://www.youtube.com/channel/UCCQPh0mSMaVpRcKUeWPotSA/feed) YouTube channel has got lots of F# videos.

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -2,6 +2,5 @@
 
 To get help if you're having trouble, you can use one of the following resources:
 
-- [Gitter](https://gitter.im/exercism/xfsharp) is Exercism F# track's Gitter room; go here to get support and ask questions related to the F# track.
 - [/r/fsharp](https://www.reddit.com/r/fsharp) is the F# subreddit.
 - [StackOverflow](http://stackoverflow.com/questions/tagged/f%23) can be used to search for your problem and see if it has been answered already. You can also ask and answer questions.


### PR DESCRIPTION
The Exerism Forum (https://forum.exercism.org/) has now made Gitter redundant.
We're directing everyone there.
