### PR TITLE
Add new test for grade-school exersice

### DIFF
--- a/exercises/practice/grade-school/GradeSchoolTests.fs
+++ b/exercises/practice/grade-school/GradeSchoolTests.fs
@@ -2,76 +2,79 @@ module GradeSchoolTests
 
 open FsUnit.Xunit
 open Xunit
+
 open GradeSchool
 
 [<Fact>]
-let ``Roster is empty when no student is added``() =
+let ``Roster is empty when no student is added`` () =
     let school = empty
     roster school |> should be Empty
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Student is added to the roster``() =
-    let school = empty |> add "Aimee" 2
-    roster school |> should equal [ "Aimee" ]
+let ``Student is added to the roster`` () =
+    let school = 
+        empty
+        |> add "Aimee" 2
+    roster school |> should equal ["Aimee"]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Multiple students in the same grade are added to the roster``() =
-    let school =
+let ``Multiple students in the same grade are added to the roster`` () =
+    let school = 
         empty
         |> add "Blair" 2
         |> add "James" 2
         |> add "Paul" 2
-    roster school |> should equal [ "Blair"; "James"; "Paul" ]
+    roster school |> should equal ["Blair"; "James"; "Paul"]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Student not added to same grade in the roster more than once``() =
-    let school =
+let ``Student not added to same grade in the roster more than once`` () =
+    let school = 
         empty
         |> add "Blair" 2
         |> add "James" 2
         |> add "James" 2
         |> add "Paul" 2
-    roster school |> should equal [ "Blair"; "James"; "Paul" ]
+    roster school |> should equal ["Blair"; "James"; "Paul"]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Students in multiple grades are added to the roster``() =
-    let school =
+let ``Students in multiple grades are added to the roster`` () =
+    let school = 
         empty
         |> add "Chelsea" 3
         |> add "Logan" 7
-    roster school |> should equal [ "Chelsea"; "Logan" ]
+    roster school |> should equal ["Chelsea"; "Logan"]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Student not added to multiple grades in the roster``() =
-    let school =
+let ``Student not added to multiple grades in the roster`` () =
+    let school = 
         empty
         |> add "Blair" 2
         |> add "James" 2
         |> add "James" 3
         |> add "Paul" 3
-    roster school |> should equal [ "Blair"; "James"; "Paul" ]
+    roster school |> should equal ["Blair"; "James"; "Paul"]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Students are sorted by grades in the roster``() =
-    let school =
+let ``Students are sorted by grades in the roster`` () =
+    let school = 
         empty
         |> add "Jim" 3
         |> add "Peter" 2
         |> add "Anna" 1
-    roster school |> should equal [ "Anna"; "Peter"; "Jim" ]
+    roster school |> should equal ["Anna"; "Peter"; "Jim"]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Students are sorted by name in the roster``() =
-    let school =
+let ``Students are sorted by name in the roster`` () =
+    let school = 
         empty
         |> add "Peter" 2
         |> add "Zoe" 2
         |> add "Alex" 2
-    roster school |> should equal [ "Alex"; "Peter"; "Zoe" ]
+    roster school |> should equal ["Alex"; "Peter"; "Zoe"]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Students are sorted by grades and then by name in the roster``() =
-    let school =
+let ``Students are sorted by grades and then by name in the roster`` () =
+    let school = 
         empty
         |> add "Peter" 2
         |> add "Anna" 1
@@ -80,17 +83,16 @@ let ``Students are sorted by grades and then by name in the roster``() =
         |> add "Alex" 2
         |> add "Jim" 3
         |> add "Charlie" 1
-    roster school
-    |> should equal [ "Anna"; "Barb"; "Charlie"; "Alex"; "Peter"; "Zoe"; "Jim" ]
+    roster school |> should equal ["Anna"; "Barb"; "Charlie"; "Alex"; "Peter"; "Zoe"; "Jim"]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Grade is empty if no students in the roster``() =
+let ``Grade is empty if no students in the roster`` () =
     let school = empty
     grade 1 school |> should be Empty
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Grade is empty if no students in that grade``() =
-    let school =
+let ``Grade is empty if no students in that grade`` () =
+    let school = 
         empty
         |> add "Peter" 2
         |> add "Zoe" 2
@@ -99,52 +101,41 @@ let ``Grade is empty if no students in that grade``() =
     grade 1 school |> should be Empty
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Student not added to same grade more than once``() =
-    let school =
+let ``Student not added to same grade more than once`` () =
+    let school = 
         empty
         |> add "Blair" 2
         |> add "James" 2
         |> add "James" 2
         |> add "Paul" 2
