### PR TITLE
Fix Ledger exercise NewLine & CultureInfo issues

### DIFF
--- a/exercises/practice/ledger/.meta/Example.fs
+++ b/exercises/practice/ledger/.meta/Example.fs
@@ -13,9 +13,15 @@ let currencySymbol =
     | "EUR" -> "€"
     | _ -> failwith "Invalid currency"
 
+let currencyNegativePattern =
+    function
+    | "en-US" -> 0
+    | "nl-NL" -> 12
+    | _ -> failwith "Invalid locale"
+
 let cultureInfo (locale: string) =
     match locale with
-    | "en-US" | "nl-NL" -> new CultureInfo(locale) 
+    | "en-US" | "nl-NL" -> new CultureInfo(locale, false) 
     | _ -> failwith "Invalid locale"
 
 let dateFormat =
@@ -27,6 +33,7 @@ let dateFormat =
 let getCulture (currency: string) (locale: string) =
     let mutable culture = cultureInfo locale
     culture.NumberFormat.CurrencySymbol <- currencySymbol currency
+    culture.NumberFormat.CurrencyNegativePattern <- currencyNegativePattern locale
     culture.DateTimeFormat.ShortDatePattern <- dateFormat locale
     culture
 

--- a/exercises/practice/ledger/.meta/Example.fs
+++ b/exercises/practice/ledger/.meta/Example.fs
@@ -70,4 +70,4 @@ let formatLedger currency locale entries =
     let culture = getCulture currency locale
     let header = printHeader culture
     let lines = List.map (printEntry culture) (orderEntries entries)
-    header :: lines |> String.concat "\n"
+    header :: lines |> String.concat System.Environment.NewLine

--- a/exercises/practice/ledger/Ledger.fs
+++ b/exercises/practice/ledger/Ledger.fs
@@ -39,23 +39,23 @@ let formatLedger currency locale entries =
         if c < 0.0 then 
             if locale = "nl-NL" then
                 if currency = "USD" then
-                    res <- res + ("$ " + c.ToString("#,#0.00", new CultureInfo("nl-NL"))).PadLeft(13) 
+                    res <- res + ("$ " + c.ToString("#,#0.00", new CultureInfo("nl-NL", false))).PadLeft(13) 
                 if currency = "EUR" then
-                    res <- res + ("€ " + c.ToString("#,#0.00", new CultureInfo("nl-NL"))).PadLeft(13) 
+                    res <- res + ("€ " + c.ToString("#,#0.00", new CultureInfo("nl-NL", false))).PadLeft(13) 
             if locale = "en-US" then
                 if currency = "USD" then
-                    res <- res + ("($" + c.ToString("#,#0.00", new CultureInfo("en-US")).Substring(1) + ")").PadLeft(13) 
+                    res <- res + ("($" + c.ToString("#,#0.00", new CultureInfo("en-US", false)).Substring(1) + ")").PadLeft(13) 
                 if currency = "EUR" then
-                    res <- res + ("(€" + c.ToString("#,#0.00", new CultureInfo("en-US")).Substring(1) + ")").PadLeft(13) 
+                    res <- res + ("(€" + c.ToString("#,#0.00", new CultureInfo("en-US", false)).Substring(1) + ")").PadLeft(13) 
         else 
             if locale = "nl-NL" then
                 if currency = "USD" then
-                    res <- res + ("$ " + c.ToString("#,#0.00", new CultureInfo("nl-NL")) + " ").PadLeft(13) 
+                    res <- res + ("$ " + c.ToString("#,#0.00", new CultureInfo("nl-NL", false)) + " ").PadLeft(13) 
                 if currency = "EUR" then
-                    res <- res + ("€ " + c.ToString("#,#0.00", new CultureInfo("nl-NL")) + " ").PadLeft(13) 
+                    res <- res + ("€ " + c.ToString("#,#0.00", new CultureInfo("nl-NL", false)) + " ").PadLeft(13) 
             if locale = "en-US" then
                 if currency = "USD" then
-                    res <- res + ("$" + c.ToString("#,#0.00", new CultureInfo("en-US")) + " ").PadLeft(13) 
+                    res <- res + ("$" + c.ToString("#,#0.00", new CultureInfo("en-US", false)) + " ").PadLeft(13) 
                 if currency = "EUR" then
-                    res <- res + ("€" + c.ToString("#,#0.00", new CultureInfo("en-US")) + " ").PadLeft(13) 
+                    res <- res + ("€" + c.ToString("#,#0.00", new CultureInfo("en-US", false)) + " ").PadLeft(13) 
     res

--- a/exercises/practice/ledger/Ledger.fs
+++ b/exercises/practice/ledger/Ledger.fs
@@ -16,7 +16,7 @@ let formatLedger currency locale entries =
         
     for x in List.sortBy (fun x -> x.dat, x.des, x.chg) entries do
 
