### PR TITLE
docs(tisbury-treasure-hunt): comment expected outputs

### DIFF
--- a/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/instructions.md
@@ -88,8 +88,8 @@ Re-format coordinates as needed for accurate comparison.
 
 ```fsharp
 createRecord ("Brass Spyglass", "4B") ("Abandoned Lighthouse", (4, 'B'), "Blue")
-("4B", "Abandoned Lighthouse", "Blue", "Brass Spyglass")
+// ("4B", "Abandoned Lighthouse", "Blue", "Brass Spyglass")
 
 createRecord ("Brass Spyglass", "4B") ("Seaside Cottages", (1, 'C'), "Blue")
-("", "", "", "")
+// ("", "", "", "")
 ```


### PR DESCRIPTION
Commented out the expected output lines in instructions.md (Task 4: Combine matched records). 

This keeps the formatting of expected results in the README’s usage examples consistent with other F# exercises.

- Commented two createRecord expected output lines in: 'exercises/concept/tisbury-treasure-hunt/.docs/instructions.md'
- Verified Markdown preview locally