### PR TITLE
Adjust "Kindergarten Garden" Docs to match expected output

### DIFF
--- a/exercises/practice/kindergarten-garden/.docs/instructions.md
+++ b/exercises/practice/kindergarten-garden/.docs/instructions.md
@@ -12,8 +12,8 @@ Four different types of seeds are planted:
 | ------ | ---------------- |
 | Grass  | G                |
 | Clover | C                |
-| Radish | R                |
-| Violet | V                |
+| Radishes | R                |
+| Violets | V                |
 
 Each child gets four cups, two on each row:
 
@@ -49,8 +49,8 @@ VRCCCGCRRGVCGCRVVCVGCGCV
 
 Then if asked for Alice's plants, it should provide:
 
-- Violets, radishes, violets, radishes
+- Violets, Radishes, Violets, Radishes
 
 While asking for Bob's plants would yield:
 
-- Clover, grass, clover, clover
+- Clover, Grass, Clover, Clover


### PR DESCRIPTION
Currently `Violet` and `Radish` types are written in singular, but both test files and expected output examples expects them in Plural.