### PR TITLE
Update formatting in instructions.append.md for Difference of Squares

### DIFF
--- a/exercises/practice/difference-of-squares/.docs/instructions.append.md
+++ b/exercises/practice/difference-of-squares/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Hints
 
 For this exercise the following F# features come in handy:
-https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-operators.html#(%20..%20)) allows you to succinctly create a range of values.
+- [(..) start finish](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-operators.html#(..)) allows you to succinctly create a range of values.
 - [List.sumBy](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-collections-listmodule.html#sumBy) is a condensed format to apply a function to a list and then sum the results.


### PR DESCRIPTION
Fixes formatting of https://exercism.org/tracks/fsharp/exercises/difference-of-squares and replaces dropped linked with another bullet point.

Before:
<img width="803" alt="Screenshot 2024-03-10 at 11 32 46" src="https://github.com/exercism/fsharp/assets/13806/3fb648ef-bb33-4284-b3aa-1b59991bdf53">

After:
<img width="725" alt="Screenshot 2024-03-10 at 11 33 49" src="https://github.com/exercism/fsharp/assets/13806/9788ab01-3d96-43f0-8523-e8492d7d06fd">

I'm not sure how to check markdown rendering in Exercism, I'm assuming it works if GitHub displays it correctly.