-    grade 2 school |> should equal [ "Blair"; "James"; "Paul" ]
+    grade 2 school |> should equal ["Blair"; "James"; "Paul"]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Student not added to multiple grades``() =
-    let school =
+let ``Student not added to multiple grades`` () =
+    let school = 
         empty
         |> add "Blair" 2
         |> add "James" 2
         |> add "James" 3
         |> add "Paul" 3
-    grade 2 school |> should equal [ "Blair"; "James" ]
+    grade 2 school |> should equal ["Blair"; "James"]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Student not added to other grade for multiple grades``() =
-    let school =
+let ``Student not added to other grade for multiple grades`` () =
+    let school = 
         empty
         |> add "Blair" 2
         |> add "James" 2
         |> add "James" 3
         |> add "Paul" 3
-    grade 3 school |> should equal [ "Paul" ]
+    grade 3 school |> should equal ["Paul"]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Students are sorted by name in a grade``() =
-    let school =
+let ``Students are sorted by name in a grade`` () =
+    let school = 
         empty
         |> add "Franklin" 5
         |> add "Bradley" 5
         |> add "Jeff" 1
-    grade 5 school |> should equal [ "Bradley"; "Franklin" ]
+    grade 5 school |> should equal ["Bradley"; "Franklin"]
 
-[<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Students are sorted by grades and then by name in the roster even when school was not sorted``() =
-    let school =
-        seq {
-            1, [ "Anna"; "Charlie"; "Barb" ]
-            2, [ "Peter"; "Zoe"; "Alex" ]
-            3, [ "Jim" ]
-        }
-        |> Map.ofSeq
-    roster school
-    |> should equal [ "Anna"; "Barb"; "Charlie"; "Alex"; "Peter"; "Zoe"; "Jim" ]

--- a/exercises/practice/grade-school/GradeSchoolTests.fs
+++ b/exercises/practice/grade-school/GradeSchoolTests.fs
@@ -2,79 +2,76 @@ module GradeSchoolTests
 
 open FsUnit.Xunit
 open Xunit
-
 open GradeSchool
 
 [<Fact>]
-let ``Roster is empty when no student is added`` () =
+let ``Roster is empty when no student is added``() =
     let school = empty
     roster school |> should be Empty
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Student is added to the roster`` () =
-    let school = 
-        empty
-        |> add "Aimee" 2
-    roster school |> should equal ["Aimee"]
+let ``Student is added to the roster``() =
+    let school = empty |> add "Aimee" 2
+    roster school |> should equal [ "Aimee" ]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Multiple students in the same grade are added to the roster`` () =
-    let school = 
+let ``Multiple students in the same grade are added to the roster``() =
+    let school =
         empty
         |> add "Blair" 2
         |> add "James" 2
         |> add "Paul" 2
-    roster school |> should equal ["Blair"; "James"; "Paul"]
+    roster school |> should equal [ "Blair"; "James"; "Paul" ]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Student not added to same grade in the roster more than once`` () =
-    let school = 
+let ``Student not added to same grade in the roster more than once``() =
+    let school =
         empty
         |> add "Blair" 2
         |> add "James" 2
         |> add "James" 2
         |> add "Paul" 2
-    roster school |> should equal ["Blair"; "James"; "Paul"]
+    roster school |> should equal [ "Blair"; "James"; "Paul" ]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Students in multiple grades are added to the roster`` () =
-    let school = 
+let ``Students in multiple grades are added to the roster``() =
+    let school =
         empty
         |> add "Chelsea" 3
         |> add "Logan" 7
-    roster school |> should equal ["Chelsea"; "Logan"]
+    roster school |> should equal [ "Chelsea"; "Logan" ]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Student not added to multiple grades in the roster`` () =
-    let school = 
+let ``Student not added to multiple grades in the roster``() =
+    let school =
         empty
         |> add "Blair" 2
         |> add "James" 2
         |> add "James" 3
         |> add "Paul" 3
-    roster school |> should equal ["Blair"; "James"; "Paul"]
+    roster school |> should equal [ "Blair"; "James"; "Paul" ]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Students are sorted by grades in the roster`` () =
-    let school = 
+let ``Students are sorted by grades in the roster``() =
+    let school =
         empty
         |> add "Jim" 3
         |> add "Peter" 2
         |> add "Anna" 1
-    roster school |> should equal ["Anna"; "Peter"; "Jim"]
+    roster school |> should equal [ "Anna"; "Peter"; "Jim" ]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Students are sorted by name in the roster`` () =
-    let school = 
+let ``Students are sorted by name in the roster``() =
+    let school =
         empty
         |> add "Peter" 2
         |> add "Zoe" 2
         |> add "Alex" 2
-    roster school |> should equal ["Alex"; "Peter"; "Zoe"]
+    roster school |> should equal [ "Alex"; "Peter"; "Zoe" ]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Students are sorted by grades and then by name in the roster`` () =
-    let school = 
+let ``Students are sorted by grades and then by name in the roster``() =
+    let school =
         empty
         |> add "Peter" 2
         |> add "Anna" 1
@@ -83,16 +80,17 @@ let ``Students are sorted by grades and then by name in the roster`` () =
         |> add "Alex" 2
         |> add "Jim" 3
         |> add "Charlie" 1
-    roster school |> should equal ["Anna"; "Barb"; "Charlie"; "Alex"; "Peter"; "Zoe"; "Jim"]
+    roster school
+    |> should equal [ "Anna"; "Barb"; "Charlie"; "Alex"; "Peter"; "Zoe"; "Jim" ]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Grade is empty if no students in the roster`` () =
+let ``Grade is empty if no students in the roster``() =
     let school = empty
     grade 1 school |> should be Empty
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Grade is empty if no students in that grade`` () =
-    let school = 
+let ``Grade is empty if no students in that grade``() =
+    let school =
         empty
         |> add "Peter" 2
         |> add "Zoe" 2
@@ -101,41 +99,52 @@ let ``Grade is empty if no students in that grade`` () =
     grade 1 school |> should be Empty
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Student not added to same grade more than once`` () =
-    let school = 
+let ``Student not added to same grade more than once``() =
+    let school =
         empty
         |> add "Blair" 2
         |> add "James" 2
         |> add "James" 2
         |> add "Paul" 2
-    grade 2 school |> should equal ["Blair"; "James"; "Paul"]
+    grade 2 school |> should equal [ "Blair"; "James"; "Paul" ]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Student not added to multiple grades`` () =
-    let school = 
+let ``Student not added to multiple grades``() =
+    let school =
         empty
         |> add "Blair" 2
         |> add "James" 2
         |> add "James" 3
         |> add "Paul" 3
-    grade 2 school |> should equal ["Blair"; "James"]
+    grade 2 school |> should equal [ "Blair"; "James" ]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Student not added to other grade for multiple grades`` () =
-    let school = 
+let ``Student not added to other grade for multiple grades``() =
+    let school =
         empty
         |> add "Blair" 2
         |> add "James" 2
         |> add "James" 3
         |> add "Paul" 3
-    grade 3 school |> should equal ["Paul"]
+    grade 3 school |> should equal [ "Paul" ]
 
 [<Fact(Skip = "Remove this Skip property to run this test")>]
-let ``Students are sorted by name in a grade`` () =
-    let school = 
+let ``Students are sorted by name in a grade``() =
+    let school =
         empty
         |> add "Franklin" 5
         |> add "Bradley" 5
         |> add "Jeff" 1
-    grade 5 school |> should equal ["Bradley"; "Franklin"]
+    grade 5 school |> should equal [ "Bradley"; "Franklin" ]
 
+[<Fact(Skip = "Remove this Skip property to run this test")>]
+let ``Students are sorted by grades and then by name in the roster even when school was not sorted``() =
+    let school =
+        seq {
+            1, [ "Anna"; "Charlie"; "Barb" ]
+            2, [ "Peter"; "Zoe"; "Alex" ]
+            3, [ "Jim" ]
+        }
+        |> Map.ofSeq
+    roster school
+    |> should equal [ "Anna"; "Barb"; "Charlie"; "Alex"; "Peter"; "Zoe"; "Jim" ]

--- a/exercises/practice/grade-school/GradeSchoolTests.fs
+++ b/exercises/practice/grade-school/GradeSchoolTests.fs
@@ -139,3 +139,15 @@ let ``Students are sorted by name in a grade`` () =
         |> add "Jeff" 1
     grade 5 school |> should equal ["Bradley"; "Franklin"]
 
+[<Fact(Skip = "Remove this Skip property to run this test")>]
+let ``Students are sorted by grades and then by name in the roster even when school was not sorted``() =
+    let school =
+        seq {
+            1, [ "Anna"; "Charlie"; "Barb" ]
+            2, [ "Peter"; "Zoe"; "Alex" ]
+            3, [ "Jim" ]
+        }
+        |> Map.ofSeq
+    roster school
+    |> should equal [ "Anna"; "Barb"; "Charlie"; "Alex"; "Peter"; "Zoe"; "Jim" ]
+    


### PR DESCRIPTION
Hello,

Exercise have this description:

> Get a sorted list of all students in all grades. Grades should sort as 1, 2, 3, etc., and students within a grade should be sorted alphabetically by name.
"Who all is enrolled in school right now?"
"Let me think. We have Anna, Barb, and Charlie in grade 1, Alex, Peter, and Zoe in grade 2 and Jim in grade 5. So the answer is: Anna, Barb, Charlie, Alex, Peter, Zoe and Jim"

Given that all tests are using `add` function as part of the `school` preparation, we never test that `roster` function handles the case when input `school` was not sorted.