### PR TITLE
Update info about dotnet sdk version requirements

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,7 +2,7 @@
 
 ## Installing .NET
 
-The F# track is built on top of the [.NET](https://dotnet.microsoft.com/learn/dotnet/what-is-dotnet) platform, which runs on Windows, Linux and macOS. To build .NET projects, you can use the .NET Command Line Interface (CLI). This CLI is part of the .NET SDK, which you can install by following the [installation instructions](https://dotnet.microsoft.com/download). Note: the F# track requires SDK version 6.0 or greater.
+The F# track is built on top of the [.NET](https://dotnet.microsoft.com/learn/dotnet/what-is-dotnet) platform, which runs on Windows, Linux and macOS. To build .NET projects, you can use the .NET Command Line Interface (CLI). This CLI is part of the .NET SDK, which you can install by following the [installation instructions](https://dotnet.microsoft.com/download). Note: the F# track requires SDK version 7.0 or greater.
 
 After completing the installation, you can verify if the CLI was installed succesfully by running this command in a terminal:
 
@@ -10,7 +10,7 @@ After completing the installation, you can verify if the CLI was installed succe
 dotnet --version
 ```
 
-It the output is a version greater than or equal to `6.0.100`, the .NET SDK has been installed succesfully.
+It the output is a version greater than or equal to `7.0.100`, the .NET SDK has been installed succesfully.
 
 ## Using an IDE
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -10,7 +10,7 @@ After completing the installation, you can verify if the CLI was installed succe
 dotnet --version
 ```
 
-It the output is a version greater than or equal to `7.0.100`, the .NET SDK has been installed succesfully.
+If the output is a version greater than or equal to `7.0.100`, the .NET SDK has been installed succesfully.
 
 ## Using an IDE
 


### PR DESCRIPTION
Since https://github.com/exercism/fsharp/pull/1111 the fsharp track requires dotnet 7.0 or greater. Update the installation guide to match this.