-        res <- res + "\n"
+        res <- res + System.Environment.NewLine
 
         if locale = "nl-NL" then 
             res <- res + x.dat.ToString("dd-MM-yyyy")

--- a/exercises/practice/ledger/LedgerTests.fs
+++ b/exercises/practice/ledger/LedgerTests.fs
@@ -26,7 +26,7 @@ let ``One entry`` () =
             mkEntry "2015-01-01" "Buy present" -1000
         ]
     let expected =
-        "Date       | Description               | Change       \n" +
+        "Date       | Description               | Change       " + System.Environment.NewLine +
         "01/01/2015 | Buy present               |      ($10.00)"
 
     formatLedger currency locale entries |> should equal expected
@@ -41,8 +41,8 @@ let ``Credit and debit`` () =
             mkEntry "2015-01-01" "Buy present" -1000
         ]
     let expected =
-        "Date       | Description               | Change       \n" +
-        "01/01/2015 | Buy present               |      ($10.00)\n" +
+        "Date       | Description               | Change       " + System.Environment.NewLine +
+        "01/01/2015 | Buy present               |      ($10.00)" + System.Environment.NewLine +
         "01/02/2015 | Get present               |       $10.00 "
 
     formatLedger currency locale entries |> should equal expected
@@ -57,8 +57,8 @@ let ``Multiple entries on same date ordered by description`` () =
             mkEntry "2015-01-01" "Get present"  1000
         ]
     let expected =
-        "Date       | Description               | Change       \n" +
-        "01/01/2015 | Buy present               |      ($10.00)\n" +
+        "Date       | Description               | Change       " + System.Environment.NewLine +
+        "01/01/2015 | Buy present               |      ($10.00)" + System.Environment.NewLine +
         "01/01/2015 | Get present               |       $10.00 "
 
     formatLedger currency locale entries |> should equal expected
@@ -74,9 +74,9 @@ let ``Final order tie breaker is change`` () =
             mkEntry "2015-01-01" "Something" 1
         ]
     let expected =
-        "Date       | Description               | Change       \n" +
-        "01/01/2015 | Something                 |       ($0.01)\n" +
-        "01/01/2015 | Something                 |        $0.00 \n" +
+        "Date       | Description               | Change       " + System.Environment.NewLine +
+        "01/01/2015 | Something                 |       ($0.01)" + System.Environment.NewLine +
+        "01/01/2015 | Something                 |        $0.00 " + System.Environment.NewLine +
         "01/01/2015 | Something                 |        $0.01 "
 
     formatLedger currency locale entries |> should equal expected
@@ -90,7 +90,7 @@ let ``Overlong descriptions`` () =
             mkEntry "2015-01-01" "Freude schoner Gotterfunken" -123456
         ]
     let expected =
-        "Date       | Description               | Change       \n" +
+        "Date       | Description               | Change       " + System.Environment.NewLine +
         "01/01/2015 | Freude schoner Gotterf... |   ($1,234.56)"
 
     formatLedger currency locale entries |> should equal expected
@@ -104,7 +104,7 @@ let ``Euros`` () =
             mkEntry "2015-01-01" "Buy present" -1000
         ]
     let expected =
-        "Date       | Description               | Change       \n" +
+        "Date       | Description               | Change       " + System.Environment.NewLine +
         "01/01/2015 | Buy present               |      (€10.00)"
 
     formatLedger currency locale entries |> should equal expected
@@ -118,7 +118,7 @@ let ``Dutch locale`` () =
             mkEntry "2015-03-12" "Buy present" 123456
         ]
     let expected =
-        "Datum      | Omschrijving              | Verandering  \n" +
+        "Datum      | Omschrijving              | Verandering  " + System.Environment.NewLine +
         "12-03-2015 | Buy present               |   $ 1.234,56 "
 
     formatLedger currency locale entries |> should equal expected
@@ -132,7 +132,7 @@ let ``Dutch negative number with 3 digits before decimal point`` () =
             mkEntry "2015-03-12" "Buy present" -12345
         ]
     let expected =
-        "Datum      | Omschrijving              | Verandering  \n" +
+        "Datum      | Omschrijving              | Verandering  " + System.Environment.NewLine +
         "12-03-2015 | Buy present               |     $ -123,45"
 
     formatLedger currency locale entries |> should equal expected
@@ -146,7 +146,7 @@ let ``American negative number with 3 digits before decimal point`` () =
             mkEntry "2015-03-12" "Buy present" -12345
         ]
     let expected =
-        "Date       | Description               | Change       \n" +
+        "Date       | Description               | Change       " + System.Environment.NewLine +
         "03/12/2015 | Buy present               |     ($123.45)"
 
     formatLedger currency locale entries |> should equal expected

