### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/accumulate/.docs/instructions.append.md
+++ b/exercises/practice/accumulate/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For this exercise the following F# feature comes in handy:
 

--- a/exercises/practice/alphametics/.docs/instructions.append.md
+++ b/exercises/practice/alphametics/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - To parse the text, you could try to use the [FParsec](http://www.quanttec.com/fparsec/tutorial.html) library.
 - You can solve this exercise with a brute force algorithm, but this will possibly have a poor runtime performance.

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Note
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/beer-song/.docs/instructions.append.md
+++ b/exercises/practice/beer-song/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/diamond/.docs/instructions.append.md
+++ b/exercises/practice/diamond/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - Testing this one can be tricky without simply hardcoding a bunch of inputs and outputs. [Property based testing](https://fsharpforfunandprofit.com/posts/property-based-testing/) is another way to think about testing that allows you to more easily test this type of algorithm.

--- a/exercises/practice/difference-of-squares/.docs/instructions.append.md
+++ b/exercises/practice/difference-of-squares/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For this exercise the following F# features come in handy:
 - [(..) start finish](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-operators.html#(..)) allows you to succinctly create a range of values.

--- a/exercises/practice/diffie-hellman/.docs/instructions.append.md
+++ b/exercises/practice/diffie-hellman/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For this exercise the following F# feature comes in handy:
 

--- a/exercises/practice/food-chain/.docs/instructions.append.md
+++ b/exercises/practice/food-chain/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/grade-school/.docs/instructions.append.md
+++ b/exercises/practice/grade-school/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For this exercise the following F# feature comes in handy:
 

--- a/exercises/practice/grains/.docs/instructions.append.md
+++ b/exercises/practice/grains/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For this exercise the following F# features come in handy:
 

--- a/exercises/practice/house/.docs/instructions.append.md
+++ b/exercises/practice/house/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Notes
+# Instructions append
+
+## Notes
 
 The [DateTime class][datetime] provides a built-in [IsLeapYear][datetime.isleapyear] method
 which you should pretend doesn't exist for the purposes of implementing this exercise.

--- a/exercises/practice/lens-person/.docs/instructions.append.md
+++ b/exercises/practice/lens-person/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - This exercise expects you to use the [Aether](https://xyncro.tech/aether/) library, which adds _lenses_ functionality to F#. With lenses, you can quite easily read or update nested structures.

--- a/exercises/practice/linked-list/.docs/instructions.append.md
+++ b/exercises/practice/linked-list/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 A [doubly linked list](https://en.wikipedia.org/wiki/Doubly_linked_list) is a mutable data structure. As F# is a functional-first language, immutability is generally preferred, but there are language features that allow the use of mutation where it is required.
 

--- a/exercises/practice/nth-prime/.docs/instructions.append.md
+++ b/exercises/practice/nth-prime/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For this exercise the following F# feature comes in handy:
 

--- a/exercises/practice/palindrome-products/.docs/instructions.append.md
+++ b/exercises/practice/palindrome-products/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - The most simple way to check if a number is a palindrome is quite slow. To speed things up, you could implement a slighly more complex algorithm which uses mutable state.

--- a/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
+++ b/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For this exercise the following F# feature comes in handy:
 

--- a/exercises/practice/poker/.docs/instructions.append.md
+++ b/exercises/practice/poker/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - [Designing with types](http://fsharpforfunandprofit.com/series/designing-with-types.html) To come up with a clean and easy to read solution for this make sure to choose the right types to represent the different parts of the problem (think of suits, values, cards, etc)

--- a/exercises/practice/proverb/.docs/instructions.append.md
+++ b/exercises/practice/proverb/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/raindrops/.docs/instructions.append.md
+++ b/exercises/practice/raindrops/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - Think of this in a generic way. If you're familiar with the (fizz buzz)[https://en.wikipedia.org/wiki/Fizz_buzz] problem this is similar except there are three conditions instead of two. How would you implement this knowing that one day we might want to extend to four, five, or even ten types of raindrops?

--- a/exercises/practice/rna-transcription/.docs/instructions.append.md
+++ b/exercises/practice/rna-transcription/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For this exercise the following F# feature comes in handy:
 

--- a/exercises/practice/space-age/.docs/instructions.append.md
+++ b/exercises/practice/space-age/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - Try to focus on minimizing the amount of code duplication. If you find yourself doing a lot of copy/paste take a step back and think about how the code can be refactored
 - [Pattern matching](https://fsharpforfunandprofit.com/posts/match-expression/) is more idiomatic than using dictionaries to translate values

--- a/exercises/practice/twelve-days/.docs/instructions.append.md
+++ b/exercises/practice/twelve-days/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/wordy/.docs/instructions.append.md
+++ b/exercises/practice/wordy/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - To parse the text, you could try to use the [FParsec](http://www.quanttec.com/fparsec/tutorial.html) library.
 - As an exercise, you could try to represent a question as an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree).


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.