### PR TITLE
Validate Exercise.sln exercise list in test.ps1

### DIFF
--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -190,7 +190,7 @@ function Assert-Exercise-List-Agreement {
     $config_filename = "config.json"
     $sln_filename = "exercises/Exercises.slnx"
 
-    if ($concept_config_sln_diff || $concept_sln_config_diff || $practice_config_sln_diff || $practice_sln_config_diff) {
+    if ($concept_config_sln_diff -or $concept_sln_config_diff -or $practice_config_sln_diff -or $practice_sln_config_diff) {
         Write-Output "Error: exercise sets in $config_filename and $sln_filename differ."
         Report-Diff "Concept" $config_filename $sln_filename $concept_config_sln_diff
         Report-Diff "Concept" $sln_filename $config_filename $concept_sln_config_diff

--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -187,12 +187,15 @@ function Assert-Exercise-List-Agreement {
     $practice_config_sln_diff = Set-Difference $config_practice_slugs $sln_practice_slugs
     $practice_sln_config_diff = Set-Difference $sln_practice_slugs $config_practice_slugs
 
+    $config_filename = "config.json"
+    $sln_filename = "exercises/Exercises.slnx"
+
     if ($concept_config_sln_diff || $concept_sln_config_diff || $practice_config_sln_diff || $practice_sln_config_diff) {
-        Write-Output "Error: exercise sets in config.json and exercises/Exercises.sln differ."
-        Report-Diff "Concept" "config.json" "exercises/Exercises.sln" $concept_config_sln_diff
-        Report-Diff "Concept" "exercises/Exercises.sln" "config.json" $concept_sln_config_diff
-        Report-Diff "Practice" "config.json" "exercises/Exercises.sln" $practice_config_sln_diff
-        Report-Diff "Practice" "exercises/Exercises.sln" "config.json" $practice_sln_config_diff
+        Write-Output "Error: exercise sets in $config_filename and $sln_filename differ."
+        Report-Diff "Concept" $config_filename $sln_filename $concept_config_sln_diff
+        Report-Diff "Concept" $sln_filename $config_filename $concept_sln_config_diff
+        Report-Diff "Practice" $config_filename $sln_filename $practice_config_sln_diff
+        Report-Diff "Practice" $sln_filename $config_filename $practice_sln_config_diff
         exit 1
     }
 }

--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -158,7 +158,7 @@ function Gather-Exercise-Slugs-From-Config($Category, $OutFile) {
 }
 
 function Gather-Exercise-Slugs-From-Sln($Category, $OutFile) {
-    xmllint --xpath "//Solution/Folder[@Name='/$Category/']/Project/@Path" exercises/Exercises.slnx | cut -d / -f 2 | sort > $OutFile
+    (Select-Xml -Path exercises/Exercises.slnx -XPath "//Solution/Folder[@Name='/$Category/']/Project/@Path").Node | Format-Table -HideTableHeaders | cut -d / -f 2 | sort > $OutFile
 }
 
 function Assert-Exercise-List-Agreement {
@@ -169,8 +169,8 @@ function Assert-Exercise-List-Agreement {
 
     $OriginalErrorActionPreference = $ErrorActionPreference
     $ErrorActionPreference = "SilentlyContinue"
-    $ConceptDiff = diff -u config-concept-slugs sln-concept-slugs
-    $PracticeDiff = diff -u config-practice-slugs sln-practice-slugs
+    $ConceptDiff = diff -uB config-concept-slugs sln-concept-slugs
+    $PracticeDiff = diff -uB config-practice-slugs sln-practice-slugs
     $ErrorActionPreference = $OriginalErrorActionPreference
     Remove-Item config-*-slugs
     Remove-Item sln-*-slugs

--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -153,6 +153,44 @@ function Test-Exercise-Example-Implementations($Exercise) {
     }
 }
 
+function Gather-Exercise-Slugs-From-Config($Category, $OutFile) {
+    jq ".exercises.$Category[] | .slug" config.json | sed 's/"//g' | sort > $OutFile
+}
+
+function Gather-Exercise-Slugs-From-Sln($Category, $OutFile) {
+    xmllint --xpath "//Solution/Folder[@Name='/$Category/']/Project/@Path" exercises/Exercises.slnx | cut -d / -f 2 | sort > $OutFile
+}
+
+function Assert-Exercise-List-Agreement {
+    Gather-Exercise-Slugs-From-Config "concept" "config-concept-slugs"
+    Gather-Exercise-Slugs-From-Sln "concept" "sln-concept-slugs"
+    Gather-Exercise-Slugs-From-Config "practice" "config-practice-slugs"
+    Gather-Exercise-Slugs-From-Sln "practice" "sln-practice-slugs"
+
+    $OriginalErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "SilentlyContinue"
+    $ConceptDiff = diff -u config-concept-slugs sln-concept-slugs
+    $PracticeDiff = diff -u config-practice-slugs sln-practice-slugs
+    $ErrorActionPreference = $OriginalErrorActionPreference
+    Remove-Item config-*-slugs
+    Remove-Item sln-*-slugs
+
+    if ($ConceptDiff || $PracticeDiff) {
+        $MessageCore = "exercise sets in config.json and exercises/Exercises.sln differ"
+        if ($ConceptDiff) {
+            Write-Output "Error: concept ${MessageCore}:"
+            Write-Output $ConceptDiff
+        }
+        if ($PracticeDiff) {
+            Write-Output "Error: practice ${MessageCore}:"
+            Write-Output $PracticeDiff
+        }
+        exit 1
+    }
+}
+
+Assert-Exercise-List-Agreement
+
 if (!$Exercise) {
     Test-Refactoring-Exercise-Default-Implementations
     Build-Generators

--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -153,39 +153,46 @@ function Test-Exercise-Example-Implementations($Exercise) {
     }
 }
 
-function Gather-Exercise-Slugs-From-Config($Category, $OutFile) {
+function Gather-Exercise-Slugs-From-Config($Category) {
     $config = Get-Content -Raw config.json | ConvertFrom-Json
-    $config.exercises.$Category.slug | sort > $OutFile
+    $config.exercises.$Category.slug
 }
 
-function Gather-Exercise-Slugs-From-Sln($Category, $OutFile) {
-    (Select-Xml -Path exercises/Exercises.slnx -XPath "//Solution/Folder[@Name='/$Category/']/Project/@Path").Node | Format-Table -HideTableHeaders | cut -d / -f 2 | sort > $OutFile
+function Gather-Exercise-Slugs-From-Sln($Category) {
+    $xpath = "//Solution/Folder[@Name='/$Category/']/Project/@Path"
+    $raw_paths = (Select-Xml -Path exercises/Exercises.slnx -XPath $xpath)
+    $raw_paths | ForEach-Object {($_.Node.Value -split '/')[-2]}
+}
+
+function Set-Difference($set1, $set2) {
+    $set1 | Where-Object {$set2 -notcontains $_}
+}
+
+function Report-Diff($category, $source, $target, $diff) {
+    if ($diff) {
+        Write-Output ""
+        Write-Output "$category exercise slugs in $source but not in ${target}:"
+        Write-Output $diff
+    }
 }
 
 function Assert-Exercise-List-Agreement {
-    Gather-Exercise-Slugs-From-Config "concept" "config-concept-slugs"
-    Gather-Exercise-Slugs-From-Sln "concept" "sln-concept-slugs"
-    Gather-Exercise-Slugs-From-Config "practice" "config-practice-slugs"
-    Gather-Exercise-Slugs-From-Sln "practice" "sln-practice-slugs"
+    $config_concept_slugs = Gather-Exercise-Slugs-From-Config "concept"
+    $sln_concept_slugs = Gather-Exercise-Slugs-From-Sln "concept"
+    $config_practice_slugs = Gather-Exercise-Slugs-From-Config "practice"
+    $sln_practice_slugs = Gather-Exercise-Slugs-From-Sln "practice"
 
-    $OriginalErrorActionPreference = $ErrorActionPreference
-    $ErrorActionPreference = "SilentlyContinue"
-    $ConceptDiff = diff -uB config-concept-slugs sln-concept-slugs
-    $PracticeDiff = diff -uB config-practice-slugs sln-practice-slugs
-    $ErrorActionPreference = $OriginalErrorActionPreference
-    Remove-Item config-*-slugs
-    Remove-Item sln-*-slugs
+    $concept_config_sln_diff = Set-Difference $config_concept_slugs $sln_concept_slugs
+    $concept_sln_config_diff = Set-Difference $sln_concept_slugs $config_concept_slugs
+    $practice_config_sln_diff = Set-Difference $config_practice_slugs $sln_practice_slugs
+    $practice_sln_config_diff = Set-Difference $sln_practice_slugs $config_practice_slugs
 
-    if ($ConceptDiff || $PracticeDiff) {
-        $MessageCore = "exercise sets in config.json and exercises/Exercises.sln differ"
-        if ($ConceptDiff) {
-            Write-Output "Error: concept ${MessageCore}:"
-            Write-Output $ConceptDiff
-        }
-        if ($PracticeDiff) {
-            Write-Output "Error: practice ${MessageCore}:"
-            Write-Output $PracticeDiff
-        }
+    if ($concept_config_sln_diff || $concept_sln_config_diff || $practice_config_sln_diff || $practice_sln_config_diff) {
+        Write-Output "Error: exercise sets in config.json and exercises/Exercises.sln differ."
+        Report-Diff "Concept" "config.json" "exercises/Exercises.sln" $concept_config_sln_diff
+        Report-Diff "Concept" "exercises/Exercises.sln" "config.json" $concept_sln_config_diff
+        Report-Diff "Practice" "config.json" "exercises/Exercises.sln" $practice_config_sln_diff
+        Report-Diff "Practice" "exercises/Exercises.sln" "config.json" $practice_sln_config_diff
         exit 1
     }
 }

--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -154,7 +154,8 @@ function Test-Exercise-Example-Implementations($Exercise) {
 }
 
 function Gather-Exercise-Slugs-From-Config($Category, $OutFile) {
-    jq ".exercises.$Category[] | .slug" config.json | sed 's/"//g' | sort > $OutFile
+    $config = Get-Content -Raw config.json | ConvertFrom-Json
+    $config.exercises.$Category.slug | sort > $OutFile
 }
 
 function Gather-Exercise-Slugs-From-Sln($Category, $OutFile) {

--- a/exercises/Exercises.slnx
+++ b/exercises/Exercises.slnx
@@ -9,7 +9,9 @@
     <Project Path="concept/interest-is-interesting/InterestIsInteresting.fsproj" />
     <Project Path="concept/log-levels/LogLevels.fsproj" />
     <Project Path="concept/lucians-luscious-lasagna/LuciansLusciousLasagna.fsproj" />
+    <Project Path="concept/password-checker/PasswordChecker.fsproj" />
     <Project Path="concept/pizza-pricing/PizzaPricing.fsproj" />
+    <Project Path="concept/role-playing-game/RolePlayingGame.fsproj" />
     <Project Path="concept/squeaky-clean/SqueakyClean.fsproj" />
     <Project Path="concept/tisbury-treasure-hunt/TisburyTreasureHunt.fsproj" />
     <Project Path="concept/tracks-on-tracks-on-tracks/TracksOnTracksOnTracks.fsproj" />


### PR DESCRIPTION
This will fail CI if the exercise sets in `config.json` and `exercises/Exercises.sln` differ, as discussed in http://forum.exercism.org/t/working-solution-to-passwordchecker-failing-on-exercism-infrastructure/30559/17.