--- a/exercises/practice/ledger/LedgerTests.fs
+++ b/exercises/practice/ledger/LedgerTests.fs
@@ -26,7 +26,7 @@ let ``One entry`` () =
             mkEntry "2015-01-01" "Buy present" -1000
         ]
     let expected =
-        "Date       | Description               | Change       " + System.Environment.NewLine +
+        "Date       | Description               | Change       \n" +
         "01/01/2015 | Buy present               |      ($10.00)"
 
     formatLedger currency locale entries |> should equal expected
@@ -41,8 +41,8 @@ let ``Credit and debit`` () =
             mkEntry "2015-01-01" "Buy present" -1000
         ]
     let expected =
-        "Date       | Description               | Change       " + System.Environment.NewLine +
-        "01/01/2015 | Buy present               |      ($10.00)" + System.Environment.NewLine +
+        "Date       | Description               | Change       \n" +
+        "01/01/2015 | Buy present               |      ($10.00)\n" +
         "01/02/2015 | Get present               |       $10.00 "
 
     formatLedger currency locale entries |> should equal expected
@@ -57,8 +57,8 @@ let ``Multiple entries on same date ordered by description`` () =
             mkEntry "2015-01-01" "Get present"  1000
         ]
     let expected =
-        "Date       | Description               | Change       " + System.Environment.NewLine +
-        "01/01/2015 | Buy present               |      ($10.00)" + System.Environment.NewLine +
+        "Date       | Description               | Change       \n" +
+        "01/01/2015 | Buy present               |      ($10.00)\n" +
         "01/01/2015 | Get present               |       $10.00 "
 
     formatLedger currency locale entries |> should equal expected
@@ -74,9 +74,9 @@ let ``Final order tie breaker is change`` () =
             mkEntry "2015-01-01" "Something" 1
         ]
     let expected =
-        "Date       | Description               | Change       " + System.Environment.NewLine +
-        "01/01/2015 | Something                 |       ($0.01)" + System.Environment.NewLine +
-        "01/01/2015 | Something                 |        $0.00 " + System.Environment.NewLine +
+        "Date       | Description               | Change       \n" +
+        "01/01/2015 | Something                 |       ($0.01)\n" +
+        "01/01/2015 | Something                 |        $0.00 \n" +
         "01/01/2015 | Something                 |        $0.01 "
 
     formatLedger currency locale entries |> should equal expected
@@ -90,7 +90,7 @@ let ``Overlong descriptions`` () =
             mkEntry "2015-01-01" "Freude schoner Gotterfunken" -123456
         ]
     let expected =
-        "Date       | Description               | Change       " + System.Environment.NewLine +
+        "Date       | Description               | Change       \n" +
         "01/01/2015 | Freude schoner Gotterf... |   ($1,234.56)"
 
     formatLedger currency locale entries |> should equal expected
@@ -104,7 +104,7 @@ let ``Euros`` () =
             mkEntry "2015-01-01" "Buy present" -1000
         ]
     let expected =
-        "Date       | Description               | Change       " + System.Environment.NewLine +
+        "Date       | Description               | Change       \n" +
         "01/01/2015 | Buy present               |      (€10.00)"
 
     formatLedger currency locale entries |> should equal expected
@@ -118,7 +118,7 @@ let ``Dutch locale`` () =
             mkEntry "2015-03-12" "Buy present" 123456
         ]
     let expected =
-        "Datum      | Omschrijving              | Verandering  " + System.Environment.NewLine +
+        "Datum      | Omschrijving              | Verandering  \n" +
         "12-03-2015 | Buy present               |   $ 1.234,56 "
 
     formatLedger currency locale entries |> should equal expected
@@ -132,7 +132,7 @@ let ``Dutch negative number with 3 digits before decimal point`` () =
             mkEntry "2015-03-12" "Buy present" -12345
         ]
     let expected =
-        "Datum      | Omschrijving              | Verandering  " + System.Environment.NewLine +
+        "Datum      | Omschrijving              | Verandering  \n" +
         "12-03-2015 | Buy present               |     $ -123,45"
 
     formatLedger currency locale entries |> should equal expected
@@ -146,7 +146,7 @@ let ``American negative number with 3 digits before decimal point`` () =
             mkEntry "2015-03-12" "Buy present" -12345
         ]
     let expected =
-        "Date       | Description               | Change       " + System.Environment.NewLine +
+        "Date       | Description               | Change       \n" +
         "03/12/2015 | Buy present               |     ($123.45)"
 
     formatLedger currency locale entries |> should equal expected


### PR DESCRIPTION
As discussed in [the forum](http://forum.exercism.org/t/issues-running-test-ps1-while-investigating-cultureinfo-problems/12493), I have done:
- Replace System.Environment.NewLine with \n
- Use new CultureInfo(locale, false) instead
- Add currencyNegativePattern function for the tests